### PR TITLE
Auto-release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,8 +12,53 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # ── Check if version changed ──────────────────────────────
+  check-version:
+    name: Check version
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version and check tag
+        id: check
+        run: |
+          version=$(grep '^version' Cargo.toml | head -1 | sed 's/version *= *"\(.*\)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Cargo.toml version: $version"
+
+          if git rev-parse "v${version}" >/dev/null 2>&1; then
+            echo "Tag v${version} already exists — skipping release"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag v${version} does not exist — will release"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Wait for CI to pass ───────────────────────────────────
+  ci:
+    name: Wait for CI
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for CI workflow
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          check-regexp: ^(Secret scan|Validate .gitignore|Format|Discover crates|syfrah-.*)$
+          wait-interval: 10
+
+  # ── Build all targets ─────────────────────────────────────
   build:
     name: Build ${{ matrix.target }}
+    needs: [check-version, ci]
+    if: needs.check-version.outputs.should_release == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -59,29 +104,17 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cross build --release --target ${{ matrix.target }}
 
-      - name: Package binary
-        run: |
-          BIN=syfrah
-          SRC=target/${{ matrix.target }}/release/$BIN
-          ARCHIVE=${BIN}-${{ github.ref_name }}-${{ matrix.target }}
-
-          mkdir -p staging
-          cp "$SRC" staging/$BIN
-          cd staging
-          tar czf ../${ARCHIVE}.tar.gz $BIN
-          cd ..
-
-          echo "ARCHIVE=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
-
-      - name: Upload artifact
+      - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: ${{ env.ARCHIVE }}
+          path: target/${{ matrix.target }}/release/syfrah
 
+  # ── Create release ────────────────────────────────────────
   release:
     name: Create Release
-    needs: build
+    needs: [check-version, build]
+    if: needs.check-version.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -91,19 +124,31 @@ jobs:
         with:
           path: artifacts
 
-      - name: Copy install script
-        run: cp scripts/install.sh artifacts/install.sh
-
-      - name: Collect archives and generate checksums
+      - name: Package archives, install script, and checksums
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
         run: |
           mkdir -p release
-          find artifacts -name '*.tar.gz' -exec cp {} release/ \;
-          cp artifacts/install.sh release/install.sh
+          for target_dir in artifacts/*/; do
+            target=$(basename "$target_dir")
+            archive="syfrah-v${VERSION}-${target}.tar.gz"
+            chmod +x "${target_dir}syfrah"
+            tar czf "release/${archive}" -C "$target_dir" syfrah
+          done
+          cp scripts/install.sh release/install.sh
           cd release
           sha256sum *.tar.gz > SHA256SUMS.txt
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+        run: |
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
           files: release/*

--- a/handbook/releasing.md
+++ b/handbook/releasing.md
@@ -21,11 +21,9 @@ All crates pick up the new version automatically.
 1. **Update CHANGELOG.md** — move items from `Unreleased` to a new version section with today's date.
 2. **Bump version** — edit `version` in `[workspace.package]` in the root `Cargo.toml`.
 3. **Run CI locally** — `just ci` (fmt + clippy + test).
-4. **Commit** — `git commit -m "Release v0.x.y"`.
-5. **Tag** — `git tag -a v0.x.y -m "v0.x.y"`.
-6. **Push** — `git push origin main --follow-tags`.
-7. **Verify CI** — wait for all checks to pass on the tagged commit.
-8. **Create GitHub release** — `gh release create v0.x.y --notes-from-tag` or write release notes from the CHANGELOG section.
+4. **Commit & push to main** — `git commit -m "Release v0.x.y"` and push (or merge a PR).
+
+The release workflow detects the new version, waits for CI to pass, builds all targets, creates the git tag, and publishes the GitHub Release automatically. No manual tagging or release creation required.
 
 ## Changelog format
 
@@ -48,12 +46,12 @@ Linux binaries are statically linked via musl so they run on any Linux distribut
 
 ## Release workflow
 
-The `Release` workflow (`.github/workflows/release.yml`) runs automatically when a `v*` tag is pushed:
+The `Release` workflow (`.github/workflows/release.yml`) runs automatically on every push to `main` and on `workflow_dispatch`:
 
-1. Builds all four targets in parallel
-2. Packages each binary into a `.tar.gz` archive
-3. Generates `SHA256SUMS.txt`
-4. Creates a GitHub Release with auto-generated release notes and all artifacts attached
+1. **check-version** — reads the version from the root `Cargo.toml` and checks whether the corresponding `v{version}` tag already exists. If the tag exists, the workflow stops early.
+2. **ci** — waits for the CI workflow checks to pass on the same commit.
+3. **build** — builds all four targets in parallel (same matrix as before).
+4. **release** — packages each binary into a `.tar.gz` archive, copies `install.sh`, generates `SHA256SUMS.txt`, creates the git tag `v{version}`, and publishes a GitHub Release with auto-generated release notes and all artifacts attached.
 
 ## Artifacts
 


### PR DESCRIPTION
## Summary

- Replace tag-triggered release workflow with push-to-main trigger that auto-creates releases when the version in `Cargo.toml` changes
- New `check-version` job reads version and skips if tag already exists; `ci` job waits for CI checks to pass before building
- Update `handbook/releasing.md` to document the simplified release process (bump version, push to main, done)

Closes #78

## Test plan

- [ ] Verify YAML is valid (done locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Merge to main and confirm the workflow runs but skips release (tag v0.1.0 already exists)
- [ ] On next version bump, confirm full release flow triggers automatically

Generated with [Claude Code](https://claude.com/claude-code)