### PR TITLE
Fix peering watch exit after accept/reject

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -126,6 +126,9 @@ enum FabricCommand {
         /// PIN for auto-accept mode
         #[arg(long)]
         pin: Option<String>,
+        /// Stay open to accept multiple join requests
+        #[arg(long)]
+        watch: bool,
         #[command(subcommand)]
         action: Option<PeeringAction>,
     },
@@ -473,10 +476,10 @@ async fn run() -> Result<()> {
                     ServiceAction::Status => cli::service::status().await,
                 }
             }
-            FabricCommand::Peering { pin, action } => {
+            FabricCommand::Peering { pin, watch, action } => {
                 setup_logging(false);
                 match action {
-                    None => cli::peering::watch(pin).await,
+                    None => cli::peering::watch(pin, watch).await,
                     Some(PeeringAction::Start {
                         port,
                         pin: start_pin,

--- a/layers/fabric/src/cli/peering.rs
+++ b/layers/fabric/src/cli/peering.rs
@@ -6,7 +6,10 @@ use anyhow::Result;
 use std::collections::HashSet;
 
 /// Interactive peering mode: watch for requests and prompt accept/reject.
-pub async fn watch(pin: Option<String>) -> Result<()> {
+///
+/// In default mode (`continuous=false`), exits after the first accept/reject.
+/// With `--watch` (`continuous=true`), loops indefinitely for batch use.
+pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
     // Auto-init if no mesh exists
     if !store::exists() {
         let node_name = hostname::get()
@@ -68,12 +71,18 @@ pub async fn watch(pin: Option<String>) -> Result<()> {
         _ => {}
     }
 
-    ui::peering_banner(51821, pin.as_deref());
+    ui::peering_banner(51821, pin.as_deref(), continuous);
 
-    // Poll for new requests
+    // Poll for new requests; handle Ctrl+C gracefully
     let mut seen: HashSet<String> = HashSet::new();
     loop {
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nPeering watch stopped. Daemon still running.");
+                return Ok(());
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+        }
 
         let resp = match send_request(ControlRequest::PeeringList).await {
             Ok(r) => r,
@@ -140,6 +149,11 @@ pub async fn watch(pin: Option<String>) -> Result<()> {
                                 println!();
                             }
                         }
+                    }
+
+                    // In default (non-watch) mode, exit after handling the first request
+                    if !continuous {
+                        return Ok(());
                     }
                 }
             }

--- a/layers/fabric/src/ui.rs
+++ b/layers/fabric/src/ui.rs
@@ -146,7 +146,11 @@ pub fn join_request_card(node_name: &str, endpoint: &str, wg_key_prefix: &str) {
 }
 
 /// Print a peering-active banner.
-pub fn peering_banner(port: u16, pin: Option<&str>) {
+///
+/// When `continuous` is true (`--watch` mode), shows "Press Ctrl+C to stop."
+/// In default mode, just says "Waiting for join request..." since it exits
+/// after the first accept/reject.
+pub fn peering_banner(port: u16, pin: Option<&str>, continuous: bool) {
     if is_tty() {
         let green = Style::new().green();
         println!(
@@ -156,9 +160,11 @@ pub fn peering_banner(port: u16, pin: Option<&str>) {
         if let Some(p) = pin {
             println!("  Mode: auto-accept with PIN");
             println!("  Nodes can join with: syfrah fabric join <this-ip> --pin {p}");
-        } else {
+        } else if continuous {
             println!("  Mode: manual approval (you will be prompted for each join request)");
             println!("  Press Ctrl+C to stop.");
+        } else {
+            println!("  Waiting for join request...");
         }
         println!();
     } else {
@@ -166,9 +172,11 @@ pub fn peering_banner(port: u16, pin: Option<&str>) {
         if let Some(p) = pin {
             println!("Mode: auto-accept with PIN");
             println!("Nodes can join with: syfrah fabric join <this-ip> --pin {p}");
-        } else {
+        } else if continuous {
             println!("Mode: manual approval");
             println!("Press Ctrl+C to stop.");
+        } else {
+            println!("Waiting for join request...");
         }
         println!();
     }


### PR DESCRIPTION
## Summary

- `syfrah fabric peering` now exits after handling the first join request (accept or reject) instead of looping forever
- Added `--watch` flag to opt into continuous mode for batch accepting multiple nodes
- Ctrl+C message changed from "Shutting down..." to "Peering watch stopped. Daemon still running."
- Removed "Press Ctrl+C to stop." from default mode banner; replaced with "Waiting for join request..."

Closes #98

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [ ] Manual: run `syfrah fabric peering`, accept a request, verify CLI exits
- [ ] Manual: run `syfrah fabric peering --watch`, accept a request, verify CLI stays open
- [ ] Manual: Ctrl+C during wait shows correct message

Generated with [Claude Code](https://claude.com/claude-code)