### PR TITLE
fix: restore Cargo.toml auto-bump in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,17 @@ jobs:
           cd release
           sha256sum *.tar.gz > SHA256SUMS.txt
 
+      - name: Bump Cargo.toml version
+        env:
+          VERSION: ${{ needs.version.outputs.next }}
+        run: |
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.toml
+          git commit -m "release: v${VERSION} [skip ci]"
+          git push origin main
+
       - name: Create git tag
         env:
           VERSION: ${{ needs.version.outputs.next }}


### PR DESCRIPTION
Closes #127

## Summary

- Adds a version auto-bump step to the release workflow that updates `Cargo.toml` before tagging
- The step updates the workspace version, commits with `[skip ci]`, and pushes to `main`
- The git tag is then created on the bump commit, so `syfrah --version` matches the release tag
- No manual `Cargo.toml` bump is required — the workflow handles it automatically

## How it works

1. Workflow computes the next version from commit messages (unchanged)
2. Binaries are built with `SYFRAH_VERSION` env var override (unchanged)
3. **New:** Before tagging, the release job updates `Cargo.toml` version and pushes a `release: vX.Y.Z [skip ci]` commit
4. Tag is created on the bump commit, release is published

## Test plan

- [ ] Merge to `main` and verify the release workflow completes successfully
- [ ] Verify the release commit updates `Cargo.toml` with the correct version
- [ ] Verify `syfrah --version` matches the release tag