### PR TITLE
fix: prevent phantom peers and invalid endpoints from breaking mesh

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -789,6 +789,51 @@ pub async fn run_daemon(
         let plr = accepted_peer_limit_counter.clone();
         let sf = accepted_store_failures.clone();
         tokio::spawn(async move {
+            // Purge stale peers with the same node name but different WG key.
+            // This prevents phantom peer accumulation from repeated init/join
+            // cycles of the same node (issue #285).
+            match store::purge_stale_peers_by_name(&record.name, &record.wg_public_key) {
+                Ok(0) => {}
+                Ok(n) => {
+                    info!(
+                        peer = %sanitize(&record.name),
+                        purged = n,
+                        "purged stale peer records with same node name"
+                    );
+                }
+                Err(e) => {
+                    warn!(error = %e, "on_accepted: failed to purge stale peers");
+                }
+            }
+
+            // Reject peers whose endpoint is 0.0.0.0 — WireGuard cannot
+            // send packets to an unspecified address (issue #285).
+            if record.endpoint.ip().is_unspecified() {
+                warn!(
+                    peer = %sanitize(&record.name),
+                    endpoint = %record.endpoint,
+                    "on_accepted: rejecting peer with unspecified (0.0.0.0) endpoint"
+                );
+                return;
+            }
+
+            // Reject peers whose endpoint matches our own public IP —
+            // a node sending WG packets to itself causes Invalid MAC
+            // loops and disrupts the mesh (issue #285).
+            if let Ok(state) = store::load() {
+                if let Some(my_endpoint) = state.public_endpoint {
+                    if record.endpoint.ip() == my_endpoint.ip() {
+                        warn!(
+                            peer = %sanitize(&record.name),
+                            endpoint = %record.endpoint,
+                            my_ip = %my_endpoint.ip(),
+                            "on_accepted: rejecting peer with self-referencing endpoint"
+                        );
+                        return;
+                    }
+                }
+            }
+
             // Check store peer count + existence in a single read transaction (fail closed: skip on error).
             // The store is the source of truth for the peer limit — not the WG kernel
             // interface — because the store is always reachable (no root required for reads)
@@ -925,6 +970,7 @@ pub async fn run_daemon(
     let announce_enc_key = enc_key;
     let announce_peering_port = peering_port;
     let announce_tls_client = tls_client_config.clone();
+    let my_endpoint_for_announce = my_record.endpoint;
     let on_announce: Arc<dyn Fn(PeerRecord) + Send + Sync> = Arc::new(move |record| {
         announce_recv.fetch_add(1, Ordering::Relaxed);
         events::emit(
@@ -934,6 +980,30 @@ pub async fn run_daemon(
             Some(&format!("mesh_ipv6={}", record.mesh_ipv6)),
             Some(announce_max_events),
         );
+
+        // Reject announced peers with 0.0.0.0 endpoint — WireGuard cannot
+        // route packets to an unspecified address (issue #285).
+        if record.endpoint.ip().is_unspecified() {
+            warn!(
+                peer = %sanitize(&record.name),
+                endpoint = %record.endpoint,
+                "on_announce: dropping peer with unspecified (0.0.0.0) endpoint"
+            );
+            return;
+        }
+
+        // Reject announced peers whose endpoint matches our own public IP.
+        // A node sending WG packets to itself causes Invalid MAC loops (issue #285).
+        if !my_endpoint_for_announce.ip().is_unspecified()
+            && record.endpoint.ip() == my_endpoint_for_announce.ip()
+        {
+            warn!(
+                peer = %sanitize(&record.name),
+                endpoint = %record.endpoint,
+                "on_announce: dropping peer with self-referencing endpoint"
+            );
+            return;
+        }
 
         // Bound concurrent announce processing with a semaphore.
         // When the semaphore is full, queue the announce for retry instead of dropping it.
@@ -1377,6 +1447,39 @@ pub async fn run_daemon(
                     continue;
                 }
             };
+
+            // Fix 0.0.0.0 endpoints: if a stored peer has an unspecified endpoint
+            // but WireGuard has learned a real endpoint via roaming, update the
+            // store so the correct endpoint is propagated (issue #285).
+            if let Ok(summary) = wg::interface_summary() {
+                for peer in &stored_peers {
+                    if peer.endpoint.ip().is_unspecified() {
+                        if let Some(wg_peer) = summary
+                            .peers
+                            .iter()
+                            .find(|wp| wp.public_key == peer.wg_public_key)
+                        {
+                            if let Some(real_endpoint) = wg_peer.endpoint {
+                                if !real_endpoint.ip().is_unspecified()
+                                    && !real_endpoint.ip().is_loopback()
+                                {
+                                    info!(
+                                        peer = %sanitize(&peer.name),
+                                        old_endpoint = %peer.endpoint,
+                                        new_endpoint = %real_endpoint,
+                                        "correcting 0.0.0.0 endpoint from WG roaming data"
+                                    );
+                                    let _ = store::update_peer_endpoint(
+                                        &peer.wg_public_key,
+                                        real_endpoint,
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             // Diff-based reconciliation: only touch peers that actually changed.
             // This avoids tearing down existing WireGuard sessions.
             // sync_peers handles diff, add/update, removal + route cleanup.
@@ -2504,5 +2607,59 @@ mod tests {
             assert_eq!(segs[6], 0, "segment 6 non-zero for secret [{};32]", i * 50);
             assert_eq!(segs[7], 0, "segment 7 non-zero for secret [{};32]", i * 50);
         }
+    }
+
+    // ── Phantom peer / endpoint validation tests (issue #285) ──
+
+    #[test]
+    fn resolve_endpoint_returns_unspecified_when_no_public_endpoint() {
+        let config = DaemonConfig {
+            mesh_name: "test".into(),
+            node_name: "node".into(),
+            wg_listen_port: 51820,
+            public_endpoint: None,
+            peering_port: 7946,
+            region: None,
+            zone: None,
+        };
+        let ep = resolve_endpoint(&config);
+        assert!(
+            ep.ip().is_unspecified(),
+            "with no --endpoint, resolve_endpoint should return 0.0.0.0"
+        );
+    }
+
+    #[test]
+    fn unspecified_endpoint_is_detectable() {
+        // Verify that our is_unspecified() check works as expected
+        // for both IPv4 and IPv6 unspecified addresses.
+        let v4_zero: SocketAddr = "0.0.0.0:51820".parse().unwrap();
+        assert!(v4_zero.ip().is_unspecified());
+
+        let v6_zero: SocketAddr = "[::]:51820".parse().unwrap();
+        assert!(v6_zero.ip().is_unspecified());
+
+        let real: SocketAddr = "65.21.178.96:51820".parse().unwrap();
+        assert!(!real.ip().is_unspecified());
+    }
+
+    #[test]
+    fn self_endpoint_detection() {
+        // Verify that we can detect when a peer's endpoint matches
+        // the local node's own public IP.
+        let my_endpoint: SocketAddr = "65.21.178.96:51820".parse().unwrap();
+        let peer_endpoint: SocketAddr = "65.21.178.96:51820".parse().unwrap();
+        let other_endpoint: SocketAddr = "65.21.140.60:51820".parse().unwrap();
+
+        assert_eq!(
+            peer_endpoint.ip(),
+            my_endpoint.ip(),
+            "peer with same IP as self should be detected"
+        );
+        assert_ne!(
+            other_endpoint.ip(),
+            my_endpoint.ip(),
+            "peer with different IP should not be flagged"
+        );
     }
 }

--- a/layers/fabric/src/peering.rs
+++ b/layers/fabric/src/peering.rs
@@ -591,6 +591,28 @@ async fn handle_incoming<S: AsyncRead + AsyncWrite + Unpin>(
                 );
             }
 
+            // Reject if endpoint is still unspecified after auto-detection.
+            // WireGuard cannot send packets to 0.0.0.0 — this would cause
+            // silent packet loss (see issue #285).
+            if req.endpoint.ip().is_unspecified() {
+                warn!(
+                    node = %sanitize(&req.node_name),
+                    endpoint = %req.endpoint,
+                    "rejecting join: endpoint is 0.0.0.0 after auto-detection"
+                );
+                let rejection = JoinResponse {
+                    accepted: false,
+                    mesh_name: None,
+                    mesh_secret: None,
+                    mesh_prefix: None,
+                    peers: vec![],
+                    reason: Some("could not detect public IP; use --endpoint to specify it".into()),
+                    approved_by: None,
+                };
+                write_message(&mut stream, &PeeringMessage::JoinResponse(rejection)).await?;
+                return Ok(());
+            }
+
             info!(
                 node = %sanitize(&req.node_name),
                 endpoint = %req.endpoint,

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -368,6 +368,34 @@ pub fn peer_count_and_exists(wg_public_key: &str) -> Result<(usize, bool), Store
     Ok((count as usize, exists))
 }
 
+/// Mark all peers with the given node name as Removed, except the one with
+/// `except_wg_key`. Returns the number of peers marked as Removed.
+///
+/// This is used during join/init to purge phantom peers left by previous
+/// init/join cycles of the same node name with different WG keys.
+pub fn purge_stale_peers_by_name(name: &str, except_wg_key: &str) -> Result<usize, StoreError> {
+    if !LayerDb::layer_exists(LAYER_NAME) {
+        return Ok(0);
+    }
+    let db = open_db()?;
+    let entries: Vec<(String, PeerRecord)> = db.list("peers")?;
+    let mut purged = 0;
+    for (key, mut peer) in entries {
+        if peer.name == name
+            && peer.wg_public_key != except_wg_key
+            && peer.status != syfrah_core::mesh::PeerStatus::Removed
+        {
+            peer.status = syfrah_core::mesh::PeerStatus::Removed;
+            db.set("peers", &key, &peer)?;
+            purged += 1;
+        }
+    }
+    if purged > 0 {
+        maybe_write_json(&db);
+    }
+    Ok(purged)
+}
+
 /// Mark a peer as Removed by name or WG public key.
 /// Returns the updated PeerRecord if found, or None if no matching peer exists.
 pub fn remove_peer(name_or_key: &str) -> Result<Option<PeerRecord>, StoreError> {
@@ -839,5 +867,99 @@ mod tests {
         assert_eq!(loaded.mesh_name, "test");
         assert_eq!(loaded.node_name, "node-1");
         assert_eq!(loaded.mesh_ipv6, state.mesh_ipv6);
+    }
+
+    // ── purge_stale_peers_by_name tests ──
+
+    #[test]
+    fn purge_stale_peers_marks_old_keys_as_removed() {
+        let (_dir, db) = temp_db();
+
+        // Simulate 3 peer records with the same node name but different keys
+        // (from repeated init/join cycles).
+        let mut p1 = make_peer("old-key-1");
+        p1.name = "node-a".into();
+        let mut p2 = make_peer("old-key-2");
+        p2.name = "node-a".into();
+        let mut p3 = make_peer("current-key");
+        p3.name = "node-a".into();
+        // A different node that should not be purged
+        let mut p4 = make_peer("other-node-key");
+        p4.name = "node-b".into();
+
+        db.set("peers", &p1.wg_public_key, &p1).unwrap();
+        db.set("peers", &p2.wg_public_key, &p2).unwrap();
+        db.set("peers", &p3.wg_public_key, &p3).unwrap();
+        db.set("peers", &p4.wg_public_key, &p4).unwrap();
+
+        // Purge stale peers for node-a, keeping current-key
+        let entries: Vec<(String, PeerRecord)> = db.list("peers").unwrap();
+        let mut purged = 0;
+        for (key, mut peer) in entries {
+            if peer.name == "node-a"
+                && peer.wg_public_key != "current-key"
+                && peer.status != PeerStatus::Removed
+            {
+                peer.status = PeerStatus::Removed;
+                db.set("peers", &key, &peer).unwrap();
+                purged += 1;
+            }
+        }
+
+        assert_eq!(purged, 2);
+
+        // Verify: old keys are Removed, current key is Active, other node untouched
+        let p1_loaded: PeerRecord = db.get("peers", "old-key-1").unwrap().unwrap();
+        assert_eq!(p1_loaded.status, PeerStatus::Removed);
+        let p2_loaded: PeerRecord = db.get("peers", "old-key-2").unwrap().unwrap();
+        assert_eq!(p2_loaded.status, PeerStatus::Removed);
+        let p3_loaded: PeerRecord = db.get("peers", "current-key").unwrap().unwrap();
+        assert_eq!(p3_loaded.status, PeerStatus::Active);
+        let p4_loaded: PeerRecord = db.get("peers", "other-node-key").unwrap().unwrap();
+        assert_eq!(p4_loaded.status, PeerStatus::Active);
+    }
+
+    #[test]
+    fn purge_stale_peers_no_stale_entries() {
+        let (_dir, db) = temp_db();
+
+        let mut p1 = make_peer("key-1");
+        p1.name = "node-a".into();
+        db.set("peers", &p1.wg_public_key, &p1).unwrap();
+
+        // Purge with the only key — nothing should be purged
+        let entries: Vec<(String, PeerRecord)> = db.list("peers").unwrap();
+        let purged = entries
+            .into_iter()
+            .filter(|(_, p)| {
+                p.name == "node-a" && p.wg_public_key != "key-1" && p.status != PeerStatus::Removed
+            })
+            .count();
+        assert_eq!(purged, 0);
+    }
+
+    #[test]
+    fn purge_stale_peers_skips_already_removed() {
+        let (_dir, db) = temp_db();
+
+        let mut p1 = make_peer("old-key");
+        p1.name = "node-a".into();
+        p1.status = PeerStatus::Removed; // already removed
+        let mut p2 = make_peer("current-key");
+        p2.name = "node-a".into();
+
+        db.set("peers", &p1.wg_public_key, &p1).unwrap();
+        db.set("peers", &p2.wg_public_key, &p2).unwrap();
+
+        let entries: Vec<(String, PeerRecord)> = db.list("peers").unwrap();
+        let purged = entries
+            .into_iter()
+            .filter(|(_, p)| {
+                p.name == "node-a"
+                    && p.wg_public_key != "current-key"
+                    && p.status != PeerStatus::Removed
+            })
+            .count();
+        assert_eq!(purged, 0, "already-removed peers should not be counted");
     }
 }

--- a/layers/fabric/src/wg.rs
+++ b/layers/fabric/src/wg.rs
@@ -194,8 +194,14 @@ pub fn diff_peers(
 
         match wg_map.get(peer.wg_public_key.as_str()) {
             Some(existing_ips) if existing_ips.contains(desired_aip.as_str()) => {
-                // Peer exists with correct allowed IPs — no change needed.
-                // Endpoint may differ due to WG roaming; that's fine.
+                // Peer exists with correct allowed IPs — normally no change needed.
+                // However, if the stored endpoint is 0.0.0.0 (unspecified), we must
+                // re-apply the peer so WireGuard can learn a valid endpoint. The
+                // general rule of ignoring endpoint differences for roaming does not
+                // apply when the stored endpoint is fundamentally unreachable.
+                if peer.endpoint.ip().is_unspecified() {
+                    to_add_or_update.push(peer.clone());
+                }
             }
             Some(_) => {
                 // Peer exists but allowed IPs changed — update
@@ -872,6 +878,50 @@ mod tests {
             remove[0], peer_b64,
             "removed peer still in WG should be in to_remove"
         );
+    }
+
+    // ── diff_peers: 0.0.0.0 endpoint triggers update (issue #285) ──
+
+    #[test]
+    fn diff_peers_zero_endpoint_triggers_update() {
+        let self_kp = generate_keypair();
+        let peer_kp = generate_keypair();
+        let peer_b64 = peer_kp.public.to_base64();
+
+        // Peer exists in WG with correct allowed IPs, but stored endpoint
+        // is 0.0.0.0 — should trigger an update so WG can learn a real endpoint.
+        let mut desired_peer = make_peer(&peer_b64, syfrah_core::mesh::PeerStatus::Active);
+        desired_peer.endpoint = "0.0.0.0:51820".parse().unwrap();
+        let desired = vec![desired_peer];
+        let wg_peers = vec![make_wg_summary(&peer_b64, "203.0.113.1:51820")];
+
+        let (add, remove) = diff_peers(&self_kp.public, &desired, &wg_peers).unwrap();
+        assert_eq!(
+            add.len(),
+            1,
+            "peer with 0.0.0.0 endpoint must be re-applied even if allowed IPs match"
+        );
+        assert_eq!(add[0].wg_public_key, peer_b64);
+        assert!(remove.is_empty());
+    }
+
+    #[test]
+    fn diff_peers_valid_endpoint_no_spurious_update() {
+        let self_kp = generate_keypair();
+        let peer_kp = generate_keypair();
+        let peer_b64 = peer_kp.public.to_base64();
+
+        // Peer with a valid (non-zero) endpoint and matching allowed IPs —
+        // should NOT trigger an update (normal roaming case).
+        let desired = vec![make_peer(&peer_b64, syfrah_core::mesh::PeerStatus::Active)];
+        let wg_peers = vec![make_wg_summary(&peer_b64, "198.51.100.1:51820")];
+
+        let (add, remove) = diff_peers(&self_kp.public, &desired, &wg_peers).unwrap();
+        assert!(
+            add.is_empty(),
+            "valid endpoint with matching IPs should not trigger update"
+        );
+        assert!(remove.is_empty());
     }
 
     // Integration tests (require root) are skipped in normal CI.


### PR DESCRIPTION
## Summary

Fixes the P0 mesh connectivity outage caused by phantom peers and invalid endpoints.

- **Purge stale peers on join:** when a node re-joins with the same name but a new WG key, old phantom peer records are marked Removed, preventing accumulation across init/join cycles
- **Reject 0.0.0.0 endpoints:** join requests with unresolvable endpoints are rejected with an actionable error; announced peers with 0.0.0.0 are dropped before reaching the store
- **Self-endpoint detection:** peers whose endpoint matches the local node's own public IP are rejected, preventing Invalid MAC handshake loops
- **Reconcile corrects 0.0.0.0 endpoints:** `diff_peers` now forces re-apply when stored endpoint is unspecified; the reconcile loop backfills real endpoints from WG roaming data

## Test plan

- [x] `store::purge_stale_peers_by_name` unit tests: purges old keys, skips current key, skips already-removed, ignores other nodes
- [x] `wg::diff_peers` unit tests: 0.0.0.0 endpoint triggers update; valid endpoint does not cause spurious update
- [x] `daemon` unit tests: unspecified endpoint detection, self-endpoint detection
- [x] `cargo fmt && cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] All 165 fabric tests pass (1 pre-existing flaky audit test unrelated to this PR)

Closes #285