### PR TITLE
Improve fabric status display UX

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -105,7 +105,14 @@ enum FabricCommand {
     /// Stop the running daemon
     Stop,
     /// Show mesh and daemon status
-    Status,
+    Status {
+        /// Show config and metrics sections
+        #[arg(long, short)]
+        verbose: bool,
+        /// Show the full mesh secret (masked by default)
+        #[arg(long)]
+        show_secret: bool,
+    },
     /// Show the event log
     Events {
         /// Output as JSON
@@ -462,9 +469,12 @@ async fn run() -> Result<()> {
                 setup_logging(false);
                 cli::stop::run().await
             }
-            FabricCommand::Status => {
+            FabricCommand::Status {
+                verbose,
+                show_secret,
+            } => {
                 setup_logging(false);
-                cli::status::run().await
+                cli::status::run(verbose, show_secret).await
             }
             FabricCommand::Events { json } => {
                 setup_logging(false);

--- a/layers/fabric/src/cli/status.rs
+++ b/layers/fabric/src/cli/status.rs
@@ -1,94 +1,70 @@
 use crate::sanitize::sanitize;
-use crate::{config, store, wg};
+use crate::{config, store, ui, wg};
 use anyhow::Result;
 
-pub async fn run() -> Result<()> {
+pub async fn run(verbose: bool, show_secret: bool) -> Result<()> {
     let state = store::load().map_err(|_| {
         anyhow::anyhow!(
             "no mesh configured. Run 'syfrah fabric init' or 'syfrah fabric join' first."
         )
     })?;
 
-    println!("Mesh:      {}", sanitize(&state.mesh_name));
-    println!("Node:      {}", sanitize(&state.node_name));
-    println!("Mesh IPv6: {}", state.mesh_ipv6);
-    println!("Prefix:    {}/48", state.mesh_prefix);
-    println!("WG port:   {}", state.wg_listen_port);
-    println!(
-        "Region:    {}",
-        state
-            .region
-            .as_deref()
-            .map(sanitize)
-            .unwrap_or_else(|| "(not set)".into())
-    );
-    println!(
-        "Zone:      {}",
-        state
-            .zone
-            .as_deref()
-            .map(sanitize)
-            .unwrap_or_else(|| "(not set)".into())
-    );
-    println!("Secret:    {}", state.mesh_secret);
-    println!("Peering:   port {}", state.peering_port);
+    // ── Mesh section ────────────────────────────────────────────────
+    let region_zone = match (state.region.as_deref(), state.zone.as_deref()) {
+        (Some(r), Some(z)) => format!("{} / zone: {}", sanitize(r), sanitize(z)),
+        (Some(r), None) => sanitize(r).to_string(),
+        _ => "(not set)".into(),
+    };
 
-    match store::daemon_running() {
-        Some(pid) => println!("Daemon:    running (pid {pid})"),
-        None => println!("Daemon:    stopped"),
-    }
+    let uptime_str = {
+        let m = &state.metrics;
+        if m.daemon_started_at > 0 {
+            let uptime = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                .saturating_sub(m.daemon_started_at);
+            fmt_duration(uptime)
+        } else {
+            "-".into()
+        }
+    };
+
+    ui::box_top("Mesh");
+    ui::box_line(&format!(" Name:     {}", sanitize(&state.mesh_name)));
+    ui::box_line(&format!(" Node:     {}", sanitize(&state.node_name)));
+    ui::box_line(&format!(" Region:   {region_zone}"));
+    ui::box_line(&format!(" Prefix:   {}/48", state.mesh_prefix));
+    ui::box_line(&format!(" Uptime:   {uptime_str}"));
+    ui::box_bottom();
     println!();
 
-    match wg::interface_summary() {
-        Ok(summary) => {
-            println!(
-                "Interface: {} ({})",
-                summary.name,
-                if summary.public_key.is_some() {
-                    "up"
-                } else {
-                    "down"
-                }
-            );
-            if let Some(port) = summary.listen_port {
-                println!("Listen:    :{port}");
-            }
-            let with_handshake = summary
-                .peers
-                .iter()
-                .filter(|p| p.last_handshake.is_some())
-                .count();
-            println!(
-                "WG peers:  {} configured, {} with handshake",
-                summary.peer_count, with_handshake
-            );
-            let (rx, tx) = summary.peers.iter().fold((0u64, 0u64), |(rx, tx), p| {
-                (rx + p.rx_bytes, tx + p.tx_bytes)
-            });
-            println!("Traffic:   rx {} / tx {}", fmt_bytes(rx), fmt_bytes(tx));
-
-            // Handshake health: count peers with recent handshake (<3min)
-            let now_ts = std::time::SystemTime::now();
-            let healthy = summary
-                .peers
-                .iter()
-                .filter(|p| {
-                    p.last_handshake
-                        .map(|h| now_ts.duration_since(h).unwrap_or_default().as_secs() < 180)
-                        .unwrap_or(false)
-                })
-                .count();
-            if summary.peer_count > 0 {
-                println!(
-                    "Health:    {}/{} peers with recent handshake (<3min)",
-                    healthy, summary.peer_count
-                );
-            }
-        }
-        Err(_) => println!("Interface: syfrah0 (down)"),
+    // ── Health status (prominent, outside box) ──────────────────────
+    let daemon_running = store::daemon_running();
+    match &daemon_running {
+        Some(pid) => ui::health_line(true, &format!("Daemon running (pid {pid})")),
+        None => ui::health_line(false, "Daemon stopped"),
     }
 
-    // Peer status breakdown
+    let iface_up = match wg::interface_summary() {
+        Ok(summary) => {
+            let up = summary.public_key.is_some();
+            if up {
+                ui::health_line(true, &format!("Interface {} is up", summary.name));
+            } else {
+                ui::health_line(false, &format!("Interface {} is down", summary.name));
+            }
+            Some((up, summary))
+        }
+        Err(_) => {
+            ui::health_line(false, "Interface syfrah0 is down");
+            None
+        }
+    };
+    println!();
+
+    // ── Peers section ───────────────────────────────────────────────
+    let total = state.peers.len();
     let active = state
         .peers
         .iter()
@@ -99,49 +75,110 @@ pub async fn run() -> Result<()> {
         .iter()
         .filter(|p| p.status == syfrah_core::mesh::PeerStatus::Unreachable)
         .count();
-    println!();
-    println!(
-        "Peers:     {} total ({} active, {} unreachable)",
-        state.peers.len(),
-        active,
-        unreachable
-    );
 
-    let m = &state.metrics;
-    if m.daemon_started_at > 0 {
-        let uptime = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs()
-            .saturating_sub(m.daemon_started_at);
+    ui::box_top(&format!("Peers ({total})"));
+    ui::peer_line("\u{25cf}", active, "active");
+    if unreachable > 0 {
+        ui::peer_line("\u{2717}", unreachable, "unreachable");
+    }
+    ui::box_bottom();
+    println!();
+
+    // ── WireGuard info (if interface is up) ─────────────────────────
+    if let Some((true, ref summary)) = iface_up {
+        let with_handshake = summary
+            .peers
+            .iter()
+            .filter(|p| p.last_handshake.is_some())
+            .count();
+        let (rx, tx) = summary.peers.iter().fold((0u64, 0u64), |(rx, tx), p| {
+            (rx + p.rx_bytes, tx + p.tx_bytes)
+        });
+        let now_ts = std::time::SystemTime::now();
+        let healthy = summary
+            .peers
+            .iter()
+            .filter(|p| {
+                p.last_handshake
+                    .map(|h| now_ts.duration_since(h).unwrap_or_default().as_secs() < 180)
+                    .unwrap_or(false)
+            })
+            .count();
+
+        ui::box_top("WireGuard");
+        ui::box_line(&format!(
+            " Peers:     {} configured, {} with handshake",
+            summary.peer_count, with_handshake
+        ));
+        if summary.peer_count > 0 {
+            ui::box_line(&format!(
+                " Health:    {}/{} recent handshake (<3min)",
+                healthy, summary.peer_count
+            ));
+        }
+        ui::box_line(&format!(
+            " Traffic:   rx {} / tx {}",
+            fmt_bytes(rx),
+            fmt_bytes(tx)
+        ));
+        ui::box_bottom();
         println!();
-        println!("Metrics:");
-        println!("  Uptime:           {}", fmt_duration(uptime));
-        println!("  Peers discovered: {}", m.peers_discovered);
-        println!("  WG reconciles:    {}", m.wg_reconciliations);
-        println!("  Peers unreached:  {}", m.peers_marked_unreachable);
-        println!("  Announce fails:   {}", m.announcements_failed);
     }
 
-    let tuning = config::load_tuning().unwrap_or_default();
-    println!();
-    println!("Config:");
-    println!(
-        "  health_check_interval: {}s",
-        tuning.health_check_interval.as_secs()
-    );
-    println!(
-        "  reconcile_interval:    {}s",
-        tuning.reconcile_interval.as_secs()
-    );
-    println!(
-        "  persist_interval:      {}s",
-        tuning.persist_interval.as_secs()
-    );
-    println!(
-        "  unreachable_timeout:   {}s",
-        tuning.unreachable_timeout.as_secs()
-    );
+    // ── Network section ─────────────────────────────────────────────
+    let secret_display = if show_secret {
+        state.mesh_secret.clone()
+    } else {
+        format!(
+            "{} (use --show-secret)",
+            ui::mask_secret(&state.mesh_secret)
+        )
+    };
+
+    ui::box_top("Network");
+    ui::box_line(&format!(" WireGuard:  port {}", state.wg_listen_port));
+    ui::box_line(&format!(" Peering:    port {}", state.peering_port));
+    ui::box_line(&format!(" Mesh IPv6:  {}", state.mesh_ipv6));
+    ui::box_line(&format!(" Secret:     {secret_display}"));
+    ui::box_bottom();
+
+    // ── Verbose-only: Metrics and Config ────────────────────────────
+    if verbose {
+        let m = &state.metrics;
+        if m.daemon_started_at > 0 {
+            println!();
+            ui::box_top("Metrics");
+            ui::box_line(&format!(" Peers discovered:  {}", m.peers_discovered));
+            ui::box_line(&format!(" WG reconciles:     {}", m.wg_reconciliations));
+            ui::box_line(&format!(
+                " Peers unreached:   {}",
+                m.peers_marked_unreachable
+            ));
+            ui::box_line(&format!(" Announce fails:    {}", m.announcements_failed));
+            ui::box_bottom();
+        }
+
+        let tuning = config::load_tuning().unwrap_or_default();
+        println!();
+        ui::box_top("Config");
+        ui::box_line(&format!(
+            " health_check_interval:  {}s",
+            tuning.health_check_interval.as_secs()
+        ));
+        ui::box_line(&format!(
+            " reconcile_interval:     {}s",
+            tuning.reconcile_interval.as_secs()
+        ));
+        ui::box_line(&format!(
+            " persist_interval:       {}s",
+            tuning.persist_interval.as_secs()
+        ));
+        ui::box_line(&format!(
+            " unreachable_timeout:    {}s",
+            tuning.unreachable_timeout.as_secs()
+        ));
+        ui::box_bottom();
+    }
 
     Ok(())
 }
@@ -167,5 +204,26 @@ fn fmt_bytes(b: u64) -> String {
         format!("{:.1} MiB", b as f64 / (1024.0 * 1024.0))
     } else {
         format!("{:.1} GiB", b as f64 / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_duration_formats_correctly() {
+        assert_eq!(fmt_duration(30), "30s");
+        assert_eq!(fmt_duration(90), "1m 30s");
+        assert_eq!(fmt_duration(3661), "1h 1m");
+        assert_eq!(fmt_duration(90061), "1d 1h");
+    }
+
+    #[test]
+    fn fmt_bytes_formats_correctly() {
+        assert_eq!(fmt_bytes(512), "512 B");
+        assert_eq!(fmt_bytes(1536), "1.5 KiB");
+        assert_eq!(fmt_bytes(1_572_864), "1.5 MiB");
+        assert_eq!(fmt_bytes(1_610_612_736), "1.5 GiB");
     }
 }

--- a/layers/fabric/src/ui.rs
+++ b/layers/fabric/src/ui.rs
@@ -202,6 +202,103 @@ pub fn peering_banner(port: u16, pin: Option<&str>, continuous: bool) {
     }
 }
 
+// ── Box-drawing section helpers ──────────────────────────────────────
+
+const BOX_WIDTH: usize = 50;
+
+/// Print the top border of a titled box section.
+/// TTY: `╭─ Title ─────────╮`  Non-TTY: `--- Title ---`
+pub fn box_top(title: &str) {
+    if is_tty() {
+        let bold = Style::new().bold();
+        // "╭─ " = 4 display chars, " ─...╮" fills the rest
+        let inner = BOX_WIDTH - 2; // chars between ╭ and ╮
+        let prefix = format!("\u{2500} {} ", title);
+        let pad = inner.saturating_sub(prefix.len());
+        println!(
+            "\u{256d}{}{}\u{256e}",
+            bold.apply_to(&prefix),
+            "\u{2500}".repeat(pad)
+        );
+    } else {
+        println!("--- {} ---", title);
+    }
+}
+
+/// Print a line inside a box section.
+/// TTY: `│  content ...     │`  Non-TTY: `  content`
+pub fn box_line(content: &str) {
+    if is_tty() {
+        let inner = BOX_WIDTH - 2;
+        let pad = inner.saturating_sub(content.len() + 1);
+        println!("\u{2502} {}{}\u{2502}", content, " ".repeat(pad));
+    } else {
+        println!("  {content}");
+    }
+}
+
+/// Print the bottom border of a box section.
+/// TTY: `╰─────────────────╯`  Non-TTY: (nothing)
+pub fn box_bottom() {
+    if is_tty() {
+        let inner = BOX_WIDTH - 2;
+        println!("\u{2570}{}\u{256f}", "\u{2500}".repeat(inner));
+    }
+}
+
+/// Print a health status line (outside a box, prominent).
+/// `ok=true` -> green bullet, `ok=false` -> red cross.
+pub fn health_line(ok: bool, msg: &str) {
+    if is_tty() {
+        if ok {
+            let green = Style::new().green().bold();
+            println!("  {} {msg}", green.apply_to("\u{25cf}"));
+        } else {
+            let red = Style::new().red().bold();
+            println!("  {} {msg}", red.apply_to("\u{2717}"));
+        }
+    } else if ok {
+        println!("  [OK]   {msg}");
+    } else {
+        println!("  [FAIL] {msg}");
+    }
+}
+
+/// Print a colored peer count line inside a box.
+pub fn peer_line(symbol: &str, count: usize, label: &str) {
+    let text = format!("{symbol} {count} {label}");
+    if is_tty() {
+        let inner = BOX_WIDTH - 2;
+        let styled = if symbol == "\u{25cf}" {
+            let green = Style::new().green();
+            format!("{} {count} {label}", green.apply_to(symbol))
+        } else {
+            let red = Style::new().red();
+            format!("{} {count} {label}", red.apply_to(symbol))
+        };
+        // For padding, use the un-styled length
+        let pad = inner.saturating_sub(text.len() + 1);
+        println!("\u{2502} {}{}\u{2502}", styled, " ".repeat(pad));
+    } else {
+        println!("  {text}");
+    }
+}
+
+/// Mask a secret string, showing prefix and last 4 chars.
+/// `syf_sk_Gegx27CfeNjX...kvd1`
+pub fn mask_secret(secret: &str) -> String {
+    if secret.len() <= 12 {
+        return "****".to_string();
+    }
+    let prefix_end = if secret.starts_with("syf_sk_") { 7 } else { 4 };
+    let suffix_start = secret.len().saturating_sub(4);
+    format!(
+        "{}****...{}",
+        &secret[..prefix_end],
+        &secret[suffix_start..]
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +330,30 @@ mod tests {
     fn check_pass_fail_do_not_panic() {
         check_pass("something works");
         check_fail("something broke", "details here");
+    }
+
+    #[test]
+    fn mask_secret_hides_middle() {
+        let masked = mask_secret("syf_sk_Gegx27CfeNjXiK3ABQZQ1YBk7NpXCunu3eytQYsTkvd1");
+        assert!(masked.starts_with("syf_sk_"));
+        assert!(masked.ends_with("kvd1"));
+        assert!(masked.contains("****"));
+        assert!(!masked.contains("Gegx27"));
+    }
+
+    #[test]
+    fn mask_secret_short_input() {
+        assert_eq!(mask_secret("short"), "****");
+    }
+
+    #[test]
+    fn box_helpers_do_not_panic() {
+        box_top("Test");
+        box_line("content here");
+        box_bottom();
+        health_line(true, "all good");
+        health_line(false, "problem");
+        peer_line("\u{25cf}", 3, "active");
+        peer_line("\u{2717}", 1, "unreachable");
     }
 }

--- a/tests/e2e/scenarios/94_ux_status_output.sh
+++ b/tests/e2e/scenarios/94_ux_status_output.sh
@@ -16,15 +16,24 @@ start_node "e2e-ux-status-2" "172.20.0.11"
 init_mesh "e2e-ux-status-1" "172.20.0.10" "status-node"
 wait_daemon "e2e-ux-status-1" 30
 
-# Test 1: Status after init — shows key info
+# Test 1: Status after init — shows key info in sections
 info "Testing: status after init..."
 output=$(docker exec "e2e-ux-status-1" syfrah fabric status 2>&1)
 
 assert_output_contains "e2e-ux-status-1" "syfrah fabric status" "status-node"
 assert_output_matches "e2e-ux-status-1" "syfrah fabric status" "fd[0-9a-f]"
-assert_output_matches "e2e-ux-status-1" "syfrah fabric status" "running|active|Daemon|Mesh"
+assert_output_matches "e2e-ux-status-1" "syfrah fabric status" "Daemon"
 
-# Test 2: Status shows region and zone
+# Test 2: Non-TTY output uses plain text (piped, no box-drawing)
+info "Testing: non-TTY fallback..."
+output_piped=$(docker exec "e2e-ux-status-1" sh -c "syfrah fabric status 2>&1 | cat")
+if echo "$output_piped" | grep -q "^--- Mesh ---"; then
+    pass "non-TTY output uses plain text sections"
+else
+    fail "non-TTY output missing plain text section headers"
+fi
+
+# Test 3: Status shows region and zone
 info "Testing: status shows region/zone..."
 if echo "$output" | grep -qi "region\|zone"; then
     pass "status shows region/zone"
@@ -32,15 +41,46 @@ else
     fail "status missing region/zone"
 fi
 
-# Test 3: Status shows metrics
-info "Testing: status shows metrics..."
-if echo "$output" | grep -qi "peer\|uptime\|reconcil"; then
-    pass "status shows metrics"
+# Test 4: Secret is masked by default
+info "Testing: secret is masked by default..."
+if echo "$output_piped" | grep -q "syf_sk_.\{20,\}"; then
+    fail "secret is fully exposed in default output"
 else
-    fail "status missing metrics info"
+    pass "secret is masked by default"
+fi
+if echo "$output_piped" | grep -q "\-\-show-secret"; then
+    pass "output hints about --show-secret flag"
+else
+    fail "output missing --show-secret hint"
 fi
 
-# Test 4: Status daemon stopped
+# Test 5: --show-secret reveals full secret
+info "Testing: --show-secret reveals secret..."
+output_secret=$(docker exec "e2e-ux-status-1" sh -c "syfrah fabric status --show-secret 2>&1 | cat")
+if echo "$output_secret" | grep -q "syf_sk_.\{20,\}"; then
+    pass "--show-secret reveals full secret"
+else
+    fail "--show-secret did not reveal secret"
+fi
+
+# Test 6: --verbose shows config and metrics
+info "Testing: --verbose shows config/metrics..."
+output_verbose=$(docker exec "e2e-ux-status-1" sh -c "syfrah fabric status --verbose 2>&1 | cat")
+if echo "$output_verbose" | grep -qi "config\|reconcil"; then
+    pass "--verbose shows config section"
+else
+    fail "--verbose missing config section"
+fi
+
+# Test 7: Default output does NOT show config section
+info "Testing: default hides config..."
+if echo "$output_piped" | grep -qi "reconcile_interval"; then
+    fail "default output leaks config section"
+else
+    pass "config hidden in default output"
+fi
+
+# Test 8: Status daemon stopped
 info "Testing: status after stop..."
 stop_daemon "e2e-ux-status-1"
 sleep 2
@@ -58,7 +98,7 @@ else
     pass "status after stop: no raw errors"
 fi
 
-# Test 5: Status with no mesh — suggests init/join
+# Test 9: Status with no mesh — suggests init/join
 info "Testing: status with no mesh..."
 err=$(docker exec "e2e-ux-status-2" syfrah fabric status 2>&1 || true)
 if echo "$err" | grep -qi "init\|join"; then


### PR DESCRIPTION
## Summary

- Reorganize `syfrah fabric status` output into visual sections with box-drawing characters (Mesh, Peers, WireGuard, Network)
- Surface daemon/interface health status prominently at the top with colored indicators (green bullet for healthy, red cross for problems)
- Mask the mesh secret by default (`syf_sk_****...kvd1`), add `--show-secret` flag to reveal the full value
- Color-code peer counts: green for active, red for unreachable
- Move Config and Metrics sections behind `--verbose` flag to reduce noise in default output
- Plain text fallback for non-TTY environments (piped output, CI): no box-drawing, no ANSI colors, same information

## Test plan

- [x] `cargo fmt` -- no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [x] `cargo test` -- all 100 fabric unit tests pass (5 new), pre-existing `readonly_file_write_fails_clean` failure in syfrah-state (root env)
- [ ] E2E scenario `94_ux_status_output.sh` validates: section headers in non-TTY, secret masking, `--show-secret` reveal, `--verbose` config/metrics, default hides config, stopped state, no-mesh error message

Closes #176