### PR TITLE
Add install.sh script to release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,16 @@ jobs:
         with:
           path: artifacts
 
+      - uses: actions/checkout@v4
+
+      - name: Copy install script
+        run: cp scripts/install.sh artifacts/install.sh
+
       - name: Collect archives and generate checksums
         run: |
           mkdir -p release
           find artifacts -name '*.tar.gz' -exec cp {} release/ \;
+          cp artifacts/install.sh release/install.sh
           cd release
           sha256sum *.tar.gz > SHA256SUMS.txt
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Install script for syfrah — downloads the latest release binary.
+set -eu
+
+REPO="sifrah/syfrah"
+BIN="syfrah"
+INSTALL_DIR="/usr/local/bin"
+
+# --- Detect OS ---
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  OS="unknown-linux-musl" ;;
+  Darwin) OS="apple-darwin" ;;
+  *)      echo "Error: unsupported operating system: $OS" >&2; exit 1 ;;
+esac
+
+# --- Detect architecture ---
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)             ARCH="x86_64" ;;
+  aarch64|arm64)      ARCH="aarch64" ;;
+  *)                  echo "Error: unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+TARGET="${ARCH}-${OS}"
+
+# --- Fetch latest release tag ---
+echo "Fetching latest release version..."
+VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')"
+
+if [ -z "$VERSION" ]; then
+  echo "Error: could not determine latest release version" >&2
+  exit 1
+fi
+
+echo "Latest version: ${VERSION}"
+
+# --- Download archive ---
+ARCHIVE="${BIN}-${VERSION}-${TARGET}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Downloading ${URL}..."
+curl -fSL -o "${TMPDIR}/${ARCHIVE}" "$URL"
+
+# --- Extract and install ---
+echo "Extracting ${ARCHIVE}..."
+tar xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+
+echo "Installing ${BIN} to ${INSTALL_DIR}..."
+install -m 755 "${TMPDIR}/${BIN}" "${INSTALL_DIR}/${BIN}"
+
+# --- Verify ---
+echo "Verifying installation..."
+if command -v "$BIN" > /dev/null 2>&1; then
+  "$BIN" --version
+  echo "Installation complete."
+else
+  echo "Warning: ${BIN} was installed to ${INSTALL_DIR} but is not on PATH." >&2
+  echo "Add ${INSTALL_DIR} to your PATH, then run: ${BIN} --version" >&2
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/install.sh` — POSIX shell script that detects OS/arch, fetches the latest release, downloads the correct archive, extracts and installs the binary to `/usr/local/bin`
- Update `.github/workflows/release.yml` to include `install.sh` in release assets
- Uploaded `install.sh` to the existing v0.1.0 release

Closes #49