### PR TITLE
Fix file and directory permissions

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -183,6 +183,11 @@ fn setup_logging(daemon_mode: bool) {
             .join("syfrah.log");
         if let Some(parent) = log_path.parent() {
             let _ = std::fs::create_dir_all(parent);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+            }
         }
         if let Ok(meta) = std::fs::metadata(&log_path) {
             if meta.len() > 10 * 1024 * 1024 {
@@ -195,6 +200,11 @@ fn setup_logging(daemon_mode: bool) {
             .append(true)
             .open(&log_path)
             .expect("failed to open log file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o644));
+        }
         if json_mode {
             tracing_subscriber::fmt()
                 .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -241,6 +251,11 @@ fn background_daemon() -> Result<()> {
         .unwrap_or_else(|| std::path::PathBuf::from("."))
         .join(".syfrah");
     let _ = std::fs::create_dir_all(&log_dir);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&log_dir, std::fs::Permissions::from_mode(0o700));
+    }
     let log_path = log_dir.join("syfrah.log");
 
     // First fork

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -77,6 +77,18 @@ fn state_dir() -> PathBuf {
         .join(".syfrah")
 }
 
+/// Create the state directory if it doesn't exist and set permissions to 0o700.
+fn ensure_state_dir() -> Result<(), StoreError> {
+    let dir = state_dir();
+    fs::create_dir_all(&dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
 fn state_file() -> PathBuf {
     state_dir().join("state.json")
 }
@@ -90,8 +102,8 @@ pub fn exists() -> bool {
 /// Save node state.
 /// Writes to both redb (primary) and JSON (backward compat for E2E tests).
 pub fn save(state: &NodeState) -> Result<(), StoreError> {
+    ensure_state_dir()?;
     let dir = state_dir();
-    fs::create_dir_all(&dir)?;
 
     // Write to redb
     let db = open_db()?;
@@ -318,8 +330,8 @@ fn open_db() -> Result<LayerDb, StoreError> {
 
 /// Write JSON only (no redb) for backward compat.
 fn save_json_only(state: &NodeState) -> Result<(), StoreError> {
+    ensure_state_dir()?;
     let dir = state_dir();
-    fs::create_dir_all(&dir)?;
     let file = state_file();
     let tmp = dir.join("state.json.tmp");
     let json = serde_json::to_string_pretty(state)?;
@@ -349,8 +361,8 @@ fn pid_file() -> PathBuf {
 pub fn write_pid() -> Result<fs::File, StoreError> {
     use std::io::Write;
 
+    ensure_state_dir()?;
     let dir = state_dir();
-    fs::create_dir_all(&dir)?;
 
     let path = pid_file();
 
@@ -401,7 +413,7 @@ pub fn write_pid() -> Result<fs::File, StoreError> {
     // Restrict permissions
     {
         use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o644));
     }
 
     // Ensure PID content is correct on the locked fd
@@ -415,8 +427,7 @@ pub fn write_pid() -> Result<fs::File, StoreError> {
 /// Non-unix fallback (no flock).
 #[cfg(not(unix))]
 pub fn write_pid() -> Result<(), StoreError> {
-    let dir = state_dir();
-    fs::create_dir_all(&dir)?;
+    ensure_state_dir()?;
     fs::write(pid_file(), std::process::id().to_string())?;
     Ok(())
 }

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -82,8 +82,20 @@ impl LayerDb {
         let dir = syfrah_dir();
         std::fs::create_dir_all(&dir)?;
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+
         let path = db_path(layer);
         let db = Database::create(&path)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
 
         Ok(Self {
             db: Arc::new(db),


### PR DESCRIPTION
## Summary
- Set `~/.syfrah/` directory to `0o700` (owner-only) on every creation path (store, state layer, binary)
- Set `*.redb` database files to `0o600` after creation (contain mesh secrets)
- Change `daemon.pid` from `0o600` to `0o644` (non-sensitive, needs to be readable by CLI)
- Set `syfrah.log` to `0o644` after creation (non-sensitive log output)
- `control.sock` already secured via umask before bind (no change needed)
- `state.json` already set to `0o600` (no change needed)

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)