### PR TITLE
Show region and zone on separate lines in status

### DIFF
--- a/layers/fabric/src/cli/status.rs
+++ b/layers/fabric/src/cli/status.rs
@@ -51,7 +51,8 @@ pub async fn run(opts: StatusOpts) -> Result<()> {
     ui::box_top("Mesh");
     ui::box_row(&format!("Name:     {}", sanitize(&state.mesh_name)));
     ui::box_row(&format!("Node:     {}", sanitize(&state.node_name)));
-    ui::box_row(&format!("Region:   {} / zone: {}", region, zone));
+    ui::box_row(&format!("Region:   {}", region));
+    ui::box_row(&format!("Zone:     {}", zone));
     ui::box_row(&format!("Prefix:   {}/48", state.mesh_prefix));
     if let Some(ref up) = uptime_str {
         ui::box_row(&format!("Uptime:   {up}"));


### PR DESCRIPTION
## Summary
- Split the combined `Region: default / zone: zone-1` line into two separate rows (`Region:` and `Zone:`) in `syfrah fabric status` output for better readability and easier parsing.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test -p syfrah-fabric --lib` — 172 passed

Closes #292