### PR TITLE
Stop printing mesh secret during init

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -75,7 +75,7 @@ pub fn setup_init(config: &DaemonConfig) -> anyhow::Result<DaemonReady> {
     let mesh_prefix = derive_prefix_from_secret(&mesh_secret);
     let mesh_ipv6 = addressing::derive_node_address(&mesh_prefix, wg_keypair.public.as_bytes());
     let endpoint = resolve_endpoint(config);
-    ui::step_ok(&sp, &format!("Secret: {mesh_secret}"));
+    ui::step_ok(&sp, "Mesh secret generated (stored in state file)");
 
     let sp = ui::spinner("Setting up WireGuard interface...");
     wg::setup_interface(&wg_keypair, config.wg_listen_port, mesh_ipv6)?;


### PR DESCRIPTION
## Summary
- Remove secret from terminal output in `setup_init` (the `syfrah fabric init` path)
- The secret remains visible only during `auto_init` (the `syfrah fabric peering` path), where the operator needs it to share with joining nodes
- The secret is still persisted to `~/.syfrah/state.json` as before

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test -p syfrah-fabric` — all 12 tests pass

Closes #192