### PR TITLE
fix: input validation for ports, names, and overflow guards

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -90,6 +90,9 @@ enum FabricCommand {
         port: u16,
         #[arg(long)]
         endpoint: Option<SocketAddr>,
+        /// Port for the peering protocol [default: WireGuard port + 1]
+        #[arg(long)]
+        peering_port: Option<u16>,
         /// PIN for auto-accept (skip manual approval)
         #[arg(long)]
         pin: Option<String>,
@@ -213,6 +216,54 @@ enum ServiceAction {
     Uninstall,
     /// Show systemd service status
     Status,
+}
+
+/// Maximum allowed length for mesh and node names.
+const MAX_NAME_LEN: usize = 64;
+
+/// Validate port configuration for fabric init/join.
+fn validate_ports(port: u16, peering_port: Option<u16>) -> Result<u16> {
+    // Port overflow: default peering port is port + 1, which overflows at 65535
+    let resolved = match peering_port {
+        Some(pp) => pp,
+        None => {
+            if port == 65535 {
+                anyhow::bail!(
+                    "Port 65535 cannot use default peering port (65536 overflows). \
+                     Set --peering-port explicitly."
+                );
+            }
+            port + 1
+        }
+    };
+
+    // Port conflict: both ports must differ
+    if resolved == port {
+        anyhow::bail!("--peering-port must differ from --port (both are {port})");
+    }
+
+    // Privileged port warning (non-blocking)
+    if port < 1024 {
+        eprintln!("Warning: port {port} is privileged (< 1024). The daemon must run as root.");
+    }
+    if resolved < 1024 {
+        eprintln!(
+            "Warning: peering port {resolved} is privileged (< 1024). The daemon must run as root."
+        );
+    }
+
+    Ok(resolved)
+}
+
+/// Validate name length for mesh and node names.
+fn validate_name(label: &str, value: &str) -> Result<()> {
+    if value.len() > MAX_NAME_LEN {
+        anyhow::bail!(
+            "{label} must be {MAX_NAME_LEN} characters or fewer (got {})",
+            value.len()
+        );
+    }
+    Ok(())
 }
 
 fn default_node_name() -> String {
@@ -428,10 +479,13 @@ async fn run() -> Result<()> {
                 foreground,
                 peering,
             } => {
-                let peering_port = peering_port.unwrap_or(port + 1);
+                validate_name("Mesh name", &name)?;
+                let resolved_node = node_name.unwrap_or_else(default_node_name);
+                validate_name("Node name", &resolved_node)?;
+                let peering_port = validate_ports(port, peering_port)?;
                 let config = DaemonConfig {
                     mesh_name: name,
-                    node_name: node_name.unwrap_or_else(default_node_name),
+                    node_name: resolved_node,
                     wg_listen_port: port,
                     public_endpoint: endpoint,
                     peering_port,
@@ -456,17 +510,21 @@ async fn run() -> Result<()> {
                 node_name,
                 port,
                 endpoint,
+                peering_port,
                 pin,
                 region,
                 zone,
                 foreground,
             } => {
+                let resolved_node = node_name.unwrap_or_else(default_node_name);
+                validate_name("Node name", &resolved_node)?;
+                let peering_port = validate_ports(port, peering_port)?;
                 let config = DaemonConfig {
                     mesh_name: String::new(),
-                    node_name: node_name.unwrap_or_else(default_node_name),
+                    node_name: resolved_node,
                     wg_listen_port: port,
                     public_endpoint: endpoint,
-                    peering_port: port + 1,
+                    peering_port,
                     region,
                     zone,
                 };
@@ -593,5 +651,75 @@ async fn run() -> Result<()> {
                 update::run(no_restart, force)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── validate_ports ───────────────────────────────────────────
+
+    #[test]
+    fn valid_default_peering_port() {
+        let pp = validate_ports(51820, None).unwrap();
+        assert_eq!(pp, 51821);
+    }
+
+    #[test]
+    fn valid_explicit_peering_port() {
+        let pp = validate_ports(51820, Some(9000)).unwrap();
+        assert_eq!(pp, 9000);
+    }
+
+    #[test]
+    fn port_overflow_rejected() {
+        let err = validate_ports(65535, None).unwrap_err();
+        assert!(
+            err.to_string().contains("65536 overflows"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn port_65535_with_explicit_peering_ok() {
+        let pp = validate_ports(65535, Some(65534)).unwrap();
+        assert_eq!(pp, 65534);
+    }
+
+    #[test]
+    fn same_port_rejected() {
+        let err = validate_ports(8080, Some(8080)).unwrap_err();
+        assert!(err.to_string().contains("must differ"), "unexpected: {err}");
+    }
+
+    // ── validate_name ────────────────────────────────────────────
+
+    #[test]
+    fn short_name_ok() {
+        assert!(validate_name("Mesh name", "my-mesh").is_ok());
+    }
+
+    #[test]
+    fn exactly_64_chars_ok() {
+        let name = "a".repeat(64);
+        assert!(validate_name("Mesh name", &name).is_ok());
+    }
+
+    #[test]
+    fn name_65_chars_rejected() {
+        let name = "a".repeat(65);
+        let err = validate_name("Mesh name", &name).unwrap_err();
+        assert!(
+            err.to_string().contains("64 characters or fewer"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn node_name_too_long_rejected() {
+        let name = "x".repeat(100);
+        let err = validate_name("Node name", &name).unwrap_err();
+        assert!(err.to_string().contains("Node name"), "unexpected: {err}");
     }
 }


### PR DESCRIPTION
## Summary

- **Port overflow guard**: `--port 65535` without explicit `--peering-port` is now rejected upfront instead of panicking at `port + 1` overflow
- **Port conflict check**: `--peering-port` equal to `--port` is rejected with a clear message
- **Privileged port warning**: ports below 1024 emit a non-blocking warning
- **Name length limits**: mesh and node names are capped at 64 characters
- **Join parity**: added `--peering-port` flag to `fabric join` (previously only on `fabric init`)
- 8 unit tests covering all validation paths

## Test plan

- [x] `cargo test -p syfrah-bin` — all 23 tests pass (8 new)
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green

Closes #265