### PR TITLE
fix: remove version validation that blocks automated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,17 +85,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify Cargo.toml version matches release version
-        env:
-          VERSION: ${{ needs.version.outputs.next }}
-        run: |
-          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          if [ "$CARGO_VERSION" != "$VERSION" ]; then
-            echo "ERROR: Cargo.toml version ($CARGO_VERSION) != release version ($VERSION)"
-            echo "Bump Cargo.toml version to $VERSION before releasing."
-            exit 1
-          fi
-
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
Closes #127

## Summary

- Removes the `Verify Cargo.toml version matches release version` step from the release workflow
- This step (added in PR #122) ran **before** the auto-bump, comparing the stale `Cargo.toml` version against the computed next version — guaranteed to fail
- The `SYFRAH_VERSION` env var already overrides `CARGO_PKG_VERSION` at build time via `build.rs`, so `syfrah --version` correctly reports the release tag without needing `Cargo.toml` to match

## Test plan

- [ ] Merge to `main` and verify the release workflow completes successfully
- [ ] Confirm `syfrah --version` on the built binary matches the release tag