### PR TITLE
Add UX error handling E2E scenarios (105-109)

### DIFF
--- a/tests/e2e/scenarios/105_ux_errors_init.sh
+++ b/tests/e2e/scenarios/105_ux_errors_init.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Scenario: UX Errors — init error messages
+# Validates init produces helpful errors in every failure mode.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── UX Errors: Init ──"
+trap cleanup EXIT
+create_network
+
+start_node "e2e-err-init-1" "172.20.0.10"
+
+# Test 1: Init when mesh already exists
+info "Testing: init when mesh already exists..."
+init_mesh "e2e-err-init-1" "172.20.0.10" "err-node-1"
+
+output=$(docker exec "e2e-err-init-1" syfrah fabric init \
+    --name another-mesh --node-name err-node-2 --endpoint 172.20.0.10:51820 2>&1 || true)
+
+if echo "$output" | grep -qi "already.*exist\|already.*init"; then
+    pass "double init: says already exists"
+else
+    fail "double init: unclear message: $(echo "$output" | head -3)"
+fi
+
+if echo "$output" | grep -qF "syfrah fabric leave"; then
+    pass "double init: suggests 'syfrah fabric leave'"
+else
+    fail "double init: doesn't suggest leave command"
+fi
+
+# Verify no raw errors
+if echo "$output" | grep -qEi "os error|anyhow|panicked|unwrap"; then
+    fail "double init: contains raw error"
+else
+    pass "double init: no raw errors"
+fi
+
+cleanup
+summary

--- a/tests/e2e/scenarios/106_ux_errors_join.sh
+++ b/tests/e2e/scenarios/106_ux_errors_join.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Scenario: UX Errors — join error messages
+# Validates join produces helpful errors in every failure mode.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── UX Errors: Join ──"
+trap cleanup EXIT
+create_network
+
+start_node "e2e-err-join-1" "172.20.0.10"
+start_node "e2e-err-join-2" "172.20.0.11"
+start_node "e2e-err-join-3" "172.20.0.12"
+
+# Set up mesh on node 1 for some tests
+init_mesh "e2e-err-join-1" "172.20.0.10" "err-join-srv-1"
+
+# Test 1: Join to unreachable IP — human message
+info "Testing: join to unreachable IP..."
+err=$(docker exec "e2e-err-join-2" syfrah fabric join 172.20.0.99:51821 \
+    --node-name err-join-2 --endpoint 172.20.0.11:51820 --pin 1234 2>&1 || true)
+if echo "$err" | grep -qEi "os error 111|ECONNREFUSED"; then
+    fail "join unreachable: raw OS error visible: $(echo "$err" | head -3)"
+else
+    pass "join unreachable: no raw OS error"
+fi
+
+# Test 2: Join when peering not active — human message
+info "Testing: join when peering not active..."
+err2=$(docker exec "e2e-err-join-2" syfrah fabric join 172.20.0.10:51821 \
+    --node-name err-join-2 --endpoint 172.20.0.11:51820 --pin 1234 2>&1 || true)
+if echo "$err2" | grep -qEi "early eof"; then
+    fail "join no peering: raw 'early eof' visible"
+else
+    pass "join no peering: no raw error"
+fi
+
+# Test 3: Join when state exists — suggests syfrah fabric leave
+info "Testing: join when state exists..."
+start_peering "e2e-err-join-1"
+join_mesh "e2e-err-join-2" "172.20.0.10" "172.20.0.11" "err-join-srv-2"
+sleep 3
+
+err3=$(docker exec "e2e-err-join-2" syfrah fabric join 172.20.0.10:51821 \
+    --node-name err-join-2b --endpoint 172.20.0.11:51820 --pin "$E2E_PIN" 2>&1 || true)
+if echo "$err3" | grep -qi "already\|exists\|leave"; then
+    pass "join with state: mentions existing state"
+else
+    fail "join with state: unclear: $(echo "$err3" | head -3)"
+fi
+
+if echo "$err3" | grep -qF "syfrah fabric leave"; then
+    pass "join with state: suggests full command path"
+elif echo "$err3" | grep -qi "leave"; then
+    pass "join with state: mentions leave"
+else
+    fail "join with state: no leave suggestion"
+fi
+
+# Test 4: Join no arguments — shows help
+info "Testing: join no arguments..."
+err4=$(docker exec "e2e-err-join-3" syfrah fabric join 2>&1 || true)
+if echo "$err4" | grep -qi "usage\|help\|argument\|required"; then
+    pass "join no args: shows usage"
+else
+    fail "join no args: no usage info: $(echo "$err4" | head -3)"
+fi
+
+# Test 5: Join after failed join — retry works (no phantom state)
+info "Testing: join retry after failure..."
+assert_join_retry_works "e2e-err-join-3" "172.20.0.10:51821" "172.20.0.12" "err-join-3"
+
+cleanup
+summary

--- a/tests/e2e/scenarios/107_ux_errors_lifecycle.sh
+++ b/tests/e2e/scenarios/107_ux_errors_lifecycle.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Scenario: UX Errors — lifecycle command error messages
+# Validates stop, start, leave, peers, status produce helpful errors.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── UX Errors: Lifecycle ──"
+trap cleanup EXIT
+create_network
+
+start_node "e2e-err-life-1" "172.20.0.10"
+
+# Test 1: stop when not running
+info "Testing: stop when not running..."
+err=$(docker exec "e2e-err-life-1" syfrah fabric stop 2>&1 || true)
+if echo "$err" | grep -qi "not running\|nothing\|no daemon\|already"; then
+    pass "stop not running: helpful message"
+else
+    fail "stop not running: unclear: $(echo "$err" | head -3)"
+fi
+
+# Test 2: start without init — suggests init/join
+info "Testing: start without init..."
+err2=$(docker exec "e2e-err-life-1" syfrah fabric start 2>&1 || true)
+if echo "$err2" | grep -qi "init\|join\|configured\|no mesh"; then
+    pass "start without init: suggests init/join"
+else
+    fail "start without init: unclear: $(echo "$err2" | head -3)"
+fi
+
+# Test 3: leave without mesh
+info "Testing: leave without mesh..."
+err3=$(docker exec "e2e-err-life-1" syfrah fabric leave 2>&1 || true)
+if echo "$err3" | grep -qi "nothing\|no mesh\|not.*found\|no state\|already"; then
+    pass "leave no mesh: says nothing to do"
+else
+    fail "leave no mesh: unclear: $(echo "$err3" | head -3)"
+fi
+
+# Test 4: double leave
+info "Testing: double leave..."
+err4=$(docker exec "e2e-err-life-1" syfrah fabric leave 2>&1 || true)
+if echo "$err4" | grep -qi "nothing\|no mesh\|not.*found\|no state\|already"; then
+    pass "double leave: says nothing to do"
+else
+    fail "double leave: unclear: $(echo "$err4" | head -3)"
+fi
+
+# Test 5: peers without mesh — suggests init/join
+info "Testing: peers without mesh..."
+err5=$(docker exec "e2e-err-life-1" syfrah fabric peers 2>&1 || true)
+if echo "$err5" | grep -qi "init\|join"; then
+    pass "peers no mesh: suggests init/join"
+else
+    fail "peers no mesh: unclear: $(echo "$err5" | head -3)"
+fi
+
+# Test 6: status without mesh — suggests init/join
+info "Testing: status without mesh..."
+err6=$(docker exec "e2e-err-life-1" syfrah fabric status 2>&1 || true)
+if echo "$err6" | grep -qi "init\|join"; then
+    pass "status no mesh: suggests init/join"
+else
+    fail "status no mesh: unclear: $(echo "$err6" | head -3)"
+fi
+
+# Test 7: leave then join — works first try
+info "Testing: leave then join cycle..."
+init_mesh "e2e-err-life-1" "172.20.0.10" "life-node-1"
+docker exec "e2e-err-life-1" syfrah fabric leave 2>&1 || true
+sleep 2
+# Should be able to init again without issues
+output_reinit=$(docker exec "e2e-err-life-1" syfrah fabric init \
+    --name re-mesh --node-name life-node-1 --endpoint 172.20.0.10:51820 2>&1 || true)
+if echo "$output_reinit" | grep -qF "syf_sk_"; then
+    pass "leave then init: works first try"
+else
+    fail "leave then init: failed: $(echo "$output_reinit" | head -3)"
+fi
+
+cleanup
+summary

--- a/tests/e2e/scenarios/108_ux_errors_commands.sh
+++ b/tests/e2e/scenarios/108_ux_errors_commands.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Scenario: UX Errors — wrong command paths and suggestions
+# Validates typos and wrong paths get helpful responses.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── UX Errors: Commands ──"
+trap cleanup EXIT
+create_network
+
+start_node "e2e-err-cmd-1" "172.20.0.10"
+
+# Test 1: syfrah without subcommand — shows help
+info "Testing: syfrah without subcommand..."
+err=$(docker exec "e2e-err-cmd-1" syfrah 2>&1 || true)
+if echo "$err" | grep -qi "help\|usage\|fabric\|commands"; then
+    pass "syfrah bare: shows help/commands"
+else
+    fail "syfrah bare: no help: $(echo "$err" | head -3)"
+fi
+
+# Test 2: syfrah with wrong subcommand — helpful error
+info "Testing: syfrah with wrong subcommand..."
+err2=$(docker exec "e2e-err-cmd-1" syfrah peering 2>&1 || true)
+if echo "$err2" | grep -qi "help\|usage\|unrecognized\|invalid\|fabric\|not found\|subcommand"; then
+    pass "syfrah peering: shows help or error"
+else
+    fail "syfrah peering: no guidance: $(echo "$err2" | head -3)"
+fi
+
+err3=$(docker exec "e2e-err-cmd-1" syfrah init 2>&1 || true)
+if echo "$err3" | grep -qi "help\|usage\|unrecognized\|invalid\|fabric\|not found\|subcommand"; then
+    pass "syfrah init: shows help or error"
+else
+    fail "syfrah init: no guidance: $(echo "$err3" | head -3)"
+fi
+
+err4=$(docker exec "e2e-err-cmd-1" syfrah join 2>&1 || true)
+if echo "$err4" | grep -qi "help\|usage\|unrecognized\|invalid\|fabric\|not found\|subcommand"; then
+    pass "syfrah join: shows help or error"
+else
+    fail "syfrah join: no guidance: $(echo "$err4" | head -3)"
+fi
+
+# Test 3: All suggested commands in error messages are valid
+info "Testing: suggested commands in error output are valid..."
+# Init to get a mesh, then test commands
+init_mesh "e2e-err-cmd-1" "172.20.0.10" "cmd-node-1"
+assert_all_commands_valid "e2e-err-cmd-1" "syfrah fabric status"
+
+cleanup
+summary

--- a/tests/e2e/scenarios/109_ux_errors_no_raw_errors.sh
+++ b/tests/e2e/scenarios/109_ux_errors_no_raw_errors.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Scenario: UX Errors — no raw Rust errors in any output
+# Runs every command in wrong states and verifies no raw errors leak.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+
+echo "── UX Errors: No Raw Errors ──"
+trap cleanup EXIT
+create_network
+
+start_node "e2e-err-raw-1" "172.20.0.10"
+
+FORBIDDEN_PATTERNS="os error|anyhow|panicked|thread 'main'|early eof|RUST_BACKTRACE|unwrap()"
+
+# Test all commands in clean state (no mesh)
+info "Testing: commands with no mesh..."
+for cmd in \
+    "syfrah fabric peers" \
+    "syfrah fabric status" \
+    "syfrah fabric stop" \
+    "syfrah fabric start" \
+    "syfrah fabric leave" \
+    "syfrah fabric token" \
+    "syfrah --help" \
+    "syfrah fabric --help"; do
+    output=$(docker exec "e2e-err-raw-1" sh -c "$cmd" 2>&1 || true)
+    if echo "$output" | grep -qEi "$FORBIDDEN_PATTERNS"; then
+        fail "$cmd (no mesh): contains raw error"
+    else
+        pass "$cmd (no mesh): clean output"
+    fi
+done
+
+# Init mesh and test commands in running state
+info "Testing: commands with running mesh..."
+init_mesh "e2e-err-raw-1" "172.20.0.10" "raw-node-1"
+
+for cmd in \
+    "syfrah fabric peers" \
+    "syfrah fabric status" \
+    "syfrah fabric token"; do
+    output=$(docker exec "e2e-err-raw-1" sh -c "$cmd" 2>&1 || true)
+    if echo "$output" | grep -qEi "$FORBIDDEN_PATTERNS"; then
+        fail "$cmd (running): contains raw error"
+    else
+        pass "$cmd (running): clean output"
+    fi
+done
+
+# Test join to bad target
+info "Testing: join to bad target..."
+output=$(docker exec "e2e-err-raw-1" sh -c \
+    "syfrah fabric join 10.99.99.99:51821 --node-name test --endpoint 172.20.0.10:51820" 2>&1 || true)
+if echo "$output" | grep -qEi "$FORBIDDEN_PATTERNS"; then
+    fail "join bad target: contains raw error"
+else
+    pass "join bad target: clean output"
+fi
+
+# Test double init
+info "Testing: double init..."
+output=$(docker exec "e2e-err-raw-1" sh -c \
+    "syfrah fabric init --name test2 --node-name n2 --endpoint 172.20.0.10:51820" 2>&1 || true)
+if echo "$output" | grep -qEi "$FORBIDDEN_PATTERNS"; then
+    fail "double init: contains raw error"
+else
+    pass "double init: clean output"
+fi
+
+cleanup
+summary


### PR DESCRIPTION
## Summary
- Adds 5 E2E scenarios testing error message quality across all CLI commands
- Validates: no raw Rust errors, helpful suggestions, correct command paths
- Forbidden pattern audit: os error, anyhow, panicked, early eof, unwrap, stack traces
- All scenarios include `trap cleanup EXIT`

Closes #109

## Test plan
- [x] All 5 scenarios pass `bash -n` syntax validation
- [ ] CI passes