### PR TITLE
Add rate limiting and connection limits on peering listener

### DIFF
--- a/layers/fabric/src/config.rs
+++ b/layers/fabric/src/config.rs
@@ -22,6 +22,10 @@ pub struct Tuning {
     pub exchange_timeout: Duration,
     /// Maximum number of events to keep in the event log ring buffer.
     pub max_events: u64,
+    /// Maximum concurrent peering connections (default 100).
+    pub max_concurrent_connections: usize,
+    /// Maximum pending join requests (default 100).
+    pub max_pending_joins: usize,
 }
 
 impl Default for Tuning {
@@ -35,6 +39,8 @@ impl Default for Tuning {
             join_timeout: Duration::from_secs(300),
             exchange_timeout: Duration::from_secs(30),
             max_events: 100,
+            max_concurrent_connections: 100,
+            max_pending_joins: 100,
         }
     }
 }
@@ -68,6 +74,8 @@ struct WireguardSection {
 struct PeeringSection {
     join_timeout: Option<u64>,
     exchange_timeout: Option<u64>,
+    max_concurrent_connections: Option<usize>,
+    max_pending_joins: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -126,5 +134,13 @@ pub fn load_tuning() -> Result<Tuning, String> {
             .map(Duration::from_secs)
             .unwrap_or(defaults.exchange_timeout),
         max_events: config.events.max_events.unwrap_or(defaults.max_events),
+        max_concurrent_connections: config
+            .peering
+            .max_concurrent_connections
+            .unwrap_or(defaults.max_concurrent_connections),
+        max_pending_joins: config
+            .peering
+            .max_pending_joins
+            .unwrap_or(defaults.max_pending_joins),
     })
 }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -448,7 +448,10 @@ pub async fn run_daemon(
     );
 
     let wg_pubkey = wg_keypair.public.clone();
-    let peering_state = Arc::new(PeeringState::new());
+    let peering_state = Arc::new(PeeringState::with_limits(
+        tuning.max_concurrent_connections,
+        tuning.max_pending_joins,
+    ));
     let enc_key = mesh_secret.encryption_key();
 
     let metrics_received = Arc::new(AtomicU64::new(0));
@@ -569,6 +572,7 @@ pub async fn run_daemon(
     let persist_recv = metrics_received.clone();
     let persist_recon = metrics_reconciliations.clone();
     let persist_unreach = metrics_unreachable.clone();
+    let persist_peering_state = peering_state.clone();
     let persist = async {
         let mut interval = tokio::time::interval(tuning.persist_interval);
         loop {
@@ -580,6 +584,14 @@ pub async fn run_daemon(
                 persist_unreach.load(Ordering::Relaxed),
             );
             let _ = store::set_metric("daemon_started_at", daemon_started);
+            let _ = store::set_metric(
+                "connections_rejected",
+                persist_peering_state.connections_rejected(),
+            );
+            let _ = store::set_metric(
+                "connections_active",
+                persist_peering_state.connections_active(),
+            );
         }
     };
 

--- a/layers/fabric/src/peering.rs
+++ b/layers/fabric/src/peering.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use thiserror::Error;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::{oneshot, RwLock, Semaphore};
 use tracing::{debug, info, warn};
 
 use syfrah_core::mesh::{
@@ -18,6 +19,11 @@ use crate::events::{self, EventType};
 const JOIN_TIMEOUT: Duration = Duration::from_secs(300);
 const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_MSG_SIZE: u32 = 65536;
+
+/// Default maximum concurrent peering connections.
+const DEFAULT_MAX_CONNECTIONS: usize = 100;
+/// Default maximum pending join requests.
+const DEFAULT_MAX_PENDING_JOINS: usize = 100;
 
 #[derive(Debug, Error)]
 pub enum PeeringError {
@@ -77,6 +83,14 @@ pub struct PeeringState {
     pending: Arc<RwLock<HashMap<String, PendingJoin>>>,
     listener_active: Arc<RwLock<bool>>,
     auto_accept: Arc<RwLock<Option<AutoAcceptConfig>>>,
+    /// Metrics: total connections rejected due to limit.
+    connections_rejected: Arc<AtomicU64>,
+    /// Metrics: currently active connections.
+    connections_active: Arc<AtomicU64>,
+    /// Max concurrent connections (configurable).
+    max_connections: usize,
+    /// Max pending join requests (configurable).
+    max_pending_joins: usize,
 }
 
 impl Default for PeeringState {
@@ -87,11 +101,30 @@ impl Default for PeeringState {
 
 impl PeeringState {
     pub fn new() -> Self {
+        Self::with_limits(DEFAULT_MAX_CONNECTIONS, DEFAULT_MAX_PENDING_JOINS)
+    }
+
+    /// Create a PeeringState with custom connection and pending-join limits.
+    pub fn with_limits(max_connections: usize, max_pending_joins: usize) -> Self {
         Self {
             pending: Arc::new(RwLock::new(HashMap::new())),
             listener_active: Arc::new(RwLock::new(false)),
             auto_accept: Arc::new(RwLock::new(None)),
+            connections_rejected: Arc::new(AtomicU64::new(0)),
+            connections_active: Arc::new(AtomicU64::new(0)),
+            max_connections,
+            max_pending_joins,
         }
+    }
+
+    /// Return the number of connections rejected due to the concurrency limit.
+    pub fn connections_rejected(&self) -> u64 {
+        self.connections_rejected.load(Ordering::Relaxed)
+    }
+
+    /// Return the number of currently active connections.
+    pub fn connections_active(&self) -> u64 {
+        self.connections_active.load(Ordering::Relaxed)
     }
 
     pub async fn is_active(&self) -> bool {
@@ -158,7 +191,13 @@ impl PeeringState {
         self.set_active(true).await;
         let addr: SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
         let listener = TcpListener::bind(addr).await?;
-        info!(port = port, "peering listener started");
+        let semaphore = Arc::new(Semaphore::new(self.max_connections));
+        info!(
+            port = port,
+            max_connections = self.max_connections,
+            max_pending_joins = self.max_pending_joins,
+            "peering listener started"
+        );
 
         loop {
             let (stream, peer_addr) = match listener.accept().await {
@@ -169,6 +208,24 @@ impl PeeringState {
                 }
             };
 
+            // Enforce concurrent connection limit via semaphore.
+            let permit = match semaphore.clone().try_acquire_owned() {
+                Ok(p) => p,
+                Err(_) => {
+                    self.connections_rejected.fetch_add(1, Ordering::Relaxed);
+                    warn!(
+                        peer = %peer_addr,
+                        active = self.connections_active.load(Ordering::Relaxed),
+                        limit = self.max_connections,
+                        "connection limit reached, rejecting"
+                    );
+                    // Drop the stream immediately (TCP RST).
+                    drop(stream);
+                    continue;
+                }
+            };
+
+            self.connections_active.fetch_add(1, Ordering::Relaxed);
             debug!("peering connection from {peer_addr}");
 
             let pending = self.pending.clone();
@@ -176,8 +233,11 @@ impl PeeringState {
             let on_announce = on_announce.clone();
             let auto_accept = self.auto_accept.clone();
             let on_accepted = on_accepted.clone();
+            let active_counter = self.connections_active.clone();
+            let max_pending = self.max_pending_joins;
 
             tokio::spawn(async move {
+                let _permit = permit; // held until this task ends
                 if let Err(e) = handle_incoming(
                     stream,
                     peer_addr,
@@ -186,11 +246,13 @@ impl PeeringState {
                     on_announce,
                     auto_accept,
                     on_accepted,
+                    max_pending,
                 )
                 .await
                 {
                     debug!("peering connection from {peer_addr} failed: {e}");
                 }
+                active_counter.fetch_sub(1, Ordering::Relaxed);
             });
         }
 
@@ -199,6 +261,7 @@ impl PeeringState {
 }
 
 /// Handle an incoming TCP connection.
+#[allow(clippy::too_many_arguments)]
 async fn handle_incoming(
     mut stream: TcpStream,
     peer_addr: SocketAddr,
@@ -207,8 +270,12 @@ async fn handle_incoming(
     on_announce: Arc<dyn Fn(PeerRecord) + Send + Sync>,
     auto_accept: Arc<RwLock<Option<AutoAcceptConfig>>>,
     on_accepted: OnAccepted,
+    max_pending_joins: usize,
 ) -> Result<(), PeeringError> {
-    let msg = read_message(&mut stream).await?;
+    // Apply read timeout to protect against slowloris attacks.
+    let msg = tokio::time::timeout(EXCHANGE_TIMEOUT, read_message(&mut stream))
+        .await
+        .map_err(|_| PeeringError::Timeout)??;
 
     match msg {
         PeeringMessage::JoinRequest(mut req) => {
@@ -295,6 +362,14 @@ async fn handle_incoming(
                 if let Some(old_id) = stale_id {
                     info!(node = %info.node_name, old_request_id = %old_id, "replacing stale join request");
                     map.remove(&old_id);
+                }
+                // Enforce pending queue limit.
+                if map.len() >= max_pending_joins {
+                    warn!(
+                        limit = max_pending_joins,
+                        "pending join queue full, rejecting request"
+                    );
+                    return Err(PeeringError::Protocol("too many pending joins".into()));
                 }
                 map.insert(
                     req.request_id.clone(),


### PR DESCRIPTION
## Summary
- Add concurrent connection limit (default 100) via tokio semaphore in `run_listener()` — connections beyond the limit get TCP RST
- Add 30s read timeout on incoming `read_message()` calls to prevent slowloris attacks
- Cap pending join queue at 100 entries to prevent memory exhaustion from flood of join requests
- All limits configurable via `config.toml` `[peering]` section (`max_concurrent_connections`, `max_pending_joins`)
- Persist `connections_rejected` and `connections_active` metrics to the store

## Test plan
- [x] `cargo test` — all 131 tests pass (including 3 peering protocol tests)
- [x] `cargo clippy` — no warnings
- [ ] Manual: verify connection flood is mitigated by semaphore
- [ ] Manual: verify slowloris is mitigated by read timeout

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)