### PR TITLE
Fix PID file TOCTOU and control socket race

### DIFF
--- a/layers/fabric/src/cli/stop.rs
+++ b/layers/fabric/src/cli/stop.rs
@@ -5,6 +5,18 @@ use anyhow::Result;
 pub async fn run() -> Result<()> {
     match store::daemon_running() {
         Some(pid) => {
+            // Validate that the PID actually belongs to a syfrah process
+            // to prevent killing an unrelated process if the PID was recycled
+            // or the PID file was tampered with.
+            if !store::is_syfrah_process(pid) {
+                eprintln!(
+                    "PID {pid} is not a syfrah process. Refusing to send signal. \
+                     Removing stale PID file."
+                );
+                store::remove_pid();
+                return Ok(());
+            }
+
             let sp = ui::spinner(&format!("Stopping daemon (pid {pid})..."));
             #[cfg(unix)]
             {

--- a/layers/fabric/src/control.rs
+++ b/layers/fabric/src/control.rs
@@ -44,9 +44,18 @@ pub async fn start_control_listener(socket_path: &Path, handler: Arc<dyn Control
     // Remove stale socket
     let _ = std::fs::remove_file(socket_path);
 
+    // Set restrictive umask *before* bind to eliminate the permission race window.
+    // The socket is created with mode 0o600 (owner-only) from the start.
+    #[cfg(unix)]
+    let old_umask = unsafe { libc::umask(0o177) };
+
     let listener = match UnixListener::bind(socket_path) {
         Ok(l) => l,
         Err(e) => {
+            #[cfg(unix)]
+            unsafe {
+                libc::umask(old_umask);
+            }
             warn!(
                 "failed to bind control socket at {}: {e}",
                 socket_path.display()
@@ -55,11 +64,10 @@ pub async fn start_control_listener(socket_path: &Path, handler: Arc<dyn Control
         }
     };
 
-    // Restrict permissions
+    // Restore the original umask immediately after bind
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600));
+    unsafe {
+        libc::umask(old_umask);
     }
 
     debug!("control socket listening at {}", socket_path.display());

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -438,7 +438,9 @@ pub async fn run_daemon(
         tuning.unreachable_timeout.as_secs(),
     );
 
-    store::write_pid()?;
+    // Acquire exclusive PID file lock. The returned file handle must be kept
+    // alive for the entire daemon lifetime — dropping it releases the flock.
+    let _pid_lock = store::write_pid()?;
     events::emit(
         EventType::DaemonStarted,
         None,

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -2,6 +2,9 @@ use std::fs;
 use std::net::Ipv6Addr;
 use std::path::PathBuf;
 
+#[cfg(unix)]
+use std::os::unix::io::AsRawFd;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -337,7 +340,80 @@ fn pid_file() -> PathBuf {
     state_dir().join("daemon.pid")
 }
 
-/// Write the current process PID to the PID file.
+/// Write the current process PID to the PID file with exclusive flock.
+///
+/// Uses flock(LOCK_EX | LOCK_NB) to prevent two daemons from running
+/// simultaneously. The PID is written atomically via a temp file + rename.
+/// The lock file is returned and must be kept alive for the daemon's lifetime.
+#[cfg(unix)]
+pub fn write_pid() -> Result<fs::File, StoreError> {
+    use std::io::Write;
+
+    let dir = state_dir();
+    fs::create_dir_all(&dir)?;
+
+    let path = pid_file();
+
+    // Open (or create) the PID file and acquire an exclusive lock.
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)?;
+
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        let existing = fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok());
+        let msg = match existing {
+            Some(pid) => format!("another daemon is already running (pid {pid})"),
+            None => "another daemon is already running (pid unknown)".to_string(),
+        };
+        return Err(StoreError::Io(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            msg,
+        )));
+    }
+
+    // Write PID atomically: write to temp file, then rename over the lock file.
+    // After rename the fd still holds the flock on the same inode.
+    let tmp = dir.join("daemon.pid.tmp");
+    fs::write(&tmp, std::process::id().to_string())?;
+    fs::rename(&tmp, &path)?;
+
+    // Re-acquire lock on the new inode after rename (rename replaces the file).
+    // The original fd still points to the old inode, so re-open + re-lock.
+    let file = fs::OpenOptions::new()
+        .create(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        return Err(StoreError::Io(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "failed to re-acquire PID file lock after atomic write",
+        )));
+    }
+
+    // Restrict permissions
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+    }
+
+    // Ensure PID content is correct on the locked fd
+    file.set_len(0)?;
+    let mut f = &file;
+    write!(f, "{}", std::process::id())?;
+
+    Ok(file)
+}
+
+/// Non-unix fallback (no flock).
+#[cfg(not(unix))]
 pub fn write_pid() -> Result<(), StoreError> {
     let dir = state_dir();
     fs::create_dir_all(&dir)?;
@@ -358,16 +434,20 @@ pub fn remove_pid() {
 }
 
 /// Check if a daemon is currently running (PID file exists and process alive, not zombie).
+/// Also cleans up stale PID files when the process is dead.
 pub fn daemon_running() -> Option<u32> {
     let pid = read_pid()?;
     #[cfg(unix)]
     {
         let alive = unsafe { libc::kill(pid as i32, 0) } == 0;
         if !alive {
+            // Stale PID file — process is dead. Clean up automatically.
+            remove_pid();
             return None;
         }
         // Check for zombie: kill(pid,0) succeeds for zombies too
         if is_zombie(pid) {
+            remove_pid();
             return None;
         }
         Some(pid)
@@ -376,6 +456,31 @@ pub fn daemon_running() -> Option<u32> {
     {
         Some(pid)
     }
+}
+
+/// Check if a PID belongs to a syfrah process.
+/// Returns true if the process cmdline/name contains "syfrah".
+#[cfg(target_os = "linux")]
+pub fn is_syfrah_process(pid: u32) -> bool {
+    std::fs::read_to_string(format!("/proc/{pid}/cmdline"))
+        .map(|c| c.contains("syfrah"))
+        .unwrap_or(false)
+}
+
+/// On macOS, use `ps` to check the process name.
+#[cfg(target_os = "macos")]
+pub fn is_syfrah_process(pid: u32) -> bool {
+    std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "comm="])
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("syfrah"))
+        .unwrap_or(false)
+}
+
+/// Non-unix fallback — cannot verify process name.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn is_syfrah_process(_pid: u32) -> bool {
+    true
 }
 
 /// Check if a process is a zombie by reading /proc/PID/status on Linux.

--- a/tests/e2e/scenarios/59_fabric_pid_safety.sh
+++ b/tests/e2e/scenarios/59_fabric_pid_safety.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── PID Safety ──"
+create_network
+start_node "e2e-pid-1" "172.20.0.10"
+init_mesh "e2e-pid-1" "172.20.0.10" "node-1"
+wait_daemon "e2e-pid-1" 30
+
+# Write fake PID (PID 1 = init, should NOT be killed)
+docker exec "e2e-pid-1" syfrah fabric stop 2>/dev/null || true
+sleep 3
+docker exec "e2e-pid-1" bash -c 'echo 1 > /root/.syfrah/daemon.pid'
+
+# Try to stop — should refuse to kill PID 1
+err=$(docker exec "e2e-pid-1" syfrah fabric stop 2>&1 || true)
+echo "$err" | grep -qi "not.*syfrah\|invalid\|refuse\|not running" && \
+    pass "refuses to kill non-syfrah PID" || \
+    fail "did not refuse to kill fake PID"
+
+# PID 1 should still be alive
+docker exec "e2e-pid-1" kill -0 1 2>/dev/null && \
+    pass "PID 1 (init) still alive" || fail "PID 1 was killed!"
+
+cleanup
+summary


### PR DESCRIPTION
## Summary
- PID file uses `flock(LOCK_EX|LOCK_NB)` for exclusive locking, preventing two daemons from running simultaneously
- `syfrah stop` validates process name contains "syfrah" before sending SIGTERM (prevents killing unrelated processes after PID recycling/tampering)
- Control socket created with restricted umask (`0o177`) before `bind()`, eliminating the permission race window
- Stale PID files (dead process) cleaned up automatically on startup
- Add `is_syfrah_process()` with Linux `/proc` and macOS `ps` implementations
- Add E2E test `59_fabric_pid_safety.sh`

Closes #35

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [ ] E2E: `59_fabric_pid_safety.sh` verifies fake PID is refused and PID 1 survives

Generated with [Claude Code](https://claude.com/claude-code)