### PR TITLE
Fix handshake showing '20535d ago' for epoch 0

### DIFF
--- a/layers/fabric/src/cli/peers.rs
+++ b/layers/fabric/src/cli/peers.rs
@@ -72,6 +72,10 @@ pub async fn run() -> Result<()> {
 }
 
 fn format_ago(time: SystemTime) -> String {
+    if time == std::time::UNIX_EPOCH {
+        return "never".into();
+    }
+
     let elapsed = SystemTime::now()
         .duration_since(time)
         .unwrap_or_default()


### PR DESCRIPTION
## Summary
- Return `"never"` in `format_ago()` when `last_handshake` is `UNIX_EPOCH` (0), instead of computing a nonsensical relative time like "20535d ago"
- Single guard clause added at the top of `format_ago()` in `layers/fabric/src/cli/peers.rs`

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy` — clean

Closes #70