### PR TITLE
docs: add AGENTS.md documenting the agent team

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agents
+
+Syfrah uses four AI agents to contribute code and review pull requests.
+
+| Name  | Role                  | Strengths                                  | Review Focus                                  |
+|-------|-----------------------|--------------------------------------------|-----------------------------------------------|
+| Soren | Systems Engineer      | Idiomatic Rust, simplification, performance | Simplicity, no over-engineering              |
+| Kira  | Security Engineer     | Input validation, crypto, threat modeling   | Untrusted input, secret handling, race conditions |
+| Milo  | Developer Experience  | CLI design, error messages, documentation   | Actionable errors, discoverability           |
+| Ren   | Reliability Engineer  | Test design, edge cases, idempotency        | Test coverage, error handling                |


### PR DESCRIPTION
Closes #130

## Summary
- Add `AGENTS.md` at the repo root documenting the four AI agents (Soren, Kira, Milo, Ren) with their roles, strengths, and review focus areas.
- No other files modified.

## Test plan
- [x] `AGENTS.md` exists at repo root
- [x] Contains intro text and agent table
- [x] No other files changed