### PR TITLE
feat: add `syfrah fabric topology` CLI command

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -184,6 +184,21 @@ enum FabricCommand {
     },
     /// Reload config.toml without restarting the daemon
     Reload,
+    /// Show mesh topology grouped by region and zone
+    Topology {
+        /// Filter to a single region
+        #[arg(long)]
+        region: Option<String>,
+        /// Filter to a single zone
+        #[arg(long)]
+        zone: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+        /// Include per-node endpoint, handshake, and traffic
+        #[arg(long)]
+        verbose: bool,
+    },
     /// Export metrics in Prometheus text format
     Metrics,
     /// Manage the systemd service
@@ -740,6 +755,21 @@ async fn run() -> Result<()> {
             FabricCommand::Reload => {
                 setup_logging(false);
                 cli::reload::run().await
+            }
+            FabricCommand::Topology {
+                region,
+                zone,
+                json,
+                verbose,
+            } => {
+                setup_logging(false);
+                cli::topology::run(cli::topology::TopologyOpts {
+                    region,
+                    zone,
+                    json,
+                    verbose,
+                })
+                .await
             }
             FabricCommand::Metrics => {
                 setup_logging(false);

--- a/layers/fabric/src/cli/mod.rs
+++ b/layers/fabric/src/cli/mod.rs
@@ -16,4 +16,5 @@ pub mod start;
 pub mod status;
 pub mod stop;
 pub mod token;
+pub mod topology;
 pub mod ui;

--- a/layers/fabric/src/cli/topology.rs
+++ b/layers/fabric/src/cli/topology.rs
@@ -1,0 +1,369 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use syfrah_core::mesh::{PeerStatus, Region, Zone};
+
+use crate::cli::ui::truncate;
+use crate::topology::TopologyView;
+use crate::{no_mesh_error, store, ui, wg};
+
+/// Options for the topology command.
+pub struct TopologyOpts {
+    /// Filter to a single region.
+    pub region: Option<String>,
+    /// Filter to a single zone.
+    pub zone: Option<String>,
+    /// Output as JSON.
+    pub json: bool,
+    /// Show per-node endpoint, handshake, and traffic.
+    pub verbose: bool,
+}
+
+pub async fn run(opts: TopologyOpts) -> Result<()> {
+    let state = store::load().map_err(|_| no_mesh_error())?;
+
+    let view = TopologyView::from_peers(&state.peers);
+
+    if opts.json {
+        return run_json(&state.mesh_name, &view, &opts);
+    }
+
+    run_tree(&state.mesh_name, &view, &opts)
+}
+
+fn run_tree(mesh_name: &str, view: &TopologyView, opts: &TopologyOpts) -> Result<()> {
+    // Resolve region filter
+    let mut regions: Vec<&Region> = view.regions();
+    regions.sort_by_key(|r| r.as_str().to_owned());
+
+    if let Some(ref filter) = opts.region {
+        let target = Region::new(filter);
+        match target {
+            Some(ref r) if regions.contains(&r) => {
+                regions.retain(|rr| *rr == r);
+            }
+            _ => {
+                let available: Vec<&str> = regions.iter().map(|r| r.as_str()).collect();
+                anyhow::bail!(
+                    "No region '{}'. Available: {}.",
+                    filter,
+                    available.join(", ")
+                );
+            }
+        }
+    }
+
+    // Zone filter validation (applied during rendering)
+    if let Some(ref filter) = opts.zone {
+        let target = Zone::new(filter);
+        let all_zones: Vec<&Zone> = regions
+            .iter()
+            .flat_map(|r| view.zones_in_region(r))
+            .collect();
+        match target {
+            Some(ref z) if all_zones.contains(&z) => {}
+            _ => {
+                let available: Vec<&str> = all_zones.iter().map(|z| z.as_str()).collect();
+                anyhow::bail!("No zone '{}'. Available: {}.", filter, available.join(", "));
+            }
+        }
+    }
+
+    // Count totals for the header
+    let total_nodes: usize = regions.iter().map(|r| view.peers_in_region(r).len()).sum();
+    let total_zones: usize = regions.iter().map(|r| view.zones_in_region(r).len()).sum();
+
+    // Header box
+    ui::box_top("Topology");
+    ui::box_row(&format!(
+        "Mesh: {}  |  Nodes: {}  |  Regions: {}  |  Zones: {}",
+        mesh_name,
+        total_nodes,
+        regions.len(),
+        total_zones,
+    ));
+    ui::box_bottom();
+    println!();
+
+    // Live WG stats for verbose mode
+    let wg_stats = if opts.verbose {
+        wg::interface_summary()
+            .ok()
+            .map(|s| {
+                s.peers
+                    .into_iter()
+                    .map(|p| (p.public_key.clone(), p))
+                    .collect::<HashMap<_, _>>()
+            })
+            .unwrap_or_default()
+    } else {
+        HashMap::new()
+    };
+
+    for region in &regions {
+        let region_count = view.peers_in_region(region).len();
+        let node_word = if region_count == 1 { "node" } else { "nodes" };
+        println!("{} ({} {})", region.as_str(), region_count, node_word);
+
+        let mut zones = view.zones_in_region(region);
+        zones.sort_by_key(|z| z.as_str().to_owned());
+
+        for zone in &zones {
+            // Apply zone filter
+            if let Some(ref filter) = opts.zone {
+                if let Some(ref target) = Zone::new(filter) {
+                    if *zone != target {
+                        continue;
+                    }
+                }
+            }
+
+            let peers = view.peers_in_zone(zone);
+            let zone_count = peers.len();
+            let zone_word = if zone_count == 1 { "node" } else { "nodes" };
+            println!("  {} ({} {})", zone.as_str(), zone_count, zone_word);
+
+            for peer in peers {
+                let name = truncate(&peer.name, 20);
+                let ipv6 = if opts.verbose {
+                    peer.mesh_ipv6.to_string()
+                } else {
+                    truncate_ipv6(&peer.mesh_ipv6.to_string())
+                };
+                let status = format_status(peer.status);
+
+                if opts.verbose {
+                    println!("    {:<20}  {:<39}  {}", name, ipv6, status);
+                    if let Some(wg_peer) = wg_stats.get(&peer.wg_public_key) {
+                        let endpoint = wg_peer
+                            .endpoint
+                            .map(|e| e.to_string())
+                            .unwrap_or_else(|| "(none)".to_string());
+                        let handshake = wg_peer
+                            .last_handshake
+                            .and_then(|t| {
+                                t.duration_since(std::time::UNIX_EPOCH)
+                                    .ok()
+                                    .map(|d| fmt_ago(d.as_secs()))
+                            })
+                            .unwrap_or_else(|| "(never)".to_string());
+                        let traffic = format!(
+                            "rx {} / tx {}",
+                            fmt_bytes(wg_peer.rx_bytes),
+                            fmt_bytes(wg_peer.tx_bytes)
+                        );
+                        println!(
+                            "    {:<20}  endpoint: {}  handshake: {}  {}",
+                            "", endpoint, handshake, traffic
+                        );
+                    }
+                } else {
+                    println!("    {:<20}  {:<16}  {}", name, ipv6, status);
+                }
+            }
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+fn run_json(mesh_name: &str, view: &TopologyView, opts: &TopologyOpts) -> Result<()> {
+    let mut regions: Vec<&Region> = view.regions();
+    regions.sort_by_key(|r| r.as_str().to_owned());
+
+    // Apply region filter
+    if let Some(ref filter) = opts.region {
+        let target = Region::new(filter);
+        match target {
+            Some(ref r) if regions.contains(&r) => {
+                regions.retain(|rr| *rr == r);
+            }
+            _ => {
+                let available: Vec<&str> = regions.iter().map(|r| r.as_str()).collect();
+                anyhow::bail!(
+                    "No region '{}'. Available: {}.",
+                    filter,
+                    available.join(", ")
+                );
+            }
+        }
+    }
+
+    let total_nodes: usize = regions.iter().map(|r| view.peers_in_region(r).len()).sum();
+
+    let json_regions: Vec<JsonRegion> = regions
+        .iter()
+        .map(|region| {
+            let mut zones = view.zones_in_region(region);
+            zones.sort_by_key(|z| z.as_str().to_owned());
+
+            // Apply zone filter
+            if let Some(ref filter) = opts.zone {
+                if let Some(ref target) = Zone::new(filter) {
+                    zones.retain(|z| *z == target);
+                }
+            }
+
+            let json_zones: Vec<JsonZone> = zones
+                .iter()
+                .map(|zone| {
+                    let peers = view.peers_in_zone(zone);
+                    let nodes: Vec<JsonNode> = peers
+                        .iter()
+                        .map(|p| JsonNode {
+                            name: p.name.clone(),
+                            mesh_ipv6: p.mesh_ipv6.to_string(),
+                            status: format_status(p.status),
+                        })
+                        .collect();
+                    JsonZone {
+                        name: zone.as_str().to_owned(),
+                        nodes,
+                    }
+                })
+                .collect();
+
+            JsonRegion {
+                name: region.as_str().to_owned(),
+                zones: json_zones,
+            }
+        })
+        .collect();
+
+    let output = JsonTopology {
+        mesh_name: mesh_name.to_owned(),
+        total_nodes,
+        regions: json_regions,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn format_status(status: PeerStatus) -> String {
+    match status {
+        PeerStatus::Active => {
+            if ui::is_tty() {
+                let green = console::Style::new().green();
+                format!("{}", green.apply_to("active"))
+            } else {
+                "active".to_string()
+            }
+        }
+        PeerStatus::Unreachable => {
+            if ui::is_tty() {
+                let red = console::Style::new().red();
+                format!("{}", red.apply_to("unreachable"))
+            } else {
+                "unreachable".to_string()
+            }
+        }
+        PeerStatus::Removed => "removed".to_string(),
+    }
+}
+
+/// Truncate an IPv6 address for compact display (first 2 groups + last group).
+fn truncate_ipv6(addr: &str) -> String {
+    let parts: Vec<&str> = addr.split(':').collect();
+    if parts.len() <= 3 {
+        return addr.to_string();
+    }
+    format!("{}:{}::..:{}", parts[0], parts[1], parts[parts.len() - 1])
+}
+
+fn fmt_bytes(b: u64) -> String {
+    if b < 1024 {
+        format!("{b} B")
+    } else if b < 1024 * 1024 {
+        format!("{:.1} KiB", b as f64 / 1024.0)
+    } else if b < 1024 * 1024 * 1024 {
+        format!("{:.1} MiB", b as f64 / (1024.0 * 1024.0))
+    } else {
+        format!("{:.1} GiB", b as f64 / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
+fn fmt_ago(epoch_secs: u64) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let ago = now.saturating_sub(epoch_secs);
+    if ago < 60 {
+        format!("{ago}s ago")
+    } else if ago < 3600 {
+        format!("{}m ago", ago / 60)
+    } else {
+        format!("{}h ago", ago / 3600)
+    }
+}
+
+// ── JSON output types ──────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct JsonTopology {
+    mesh_name: String,
+    total_nodes: usize,
+    regions: Vec<JsonRegion>,
+}
+
+#[derive(Serialize)]
+struct JsonRegion {
+    name: String,
+    zones: Vec<JsonZone>,
+}
+
+#[derive(Serialize)]
+struct JsonZone {
+    name: String,
+    nodes: Vec<JsonNode>,
+}
+
+#[derive(Serialize)]
+struct JsonNode {
+    name: String,
+    mesh_ipv6: String,
+    status: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_ipv6_short() {
+        assert_eq!(truncate_ipv6("::1"), "::1");
+    }
+
+    #[test]
+    fn truncate_ipv6_full() {
+        let result = truncate_ipv6("fd27:0:0:0:0:0:0:e101");
+        assert!(result.contains("fd27"));
+        assert!(result.contains("e101"));
+    }
+
+    #[test]
+    fn fmt_bytes_cases() {
+        assert_eq!(fmt_bytes(500), "500 B");
+        assert_eq!(fmt_bytes(2048), "2.0 KiB");
+        assert_eq!(fmt_bytes(2 * 1024 * 1024), "2.0 MiB");
+    }
+
+    #[test]
+    fn fmt_ago_recent() {
+        // Just test the formatting logic with known epoch
+        let result = fmt_ago(0);
+        assert!(result.contains("h ago") || result.contains("m ago"));
+    }
+
+    #[test]
+    fn format_status_values() {
+        // In test (non-TTY), should return plain strings
+        assert_eq!(format_status(PeerStatus::Active), "active");
+        assert_eq!(format_status(PeerStatus::Unreachable), "unreachable");
+        assert_eq!(format_status(PeerStatus::Removed), "removed");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `syfrah fabric topology` command showing mesh peers grouped by region/zone in a tree view
- Supports `--region` and `--zone` filters with actionable error messages when a filter doesn't match
- Supports `--json` for structured JSON output and `--verbose` for per-node endpoint, handshake, and traffic info
- Follows existing box/heading UI patterns from `status.rs`; degrades gracefully in non-TTY environments

## Test plan
- [ ] `cargo test` passes (all new unit tests green)
- [ ] `cargo clippy` clean
- [ ] Manual: `syfrah fabric topology` shows tree view with regions/zones
- [ ] Manual: `--region eu-west` filters correctly; invalid region shows available regions
- [ ] Manual: `--json` output is valid JSON parseable with jq
- [ ] Manual: `--verbose` shows endpoint, handshake time, and traffic per node
- [ ] Non-TTY: output has no ANSI codes

Closes #290