### PR TITLE
Fix start command help text and add already-running check

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -96,7 +96,7 @@ enum FabricCommand {
         #[arg(long, short)]
         foreground: bool,
     },
-    /// Restart the daemon from saved state
+    /// Start the daemon from saved state
     Start {
         /// Run daemon in foreground instead of backgrounding
         #[arg(long, short)]
@@ -451,6 +451,14 @@ async fn run() -> Result<()> {
                 }
             }
             FabricCommand::Start { foreground } => {
+                if !foreground {
+                    if let Some(pid) = syfrah_fabric::store::daemon_running() {
+                        eprintln!(
+                            "Daemon is already running (pid {pid}). Use 'syfrah fabric stop' first."
+                        );
+                        std::process::exit(1);
+                    }
+                }
                 if foreground {
                     // Log to file when running as daemon (foreground or background)
                     setup_logging(true);


### PR DESCRIPTION
## Summary
- Fix `syfrah fabric start` help text: change "Restart" to "Start"
- Add an already-running guard before background daemon launch — if a daemon is already running, print `Daemon is already running (pid N). Use 'syfrah fabric stop' first.` and exit with code 1

## Test plan
- [x] `cargo fmt` — no changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test` — all passing (one pre-existing failure in `syfrah-state` unrelated to this change)
- [ ] Manual: run `syfrah fabric start` twice; second invocation should print the already-running message

Closes #191