### PR TITLE
Add local E2E test runner (no Docker rebuild)

### DIFF
--- a/dev/e2e.sh
+++ b/dev/e2e.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run E2E tests locally using a volume-mounted binary instead of baking it
+# into the Docker image. This avoids the ~3 min Docker rebuild on each code
+# change — just `cargo build` and re-run.
+#
+# Usage:
+#   ./dev/e2e.sh                     # run all scenarios
+#   ./dev/e2e.sh fabric              # run only fabric scenarios
+#   ./dev/e2e.sh 01_fabric           # run scenarios matching "01_fabric"
+#   ./dev/e2e.sh --help              # show this help
+#
+# Workflow:
+#   cargo build --release --target x86_64-unknown-linux-musl && ./dev/e2e.sh fabric
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Colors ────────────────────────────────────────────────────
+
+BOLD='\033[1m'
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# ── Help ──────────────────────────────────────────────────────
+
+show_help() {
+    cat <<'EOF'
+dev/e2e.sh — Run E2E integration tests locally (no Docker rebuild)
+
+USAGE
+  ./dev/e2e.sh [FILTER]       Run scenarios (optionally filtered by name)
+  ./dev/e2e.sh --help         Show this help
+
+FILTER EXAMPLES
+  ./dev/e2e.sh                Run all scenarios
+  ./dev/e2e.sh fabric         Run all *fabric* scenarios
+  ./dev/e2e.sh 01_fabric      Run scenario 01_fabric_mesh_formation
+  ./dev/e2e.sh ux             Run all *ux* scenarios
+  ./dev/e2e.sh state          Run all *state* scenarios
+
+HOW IT WORKS
+  1. Builds a lightweight Docker image (no Rust compilation)
+  2. Sets E2E_BINARY_MOUNT so lib.sh volume-mounts the local binary
+  3. Delegates to tests/e2e/run.sh with SKIP_BUILD=1
+
+PREREQUISITES
+  - Docker
+  - WireGuard kernel module (sudo modprobe wireguard)
+  - A compiled syfrah binary (static musl build):
+      cargo build --release --target x86_64-unknown-linux-musl
+
+    Or for faster debug builds:
+      cargo build --target x86_64-unknown-linux-musl
+
+ENVIRONMENT VARIABLES
+  E2E_BINARY   Override path to the syfrah binary
+                Default: target/x86_64-unknown-linux-musl/release/syfrah
+                Fallback: target/x86_64-unknown-linux-musl/debug/syfrah
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    show_help
+    exit 0
+fi
+
+# ── Cleanup on Ctrl+C ────────────────────────────────────────
+
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Interrupted — cleaning up containers...${NC}"
+    # Let run.sh's own cleanup handle containers; just remove the network
+    docker network rm syfrah-e2e >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ── Locate binary ────────────────────────────────────────────
+
+if [ -n "${E2E_BINARY:-}" ]; then
+    BINARY="$E2E_BINARY"
+elif [ -f "$REPO_ROOT/target/x86_64-unknown-linux-musl/release/syfrah" ]; then
+    BINARY="$REPO_ROOT/target/x86_64-unknown-linux-musl/release/syfrah"
+elif [ -f "$REPO_ROOT/target/x86_64-unknown-linux-musl/debug/syfrah" ]; then
+    BINARY="$REPO_ROOT/target/x86_64-unknown-linux-musl/debug/syfrah"
+else
+    echo -e "${RED}ERROR: No syfrah binary found.${NC}"
+    echo ""
+    echo "Build it first:"
+    echo "  cargo build --release --target x86_64-unknown-linux-musl"
+    echo ""
+    echo "Or set E2E_BINARY to point to an existing binary."
+    exit 1
+fi
+
+# Verify it's a static binary (musl) — the E2E containers are minimal
+if file "$BINARY" | grep -q "dynamically linked"; then
+    echo -e "${YELLOW}WARNING: Binary appears to be dynamically linked.${NC}"
+    echo "E2E containers may not have the required shared libraries."
+    echo "Consider building with: cargo build --release --target x86_64-unknown-linux-musl"
+    echo ""
+fi
+
+BINARY="$(cd "$(dirname "$BINARY")" && pwd)/$(basename "$BINARY")"
+
+# ── Build lightweight E2E image (no compilation) ─────────────
+
+echo -e "${BOLD}==========================================${NC}"
+echo -e "${BOLD}  Syfrah E2E Tests (LOCAL mode)${NC}"
+echo -e "${BOLD}==========================================${NC}"
+echo ""
+echo -e "  Binary: ${GREEN}${BINARY}${NC}"
+echo -e "  Mode:   ${GREEN}LOCAL${NC} (volume-mounted, no Docker rebuild)"
+echo ""
+
+echo -e "${YELLOW}-> Building lightweight E2E base image...${NC}"
+
+# Build a minimal image without the syfrah binary baked in.
+# The binary will be volume-mounted at runtime by lib.sh.
+docker build -t syfrah-e2e-test -f - "$REPO_ROOT" --quiet <<'DOCKERFILE'
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y \
+    wireguard-tools \
+    iproute2 \
+    iputils-ping \
+    procps \
+    iptables \
+    jq \
+    ncat \
+    tini \
+    && rm -rf /var/lib/apt/lists/*
+CMD ["sleep", "infinity"]
+DOCKERFILE
+
+echo ""
+
+# ── Run E2E via the standard runner ──────────────────────────
+
+export E2E_BINARY_MOUNT="$BINARY"
+export SKIP_BUILD=1
+
+exec "$REPO_ROOT/tests/e2e/run.sh" "${1:-}"

--- a/handbook/local-dev.md
+++ b/handbook/local-dev.md
@@ -103,6 +103,59 @@ Ensure Docker daemon has IPv6 enabled. Check `/etc/docker/daemon.json`:
 }
 ```
 
+## Running E2E Tests Locally
+
+The CI E2E suite (`tests/e2e/run.sh`) rebuilds a full Docker image on every run (~3 min), which makes local iteration slow. `dev/e2e.sh` solves this by volume-mounting a locally-compiled binary into lightweight containers.
+
+### Quick start
+
+```bash
+# 1. Build a static binary (musl, needed for the minimal containers)
+cargo build --release --target x86_64-unknown-linux-musl
+
+# 2. Run all E2E scenarios
+./dev/e2e.sh
+
+# 3. Run a specific group
+./dev/e2e.sh fabric
+
+# 4. Run a single scenario
+./dev/e2e.sh 01_fabric
+```
+
+Or via just:
+
+```bash
+just e2e-local
+just e2e-local fabric
+just e2e-local 01_fabric
+```
+
+### How it works
+
+1. `dev/e2e.sh` builds a lightweight Docker image (debian + wireguard-tools, no Rust compilation)
+2. It sets `E2E_BINARY_MOUNT` pointing to the local static binary
+3. `tests/e2e/lib.sh` `start_node()` detects the env var and adds a `-v` flag to volume-mount the binary into each container
+4. Delegates to the standard `tests/e2e/run.sh` with `SKIP_BUILD=1`
+
+CI is unchanged — when `E2E_BINARY_MOUNT` is not set, `start_node()` uses the baked-in binary as before.
+
+### Iteration workflow
+
+```
+edit code -> cargo build --release --target x86_64-unknown-linux-musl -> ./dev/e2e.sh fabric -> repeat
+```
+
+The first run builds the base Docker image (~10s). Subsequent runs skip this if the image is cached, so the cycle is: compile + run scenarios.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `E2E_BINARY` | (auto-detected) | Override path to the syfrah binary |
+| `E2E_BINARY_MOUNT` | (set by e2e.sh) | Used by lib.sh to volume-mount the binary |
+| `SKIP_BUILD` | (set by e2e.sh) | Tells run.sh to skip the Docker image build |
+
 ## Files
 
 ```
@@ -110,4 +163,5 @@ dev/
   Dockerfile           # Minimal image: debian + wireguard-tools + iproute2
   docker-compose.yml   # 2 nodes, bridge network, volume mount
   dev.sh               # Helper script for the full workflow
+  e2e.sh               # Run E2E tests locally with volume-mounted binary
 ```

--- a/handbook/testing.md
+++ b/handbook/testing.md
@@ -286,15 +286,23 @@ just test
 # Unit tests for one layer
 cargo test -p syfrah-fabric
 
-# E2E tests (requires Docker)
+# E2E tests — full Docker rebuild (same as CI)
 just e2e
 
-# Run a specific E2E scenario
+# E2E tests — local mode (volume-mounted binary, no rebuild)
+cargo build --release --target x86_64-unknown-linux-musl
+just e2e-local              # all scenarios
+just e2e-local fabric       # only fabric scenarios
+just e2e-local 01_fabric    # single scenario
+
+# Run a specific E2E scenario (CI mode)
 ./tests/e2e/run.sh 01_mesh
 
 # Everything (unit + E2E)
 just ci && just e2e
 ```
+
+The `just e2e-local` command uses `dev/e2e.sh`, which volume-mounts a locally-compiled static binary into lightweight containers. This avoids the ~3 min Docker image rebuild, making the edit-build-test cycle much faster. See `handbook/local-dev.md` for details.
 
 ## What we test at each layer
 

--- a/justfile
+++ b/justfile
@@ -36,9 +36,13 @@ audit:
 run *ARGS:
     cargo run --bin syfrah -- {{ARGS}}
 
-# Run all E2E tests (requires Docker)
+# Run all E2E tests (requires Docker, rebuilds image from scratch)
 e2e:
     ./tests/e2e/run.sh
+
+# Run E2E tests locally with volume-mounted binary (no Docker rebuild)
+e2e-local FILTER="":
+    ./dev/e2e.sh {{FILTER}}
 
 # Run E2E tests for a specific layer
 e2e-layer LAYER:

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -49,13 +49,20 @@ remove_network() {
 # ── Containers ────────────────────────────────────────────────
 
 # Start a container. Args: <name> <ip>
+# When E2E_BINARY_MOUNT is set, the local binary is volume-mounted into the
+# container instead of using the one baked into the Docker image.
 start_node() {
     local name="$1"
     local ip="$2"
 
     docker rm -f "$name" >/dev/null 2>&1 || true
 
-    debug "starting container $name at $ip"
+    local volume_args=()
+    if [ -n "${E2E_BINARY_MOUNT:-}" ]; then
+        volume_args=(-v "${E2E_BINARY_MOUNT}:/usr/local/bin/syfrah:ro")
+    fi
+
+    debug "starting container $name at $ip${E2E_BINARY_MOUNT:+ (local binary)}"
     docker run -d \
         --name "$name" \
         --network "$E2E_NETWORK" \
@@ -63,6 +70,7 @@ start_node() {
         --privileged \
         --hostname "$name" \
         --init \
+        "${volume_args[@]+"${volume_args[@]}"}" \
         "$E2E_IMAGE" >/dev/null
 
     E2E_CONTAINERS+=("$name")


### PR DESCRIPTION
## Summary

- Adds `dev/e2e.sh` — runs E2E scenarios using a volume-mounted local binary instead of rebuilding the Docker image (~3 min saved per iteration)
- Modifies `tests/e2e/lib.sh` `start_node()` to accept `E2E_BINARY_MOUNT` env var for volume-mounting the binary into containers
- Adds `just e2e-local [FILTER]` command to the justfile
- Documents the local E2E workflow in `handbook/local-dev.md` and `handbook/testing.md`

**Workflow:** `cargo build --release --target x86_64-unknown-linux-musl && ./dev/e2e.sh fabric`

CI is unchanged — when `E2E_BINARY_MOUNT` is not set, `start_node()` behaves exactly as before.

## Test plan

- [ ] Run `./dev/e2e.sh 01_fabric` locally and verify the scenario passes with volume-mounted binary
- [ ] Run `just e2e-local fabric` and verify it delegates correctly
- [ ] Run `./dev/e2e.sh --help` and verify usage is shown
- [ ] Verify CI E2E tests still pass (no env var = baked binary, no behavior change)
- [ ] Run `./dev/e2e.sh` without a compiled binary and verify it shows a clear error message

Closes #270