### PR TITLE
Fix join error message to reference 'syfrah fabric leave'

### DIFF
--- a/layers/fabric/src/cli/join.rs
+++ b/layers/fabric/src/cli/join.rs
@@ -1,4 +1,5 @@
 use crate::daemon::{self, DaemonConfig};
+use crate::store;
 use anyhow::{Context, Result};
 use std::net::SocketAddr;
 
@@ -11,6 +12,12 @@ pub async fn run(
     region: Option<String>,
     zone: Option<String>,
 ) -> Result<()> {
+    if store::exists() {
+        anyhow::bail!(
+            "Mesh state already exists. Run 'syfrah fabric leave' first to clear it, then retry the join."
+        );
+    }
+
     // Parse target: "1.2.3.4" → "1.2.3.4:51821", or "1.2.3.4:9999" as-is
     let target_addr: SocketAddr = if target.contains(':') {
         target


### PR DESCRIPTION
## Summary
- Add `store::exists()` check at the start of `cli/join.rs` so users get a clear "Run 'syfrah fabric leave' first" error before any TCP connection attempt
- Verified no remaining instances of `syfrah leave` (without `fabric`) in user-facing strings

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)