### PR TITLE
Improve CLI error messages with actionable context

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -222,7 +222,14 @@ fn daemonize() -> Result<bool> {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("Error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<()> {
     let args = Cli::parse();
 
     match args.command {

--- a/layers/fabric/src/cli/init.rs
+++ b/layers/fabric/src/cli/init.rs
@@ -1,5 +1,5 @@
 use crate::daemon::{self, DaemonConfig};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::net::SocketAddr;
 
 pub async fn run(
@@ -21,4 +21,5 @@ pub async fn run(
         zone,
     })
     .await
+    .context("Failed to initialize mesh. If a mesh already exists, run: syfrah fabric leave")
 }

--- a/layers/fabric/src/cli/join.rs
+++ b/layers/fabric/src/cli/join.rs
@@ -1,5 +1,5 @@
 use crate::daemon::{self, DaemonConfig};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::net::SocketAddr;
 
 pub async fn run(
@@ -36,4 +36,7 @@ pub async fn run(
         pin,
     )
     .await
+    .context(format!(
+        "Failed to join mesh via {target}. Check that the target node is running and peering is active."
+    ))
 }

--- a/layers/fabric/src/cli/start.rs
+++ b/layers/fabric/src/cli/start.rs
@@ -1,6 +1,8 @@
 use crate::daemon;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 pub async fn run() -> Result<()> {
-    daemon::run_start().await
+    daemon::run_start()
+        .await
+        .context("Failed to start daemon. Is the mesh configured? Try: syfrah fabric status")
 }

--- a/tests/e2e/scenarios/47_fabric_error_messages.sh
+++ b/tests/e2e/scenarios/47_fabric_error_messages.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Scenario: CLI error messages are actionable
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── Error Messages ──"
+create_network
+
+start_node "e2e-errmsg-1" "172.20.0.10"
+
+# Test 1: start without init — should suggest init/join
+info "Testing: start without init..."
+err=$(docker exec "e2e-errmsg-1" syfrah fabric start 2>&1 || true)
+if echo "$err" | grep -qi "init\|join\|configured"; then
+    pass "start without init suggests init/join"
+else
+    fail "start without init: unhelpful message: $err"
+fi
+
+# Test 2: double init — should suggest leave
+info "Testing: double init..."
+init_mesh "e2e-errmsg-1" "172.20.0.10" "node-1"
+err=$(docker exec "e2e-errmsg-1" syfrah fabric init \
+    --name test2 --node-name node-2 --endpoint 172.20.0.10:51820 2>&1 || true)
+if echo "$err" | grep -qi "leave\|already"; then
+    pass "double init suggests leave"
+else
+    fail "double init: unhelpful message: $err"
+fi
+
+cleanup
+summary


### PR DESCRIPTION
## Summary

- Custom error handler in main.rs — no raw anyhow chain output
- Add `.context()` with actionable hints to init, join, start commands
- E2E test 47 verifies error messages suggest next steps

Closes #11