### PR TITLE
fix: robust daemon stop with SIGKILL retry and D-state detection

### DIFF
--- a/bin/syfrah/src/update.rs
+++ b/bin/syfrah/src/update.rs
@@ -130,27 +130,68 @@ fn stop_daemon() -> Result<Option<usize>> {
         }
     }
 
-    // Escalate to SIGKILL if SIGTERM didn't work
+    // Escalate to SIGKILL if SIGTERM didn't work, with retries
     if syfrah_fabric::store::daemon_running().is_some() {
-        #[cfg(unix)]
-        unsafe {
-            libc::kill(pid_i32, libc::SIGKILL);
-        }
-        // Brief wait for SIGKILL to take effect
-        for _ in 0..20 {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            if syfrah_fabric::store::daemon_running().is_none() {
+        let mut killed = false;
+        for attempt in 0..3 {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid_i32, libc::SIGKILL);
+            }
+            // Wait up to 1s for SIGKILL to take effect
+            for _ in 0..10 {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+                if syfrah_fabric::store::daemon_running().is_none() {
+                    killed = true;
+                    break;
+                }
+            }
+            if killed {
                 break;
             }
-        }
-    }
 
-    if syfrah_fabric::store::daemon_running().is_some() {
-        ui::step_fail(&sp, &format!("Daemon (pid {pid}) did not stop in time"));
-        bail!(
-            "daemon did not stop within 12 seconds (SIGTERM + SIGKILL). \
-             Stop it manually with 'kill -9 {pid}' and re-run the update."
-        );
+            // Check process state to diagnose why SIGKILL didn't work
+            match syfrah_fabric::store::process_state(pid) {
+                Some('Z') => {
+                    // Zombie — reap it and we're done
+                    syfrah_fabric::store::try_reap(pid);
+                    syfrah_fabric::store::remove_pid();
+                    killed = true;
+                    break;
+                }
+                Some('D') => {
+                    ui::warn(&format!(
+                        "Daemon (pid {pid}) is in uninterruptible I/O (D state), \
+                         retry {}/3...",
+                        attempt + 1
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        if !killed && syfrah_fabric::store::daemon_running().is_some() {
+            // Check one last time for zombie or D state
+            match syfrah_fabric::store::process_state(pid) {
+                Some('Z') => {
+                    syfrah_fabric::store::try_reap(pid);
+                    syfrah_fabric::store::remove_pid();
+                }
+                Some('D') => {
+                    ui::warn(&format!(
+                        "Daemon (pid {pid}) stuck in uninterruptible I/O. \
+                         A reboot may be required to fully reclaim resources."
+                    ));
+                    ui::warn("Proceeding with update anyway — the old binary will be replaced.");
+                }
+                _ => {
+                    ui::warn(&format!(
+                        "Daemon (pid {pid}) did not stop after 3 SIGKILL attempts. \
+                         Proceeding with update anyway."
+                    ));
+                }
+            }
+        }
     }
 
     // Only remove PID if no new daemon has started in the meantime (TOCTOU guard).

--- a/layers/fabric/src/cli/stop.rs
+++ b/layers/fabric/src/cli/stop.rs
@@ -23,19 +23,77 @@ pub async fn run() -> Result<()> {
                 // Send SIGTERM
                 unsafe { libc::kill(pid as i32, libc::SIGTERM) };
             }
-            // Wait up to 10s for graceful shutdown, then escalate to SIGKILL
-            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-            if store::daemon_running().is_some() {
-                #[cfg(unix)]
-                {
-                    unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+            // Wait up to 10s for graceful shutdown, polling every 100ms
+            for _ in 0..100 {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                if store::daemon_running().is_none() {
+                    break;
                 }
-                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                if store::daemon_running().is_some() {
-                    ui::step_fail(
-                        &sp,
-                        &format!("Daemon still running after SIGKILL. Try 'kill -9 {pid}'."),
-                    );
+            }
+
+            // Escalate to SIGKILL if SIGTERM didn't work, with retries
+            if store::daemon_running().is_some() {
+                let mut killed = false;
+                for attempt in 0..3u8 {
+                    #[cfg(unix)]
+                    {
+                        unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+                    }
+                    for _ in 0..10 {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        if store::daemon_running().is_none() {
+                            killed = true;
+                            break;
+                        }
+                    }
+                    if killed {
+                        break;
+                    }
+
+                    match store::process_state(pid) {
+                        Some('Z') => {
+                            store::try_reap(pid);
+                            store::remove_pid();
+                            killed = true;
+                            break;
+                        }
+                        Some('D') => {
+                            ui::warn(&format!(
+                                "Daemon (pid {pid}) is in uninterruptible I/O (D state), \
+                                 retry {}/3...",
+                                attempt + 1
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
+
+                if !killed && store::daemon_running().is_some() {
+                    match store::process_state(pid) {
+                        Some('Z') => {
+                            store::try_reap(pid);
+                            store::remove_pid();
+                            ui::step_ok(&sp, "Daemon reaped (was zombie).");
+                        }
+                        Some('D') => {
+                            ui::step_fail(
+                                &sp,
+                                &format!(
+                                    "Daemon (pid {pid}) stuck in uninterruptible I/O. \
+                                     A reboot may be required."
+                                ),
+                            );
+                        }
+                        _ => {
+                            ui::step_fail(
+                                &sp,
+                                &format!(
+                                    "Daemon (pid {pid}) did not stop after 3 SIGKILL attempts. \
+                                     Try 'kill -9 {pid}'."
+                                ),
+                            );
+                        }
+                    }
                 } else {
                     store::remove_pid();
                     ui::step_ok(&sp, "Daemon killed (SIGKILL after 10s timeout).");

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -608,6 +608,36 @@ fn is_zombie(_pid: u32) -> bool {
     false
 }
 
+/// Read the single-letter process state from `/proc/{pid}/status`.
+/// Returns `Some('S')`, `Some('D')`, `Some('Z')`, etc., or `None` if unreadable.
+#[cfg(target_os = "linux")]
+pub fn process_state(pid: u32) -> Option<char> {
+    let contents = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    for line in contents.lines() {
+        if let Some(state) = line.strip_prefix("State:") {
+            return state.trim().chars().next();
+        }
+    }
+    None
+}
+
+/// Non-Linux stub — always returns `None`.
+#[cfg(not(target_os = "linux"))]
+pub fn process_state(_pid: u32) -> Option<char> {
+    None
+}
+
+/// Attempt to reap a zombie process via `waitpid`.
+#[cfg(unix)]
+pub fn try_reap(pid: u32) {
+    unsafe {
+        libc::waitpid(pid as i32, std::ptr::null_mut(), libc::WNOHANG);
+    }
+}
+
+#[cfg(not(unix))]
+pub fn try_reap(_pid: u32) {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- **SIGKILL retry**: After SIGTERM timeout, send SIGKILL up to 3 times with 1s between attempts instead of giving up after one try
- **Process state diagnosis**: Read `/proc/{pid}/status` after each failed SIGKILL to detect zombie (Z) or uninterruptible sleep (D) states
- **Zombie reap**: If process is zombie, call `waitpid` to reap it and proceed
- **D-state handling**: If process is stuck in uninterruptible I/O, warn the user that a reboot may be required
- **Update proceeds anyway**: In the update path, if the daemon cannot be stopped after all retries, proceed with the binary replacement rather than blocking the update
- **Consistent fix**: Applied the same logic to both `bin/syfrah/src/update.rs` (stop_daemon) and `layers/fabric/src/cli/stop.rs` (fabric stop)

## Test plan

- [ ] Verify `cargo test` passes (pre-existing `readonly_file_write_fails_clean` failure in syfrah-state is unrelated)
- [ ] `cargo clippy` clean
- [ ] Test `syfrah update` with a running daemon — should stop within timeout
- [ ] Test `syfrah fabric stop` with a running daemon — same improved behavior
- [ ] Simulate zombie process to verify reap path
- [ ] Simulate D-state process to verify warning message

Closes #256