### PR TITLE
Add security warning to fabric token output

### DIFF
--- a/layers/fabric/src/cli/token.rs
+++ b/layers/fabric/src/cli/token.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 
 pub async fn run() -> Result<()> {
     let state = store::load().map_err(|_| no_mesh_error())?;
+    eprintln!("Warning: this is a sensitive credential. Do not share publicly.");
     println!("{}", state.mesh_secret);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Print a security warning to stderr before outputting the mesh secret token, so operators are reminded not to share it publicly.

Closes #211