### PR TITLE
docs: document config.toml in handbook

### DIFF
--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -4,7 +4,7 @@
 
 The syfrah daemon reads optional configuration from `~/.syfrah/config.toml` at startup. Every setting has a sensible default, so the file is not required. Create it only when you need to tune behavior for your environment.
 
-If the file does not exist, the daemon starts with built-in defaults. If the file exists but contains invalid TOML or unrecognized keys, the daemon refuses to start and prints the parse error.
+If the file does not exist, the daemon starts with built-in defaults. If the file exists but contains invalid TOML syntax or type mismatches (e.g. a string where an integer is expected), the daemon refuses to start and prints the parse error. Unrecognized keys are silently ignored — double-check spelling if a setting does not seem to take effect.
 
 ## File location
 


### PR DESCRIPTION
Closes #145

## Summary

- Add `handbook/configuration.md` documenting all `~/.syfrah/config.toml` options
- Covers all five sections: `[daemon]`, `[wireguard]`, `[peering]`, `[events]`, `[limits]`
- Lists every key with its type, default value, and description
- Includes minimal and full example config files
- Notes that changes require a daemon restart

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] All config keys from `config.rs` are documented
- [x] Default values match source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)