### PR TITLE
fix: bump version to 0.2.0 and add version/tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify Cargo.toml version matches release version
+        env:
+          VERSION: ${{ needs.version.outputs.next }}
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$CARGO_VERSION" != "$VERSION" ]; then
+            echo "ERROR: Cargo.toml version ($CARGO_VERSION) != release version ($VERSION)"
+            echo "Bump Cargo.toml version to $VERSION before releasing."
+            exit 1
+          fi
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/sifrah/syfrah"

--- a/handbook/releasing.md
+++ b/handbook/releasing.md
@@ -20,10 +20,15 @@ Every merge to `main` automatically produces a new GitHub Release. There is no m
    | `[Feature]` or `feat:` | Minor (0.X.0) | `0.2.0 -> 0.3.0` |
    | Anything else | Patch (0.0.X) | `0.2.0 -> 0.2.1` |
 
-4. **CI gate** -- the workflow waits for CI checks to pass before proceeding.
-5. **Cargo.toml bump** -- the workflow updates `version` in `[workspace.package]` in the root `Cargo.toml`, commits with `release: vX.Y.Z [skip ci]`, and pushes directly to `main`.
-6. **Build** -- all four targets are built in parallel (same matrix as CI).
-7. **Release** -- binaries are packaged into `.tar.gz` archives, `SHA256SUMS.txt` is generated, a git tag `vX.Y.Z` is created, and a GitHub Release is published with all artifacts.
+4. **Version validation** -- each build job verifies that the version in `Cargo.toml` matches the calculated release version. The build fails immediately if they differ.
+5. **Build** -- all four targets are built in parallel (same matrix as CI).
+6. **Release** -- binaries are packaged into `.tar.gz` archives, `SHA256SUMS.txt` is generated, a git tag `vX.Y.Z` is created, and a GitHub Release is published with all artifacts.
+
+### Keeping Cargo.toml in sync
+
+The binary version reported by `syfrah --version` comes from `CARGO_PKG_VERSION`, which is baked in at compile time from `Cargo.toml`. The release workflow validates that `Cargo.toml` matches the computed release version and **will fail the build if they differ**.
+
+**Before merging a version-bumping PR**, update `version` in `[workspace.package]` in the root `Cargo.toml` to match the version that the release workflow will compute. All crates inherit this version via `version.workspace = true`.
 
 ### Influencing the version bump
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,8 +55,14 @@ install -m 755 "${TMPDIR}/${BIN}" "${INSTALL_DIR}/${BIN}"
 
 # --- Verify ---
 echo "Verifying installation..."
+EXPECTED_VERSION="${VERSION#v}"
 if command -v "$BIN" > /dev/null 2>&1; then
-  "$BIN" --version
+  ACTUAL_VERSION=$("$BIN" --version | awk '{print $2}')
+  if [ "$ACTUAL_VERSION" != "$EXPECTED_VERSION" ]; then
+    echo "ERROR: version mismatch — expected ${EXPECTED_VERSION}, got ${ACTUAL_VERSION}" >&2
+    exit 1
+  fi
+  echo "${BIN} ${ACTUAL_VERSION}"
   echo "Installation complete."
 else
   echo "Warning: ${BIN} was installed to ${INSTALL_DIR} but is not on PATH." >&2


### PR DESCRIPTION
## Summary

- Bumps workspace version in `Cargo.toml` from `0.1.0` to `0.2.0` so `syfrah --version` reports the correct version
- Adds a version validation step to the release workflow that fails the build if `Cargo.toml` version doesn't match the computed release version
- Updates `install.sh` to verify the installed binary reports the expected version (exits non-zero on mismatch)
- Updates `handbook/releasing.md` to document the version consistency requirement

## Test plan

- [ ] CI passes (fmt, clippy, test)
- [ ] Rebuild v0.2.0 release assets — verify `syfrah --version` outputs `syfrah 0.2.0`
- [ ] Trigger a release with a mismatched Cargo.toml version — verify the build fails at the validation step
- [ ] Run `install.sh` against the rebuilt release — verify version check passes

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)