### PR TITLE
Add getting-started hint after install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -214,3 +214,4 @@ fi
 # --- Done -------------------------------------------------------------------
 
 printf "\n%s v%s installed successfully.\n" "$BIN" "$EXPECTED_VERSION"
+printf "Run 'syfrah fabric init --name my-mesh' to get started.\n"


### PR DESCRIPTION
## Summary
- After a successful install, the script now prints: `Run 'syfrah fabric init --name my-mesh' to get started.`
- Gives new users an immediate next step without needing to check docs.

Closes #205