### PR TITLE
Add configurable daemon intervals via config.toml

### DIFF
--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -22,6 +22,7 @@ libc = "0.2"
 rand = "0.8"
 clap = { version = "4", features = ["derive"] }
 hostname = "0.4"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/layers/fabric/src/cli/status.rs
+++ b/layers/fabric/src/cli/status.rs
@@ -1,4 +1,4 @@
-use crate::{store, wg};
+use crate::{config, store, wg};
 use anyhow::Result;
 
 pub async fn run() -> Result<()> {
@@ -78,6 +78,26 @@ pub async fn run() -> Result<()> {
         println!("  WG reconciles:   {}", m.wg_reconciliations);
         println!("  Peers unreached: {}", m.peers_marked_unreachable);
     }
+
+    let tuning = config::load_tuning().unwrap_or_default();
+    println!();
+    println!("Config:");
+    println!(
+        "  health_check_interval: {}s",
+        tuning.health_check_interval.as_secs()
+    );
+    println!(
+        "  reconcile_interval:    {}s",
+        tuning.reconcile_interval.as_secs()
+    );
+    println!(
+        "  persist_interval:      {}s",
+        tuning.persist_interval.as_secs()
+    );
+    println!(
+        "  unreachable_timeout:   {}s",
+        tuning.unreachable_timeout.as_secs()
+    );
 
     Ok(())
 }

--- a/layers/fabric/src/config.rs
+++ b/layers/fabric/src/config.rs
@@ -1,0 +1,119 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+fn syfrah_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".syfrah")
+}
+
+/// Daemon tuning parameters. All fields are optional — defaults match the
+/// original hardcoded values.
+#[derive(Debug, Clone)]
+pub struct Tuning {
+    pub health_check_interval: Duration,
+    pub reconcile_interval: Duration,
+    pub persist_interval: Duration,
+    pub unreachable_timeout: Duration,
+    pub keepalive_interval: u16,
+    pub join_timeout: Duration,
+    pub exchange_timeout: Duration,
+}
+
+impl Default for Tuning {
+    fn default() -> Self {
+        Self {
+            health_check_interval: Duration::from_secs(60),
+            reconcile_interval: Duration::from_secs(30),
+            persist_interval: Duration::from_secs(30),
+            unreachable_timeout: Duration::from_secs(300),
+            keepalive_interval: 25,
+            join_timeout: Duration::from_secs(300),
+            exchange_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ConfigFile {
+    #[serde(default)]
+    daemon: DaemonSection,
+    #[serde(default)]
+    wireguard: WireguardSection,
+    #[serde(default)]
+    peering: PeeringSection,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct DaemonSection {
+    health_check_interval: Option<u64>,
+    reconcile_interval: Option<u64>,
+    persist_interval: Option<u64>,
+    unreachable_timeout: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct WireguardSection {
+    keepalive_interval: Option<u16>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct PeeringSection {
+    join_timeout: Option<u64>,
+    exchange_timeout: Option<u64>,
+}
+
+/// Load tuning from `~/.syfrah/config.toml`. Returns defaults if file
+/// doesn't exist. Returns error only if file exists but is invalid.
+pub fn load_tuning() -> Result<Tuning, String> {
+    let path = syfrah_dir().join("config.toml");
+    if !path.exists() {
+        return Ok(Tuning::default());
+    }
+
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+
+    let config: ConfigFile =
+        toml::from_str(&content).map_err(|e| format!("invalid config.toml: {e}"))?;
+
+    let defaults = Tuning::default();
+    Ok(Tuning {
+        health_check_interval: config
+            .daemon
+            .health_check_interval
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.health_check_interval),
+        reconcile_interval: config
+            .daemon
+            .reconcile_interval
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.reconcile_interval),
+        persist_interval: config
+            .daemon
+            .persist_interval
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.persist_interval),
+        unreachable_timeout: config
+            .daemon
+            .unreachable_timeout
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.unreachable_timeout),
+        keepalive_interval: config
+            .wireguard
+            .keepalive_interval
+            .unwrap_or(defaults.keepalive_interval),
+        join_timeout: config
+            .peering
+            .join_timeout
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.join_timeout),
+        exchange_timeout: config
+            .peering
+            .exchange_timeout
+            .map(Duration::from_secs)
+            .unwrap_or(defaults.exchange_timeout),
+    })
+}

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use tracing::{info, warn};
 use wireguard_control::{Key, KeyPair};
@@ -10,14 +10,11 @@ use syfrah_core::addressing;
 use syfrah_core::mesh::{PeerRecord, PeerStatus};
 use syfrah_core::secret::MeshSecret;
 
+use crate::config::{self, Tuning};
 use crate::control::{self, ControlHandler, ControlRequest, ControlResponse};
 use crate::peering::{self, AutoAcceptConfig, PeeringState};
 use crate::store::{self, NodeState};
 use crate::wg;
-
-const UNREACHABLE_TIMEOUT: Duration = Duration::from_secs(300);
-const PERSIST_INTERVAL: Duration = Duration::from_secs(30);
-const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub struct DaemonConfig {
     pub mesh_name: String,
@@ -295,6 +292,18 @@ pub async fn run_daemon(
     mesh_secret: MeshSecret,
     peering_port: u16,
 ) -> anyhow::Result<()> {
+    let tuning = config::load_tuning().unwrap_or_else(|e| {
+        warn!("failed to load config.toml: {e}, using defaults");
+        Tuning::default()
+    });
+    info!(
+        "daemon tuning: health_check={}s reconcile={}s persist={}s unreachable={}s",
+        tuning.health_check_interval.as_secs(),
+        tuning.reconcile_interval.as_secs(),
+        tuning.persist_interval.as_secs(),
+        tuning.unreachable_timeout.as_secs(),
+    );
+
     store::write_pid()?;
 
     let wg_pubkey = wg_keypair.public.clone();
@@ -392,7 +401,7 @@ pub async fn run_daemon(
     let persist_recon = metrics_reconciliations.clone();
     let persist_unreach = metrics_unreachable.clone();
     let persist = async {
-        let mut interval = tokio::time::interval(PERSIST_INTERVAL);
+        let mut interval = tokio::time::interval(tuning.persist_interval);
         loop {
             interval.tick().await;
             let _ = store::set_metric("peers_discovered", persist_recv.load(Ordering::Relaxed));
@@ -406,10 +415,11 @@ pub async fn run_daemon(
     };
 
     // Health check: unreachable detection + recovery + last_seen update
+    let unreachable_timeout_secs = tuning.unreachable_timeout.as_secs();
     let health_counter = metrics_unreachable.clone();
     let health_recon = metrics_reconciliations.clone();
     let health_check = async {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        let mut interval = tokio::time::interval(tuning.health_check_interval);
         loop {
             interval.tick().await;
 
@@ -440,7 +450,7 @@ pub async fn run_daemon(
 
                 // Recovery: unreachable → active if recent handshake
                 if peer.status == PeerStatus::Unreachable
-                    && current.saturating_sub(peer.last_seen) < UNREACHABLE_TIMEOUT.as_secs()
+                    && current.saturating_sub(peer.last_seen) < unreachable_timeout_secs
                 {
                     info!(
                         "peer {} recovered (recent handshake), marking active",
@@ -452,7 +462,7 @@ pub async fn run_daemon(
 
                 // Detection: active → unreachable if no handshake for too long
                 if peer.status == PeerStatus::Active
-                    && current.saturating_sub(peer.last_seen) > UNREACHABLE_TIMEOUT.as_secs()
+                    && current.saturating_sub(peer.last_seen) > unreachable_timeout_secs
                 {
                     info!("marking peer {} as unreachable", peer.name);
                     peer.status = PeerStatus::Unreachable;
@@ -474,14 +484,17 @@ pub async fn run_daemon(
     let reconcile_wg_pubkey = wg_pubkey.clone();
     let reconcile_recon = health_recon;
     let reconcile = async {
-        let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+        let mut interval = tokio::time::interval(tuning.reconcile_interval);
         loop {
             interval.tick().await;
 
             let stored_peers = store::get_peers().unwrap_or_default();
             let wg_summary = match wg::interface_summary() {
                 Ok(s) => s,
-                Err(_) => continue,
+                Err(e) => {
+                    warn!("reconciliation: WireGuard interface unavailable: {e}");
+                    continue;
+                }
             };
 
             // For each stored peer, ensure it's in WireGuard

--- a/layers/fabric/src/lib.rs
+++ b/layers/fabric/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod config;
 pub mod control;
 pub mod daemon;
 pub mod peering;

--- a/tests/e2e/scenarios/42_fabric_custom_intervals.sh
+++ b/tests/e2e/scenarios/42_fabric_custom_intervals.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Scenario: Daemon uses custom intervals from config.toml
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── Custom Intervals ──"
+create_network
+
+start_node "e2e-config-1" "172.20.0.10"
+start_node "e2e-config-2" "172.20.0.11"
+
+# Write custom config with fast health check and fast unreachable timeout
+docker exec "e2e-config-1" mkdir -p /root/.syfrah
+docker exec "e2e-config-1" sh -c 'cat > /root/.syfrah/config.toml << EOF
+[daemon]
+health_check_interval = 10
+unreachable_timeout = 20
+reconcile_interval = 10
+EOF'
+
+# Init and join with custom config
+init_mesh "e2e-config-1" "172.20.0.10" "node-1"
+start_peering "e2e-config-1"
+join_mesh "e2e-config-2" "172.20.0.10" "172.20.0.11" "node-2"
+if ! wait_for_convergence "e2e-config-" 2 1 30; then
+    fail "initial mesh did not converge"
+    cleanup; summary
+fi
+
+# Verify config is displayed in status
+config_output=$(docker exec "e2e-config-1" syfrah fabric status 2>&1)
+if echo "$config_output" | grep -q "health_check_interval.*10"; then
+    pass "status shows custom health_check_interval"
+else
+    fail "status does not show custom health_check_interval"
+    echo "$config_output"
+fi
+
+if echo "$config_output" | grep -q "unreachable_timeout.*20"; then
+    pass "status shows custom unreachable_timeout"
+else
+    fail "status does not show custom unreachable_timeout"
+    echo "$config_output"
+fi
+
+# Block traffic to node-2, peer should be marked unreachable faster
+info "Blocking traffic to node-2..."
+block_traffic "e2e-config-1" "172.20.0.11"
+
+info "Waiting 35s for fast unreachable detection (20s timeout + 10s check)..."
+sleep 35
+
+# Check peer status
+peer_status=$(docker exec "e2e-config-1" syfrah fabric peers 2>&1 | grep "node-2")
+if echo "$peer_status" | grep -qi "unreachable"; then
+    pass "node-2 marked unreachable within 35s (fast config)"
+else
+    fail "node-2 not yet unreachable after 35s"
+    echo "$peer_status"
+fi
+
+cleanup
+summary

--- a/tests/e2e/scenarios/43_fabric_reconcile_logging.sh
+++ b/tests/e2e/scenarios/43_fabric_reconcile_logging.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Scenario: Reconciliation logs WG unavailability instead of silent skip
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── Reconciliation Logging ──"
+create_network
+
+start_node "e2e-reconlog-1" "172.20.0.10"
+start_node "e2e-reconlog-2" "172.20.0.11"
+
+# Use fast reconcile interval to speed up the test
+docker exec "e2e-reconlog-1" mkdir -p /root/.syfrah
+docker exec "e2e-reconlog-1" sh -c 'cat > /root/.syfrah/config.toml << EOF
+[daemon]
+reconcile_interval = 5
+EOF'
+
+init_mesh "e2e-reconlog-1" "172.20.0.10" "node-1"
+start_peering "e2e-reconlog-1"
+join_mesh "e2e-reconlog-2" "172.20.0.10" "172.20.0.11" "node-2"
+if ! wait_for_convergence "e2e-reconlog-" 2 1 30; then
+    fail "initial mesh did not converge"
+    cleanup; summary
+fi
+
+# Remove WireGuard interface (simulates WG crash)
+info "Removing WireGuard interface..."
+docker exec "e2e-reconlog-1" ip link delete syfrah0 2>/dev/null || true
+
+# Wait for reconciliation cycle
+sleep 10
+
+# Check log for WG unavailable warning
+log_output=$(docker exec "e2e-reconlog-1" cat /root/.syfrah/syfrah.log 2>&1)
+if echo "$log_output" | grep -qi "unavailable\|interface.*error\|reconcil"; then
+    pass "reconciliation logs WG unavailability"
+else
+    fail "reconciliation silently skipped WG error (no log entry)"
+    debug "Log tail:"
+    echo "$log_output" | tail -10
+fi
+
+cleanup
+summary


### PR DESCRIPTION
## Summary

- All hardcoded daemon intervals are now configurable via `~/.syfrah/config.toml`
- Config is optional — defaults match the original values
- Fix silent skip in reconciliation loop (now logs WG unavailability)
- Display active configuration in `syfrah fabric status`

## Configurable parameters

| Parameter | Default | Section |
|-----------|---------|---------|
| health_check_interval | 60s | [daemon] |
| reconcile_interval | 30s | [daemon] |
| persist_interval | 30s | [daemon] |
| unreachable_timeout | 300s | [daemon] |
| keepalive_interval | 25s | [wireguard] |
| join_timeout | 300s | [peering] |
| exchange_timeout | 30s | [peering] |

## Test plan

- [ ] E2E test 42: custom intervals + fast unreachable detection (20s instead of 300s)
- [ ] E2E test 43: reconciliation logs WG unavailability
- [ ] All existing E2E scenarios still pass
- [ ] Unit tests pass

Closes #7