### PR TITLE
fix: add read timeout to control socket connections

### DIFF
--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -31,3 +31,4 @@ toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }

--- a/layers/fabric/src/control.rs
+++ b/layers/fabric/src/control.rs
@@ -276,6 +276,8 @@ mod tests {
 
     #[tokio::test]
     async fn control_slow_client_times_out() {
+        tokio::time::pause();
+
         use std::sync::atomic::{AtomicBool, Ordering};
         use tokio::net::UnixListener;
 
@@ -304,7 +306,7 @@ mod tests {
         // Accept the connection and handle it; should timeout within CONTROL_READ_TIMEOUT
         let (stream, _) = listener.accept().await.unwrap();
         let result = tokio::time::timeout(
-            Duration::from_secs(10),
+            CONTROL_READ_TIMEOUT + Duration::from_secs(1),
             handle_control_connection(stream, handler),
         )
         .await


### PR DESCRIPTION
Closes #142

## Summary
- Add a 5-second read timeout (`CONTROL_READ_TIMEOUT`) on `handle_control_connection` using `tokio::time::timeout`
- Slow or malicious clients that don't send a complete request within the timeout are dropped with a `warn!` log
- Normal CLI operations are unaffected (typical control messages complete in milliseconds)

## Test plan
- [x] New test `control_slow_client_times_out`: connects to the control socket but sends nothing, verifies the server returns a timeout error within the deadline and the handler is never invoked
- [x] All existing tests pass (clippy clean, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)