### PR TITLE
fix: wrap connection errors with actionable context

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1698,7 +1698,7 @@ mod tests {
 
     #[test]
     fn map_join_error_generic_io_includes_context() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "network down");
+        let io_err = std::io::Error::other("network down");
         let peering_err = crate::peering::PeeringError::Io(io_err);
         let target: SocketAddr = "203.0.113.1:51821".parse().unwrap();
         let mapped = map_join_error(peering_err, target);


### PR DESCRIPTION
## Summary
- Connection errors (refused, reset, generic I/O) during `syfrah fabric join` now show a clear message: *"Could not connect to host:port. Is the target node running with peering enabled?"* instead of a raw OS error.
- Added three new test cases for the new `map_join_error` arms (ConnectionRefused, ConnectionReset, generic I/O).

## Test plan
- [x] `cargo fmt && cargo clippy` clean
- [x] `cargo test -p syfrah-fabric` — 118 passed, 0 failed
- [x] New tests: `map_join_error_connection_refused_is_friendly`, `map_join_error_connection_reset_is_friendly`, `map_join_error_generic_io_includes_context`

Closes #196