### PR TITLE
Add release workflow with pre-compiled binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      # Linux x86_64 musl: install musl-tools
+      - name: Install musl-tools (x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      # Linux aarch64: use cross for cross-compilation
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: cargo install cross --locked
+
+      # Build with cargo for native targets
+      - name: Build (cargo)
+        if: matrix.target != 'aarch64-unknown-linux-musl'
+        run: cargo build --release --target ${{ matrix.target }}
+
+      # Build with cross for aarch64-linux-musl
+      - name: Build (cross)
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          BIN=syfrah
+          SRC=target/${{ matrix.target }}/release/$BIN
+          ARCHIVE=${BIN}-${{ github.ref_name }}-${{ matrix.target }}
+
+          mkdir -p staging
+          cp "$SRC" staging/$BIN
+          cd staging
+          tar czf ../${ARCHIVE}.tar.gz $BIN
+          cd ..
+
+          echo "ARCHIVE=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Collect archives and generate checksums
+        run: |
+          mkdir -p release
+          find artifacts -name '*.tar.gz' -exec cp {} release/ \;
+          cd release
+          sha256sum *.tar.gz > SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: release/*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@ An open-source control plane that turns rented dedicated servers into a programm
 
 Take servers from OVH, Hetzner, Scaleway, or any provider. Syfrah connects them into an encrypted mesh, orchestrates compute, storage, and networking, and exposes cloud services on top.
 
+## Install
+
+**Download a pre-built binary** from the [latest release](https://github.com/sifrah/syfrah/releases/latest):
+
+```bash
+# Example: Linux amd64
+curl -LO https://github.com/sifrah/syfrah/releases/latest/download/syfrah-v0.1.0-x86_64-unknown-linux-musl.tar.gz
+tar xzf syfrah-v0.1.0-x86_64-unknown-linux-musl.tar.gz
+sudo mv syfrah /usr/local/bin/
+```
+
+**Via cargo install** (requires Rust toolchain):
+
+```bash
+cargo install --git https://github.com/sifrah/syfrah.git
+```
+
+**From source:**
+
+```bash
+git clone https://github.com/sifrah/syfrah.git
+cd syfrah
+cargo build --release
+# Binary at target/release/syfrah
+```
+
 ## Quick Start
 
 ```bash

--- a/handbook/ci.md
+++ b/handbook/ci.md
@@ -11,6 +11,7 @@ Syfrah uses GitHub Actions for continuous integration. The CI dynamically discov
 | **CI** | `.github/workflows/ci.yml` | Push/PR on `main` | Format, lint, test per layer |
 | **Documentation** | `.github/workflows/docs.yml` | Push on `main` (docs/layers change) | Build and deploy docs site |
 | **Security** | `.github/workflows/security.yml` | Weekly + Cargo.toml changes | `cargo audit` for vulnerabilities |
+| **Release** | `.github/workflows/release.yml` | `v*` tag push | Build static binaries, create GitHub Release |
 
 ## CI pipeline
 

--- a/handbook/releasing.md
+++ b/handbook/releasing.md
@@ -1,0 +1,53 @@
+# Releasing
+
+## Overview
+
+Syfrah publishes pre-compiled binaries for every tagged release. Pushing a `v*` tag triggers the release workflow, which builds static binaries for four targets and creates a GitHub Release with the archives and SHA256 checksums.
+
+## Targets
+
+| Target | OS | Arch | Build method |
+|---|---|---|---|
+| `x86_64-unknown-linux-musl` | Linux | amd64 | `cargo build` with musl-tools |
+| `aarch64-unknown-linux-musl` | Linux | arm64 | `cross build` |
+| `x86_64-apple-darwin` | macOS | amd64 | `cargo build` (native) |
+| `aarch64-apple-darwin` | macOS | arm64 | `cargo build` (native) |
+
+Linux binaries are statically linked via musl so they run on any Linux distribution with no runtime dependencies.
+
+## How to cut a release
+
+1. Make sure `main` is green (all CI checks pass).
+2. Choose a version following [semver](https://semver.org/). Current: `0.1.0`.
+3. Tag and push:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+4. The `Release` workflow (`.github/workflows/release.yml`) runs automatically:
+   - Builds all four targets in parallel
+   - Packages each binary into a `.tar.gz` archive
+   - Generates `SHA256SUMS.txt`
+   - Creates a GitHub Release with auto-generated release notes and all artifacts attached
+
+5. Verify the release at `https://github.com/sifrah/syfrah/releases`.
+
+## Artifacts
+
+Each release contains:
+
+```
+syfrah-v0.1.0-x86_64-unknown-linux-musl.tar.gz
+syfrah-v0.1.0-aarch64-unknown-linux-musl.tar.gz
+syfrah-v0.1.0-x86_64-apple-darwin.tar.gz
+syfrah-v0.1.0-aarch64-apple-darwin.tar.gz
+SHA256SUMS.txt
+```
+
+## Verifying a download
+
+```bash
+sha256sum -c SHA256SUMS.txt
+```


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on `v*` tag push that builds static binaries for 4 targets (Linux amd64/arm64 musl, macOS amd64/arm64), generates SHA256 checksums, and creates a GitHub Release via `softprops/action-gh-release@v2`
- Add install instructions (binary download, cargo install, from source) to README before Quick Start
- Document release process in `handbook/releasing.md` and reference the workflow in `handbook/ci.md`

Closes #41

## Test plan

- [ ] Verify YAML syntax is valid (done locally with Python yaml parser)
- [ ] Push a `v0.1.0` tag to trigger the workflow and confirm all 4 builds succeed
- [ ] Confirm GitHub Release is created with archives and SHA256SUMS.txt
- [ ] Verify downloaded binary runs on Linux and macOS