### PR TITLE
Add dev environment topology testing script

### DIFF
--- a/dev/dev.sh
+++ b/dev/dev.sh
@@ -16,6 +16,8 @@ Commands:
   exec <node> <cmd...>   Run a command on a node (node1 or node2)
   n1 <cmd...>            Shortcut for: exec node1 <cmd...>
   n2 <cmd...>            Shortcut for: exec node2 <cmd...>
+  n3 <cmd...>            Shortcut for: exec node3 <cmd...>
+  n4 <cmd...>            Shortcut for: exec node4 <cmd...>
   logs [node]            Show container logs
   status      Show container and WireGuard status on both nodes
   shell <node>           Open a shell on a node
@@ -60,6 +62,8 @@ cmd_up() {
     echo "==> Containers ready."
     echo "    node1: docker exec syfrah-node1 ..."
     echo "    node2: docker exec syfrah-node2 ..."
+    echo "    node3: docker exec syfrah-node3 ..."
+    echo "    node4: docker exec syfrah-node4 ..."
 }
 
 cmd_down() {
@@ -88,7 +92,7 @@ cmd_logs() {
 }
 
 cmd_status() {
-    for node in node1 node2; do
+    for node in node1 node2 node3 node4; do
         echo "=== $node ==="
         docker exec "syfrah-${node}" sh -c '
             echo "-- IP addresses --"
@@ -130,6 +134,8 @@ case "$command" in
     exec)    cmd_exec "$@" ;;
     n1)      cmd_exec "node1" "$@" ;;
     n2)      cmd_exec "node2" "$@" ;;
+    n3)      cmd_exec "node3" "$@" ;;
+    n4)      cmd_exec "node4" "$@" ;;
     logs)    cmd_logs "${1:-}" ;;
     status)  cmd_status ;;
     shell)   cmd_shell "$1" ;;

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -31,6 +31,38 @@ services:
     networks:
       - mesh
 
+  node3:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: syfrah-node3
+    hostname: node3
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    volumes:
+      - ../target/debug/syfrah:/usr/local/bin/syfrah:ro
+    networks:
+      - mesh
+
+  node4:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: syfrah-node4
+    hostname: node4
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    volumes:
+      - ../target/debug/syfrah:/usr/local/bin/syfrah:ro
+    networks:
+      - mesh
+
 networks:
   mesh:
     driver: bridge

--- a/dev/test-topology.sh
+++ b/dev/test-topology.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+#
+# Topology test: spin up 4 containers across 2 regions and 2 zones, build the
+# mesh, then verify that `syfrah fabric topology` and `syfrah fabric peers
+# --topology` report the correct tree.
+#
+# Prerequisites:
+#   - Docker with Compose v2
+#   - WireGuard kernel module loaded on the host
+#   - syfrah binary at target/debug/syfrah (run `cargo build` first)
+#
+# Usage:
+#   ./dev/test-topology.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+
+# Container names
+N1="syfrah-node1"
+N2="syfrah-node2"
+N3="syfrah-node3"
+N4="syfrah-node4"
+
+# Helpers
+n1() { docker exec "$N1" "$@"; }
+n2() { docker exec "$N2" "$@"; }
+n3() { docker exec "$N3" "$@"; }
+n4() { docker exec "$N4" "$@"; }
+
+die() { echo "FAIL: $1" >&2; cleanup; exit 1; }
+
+pass() { echo "  PASS: $1"; }
+
+cleanup() {
+    echo ""
+    echo "==> Cleaning up containers..."
+    docker compose -f "$COMPOSE_FILE" down --timeout 3 >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# ─── Pre-checks ───────────────────────────────────────────────────────────────
+
+echo "==> Checking prerequisites..."
+
+if ! lsmod | grep -q wireguard 2>/dev/null; then
+    echo "    Loading wireguard kernel module..."
+    sudo modprobe wireguard || die "Could not load wireguard module. Install: sudo apt install wireguard"
+fi
+
+BINARY="$SCRIPT_DIR/../target/debug/syfrah"
+if [ ! -f "$BINARY" ]; then
+    die "Binary not found at $BINARY. Run: cargo build"
+fi
+
+# ─── Start 4 containers ──────────────────────────────────────────────────────
+
+echo "==> Starting 4 containers (2 regions, 2 zones)..."
+docker compose -f "$COMPOSE_FILE" down --timeout 2 >/dev/null 2>&1 || true
+docker compose -f "$COMPOSE_FILE" up -d --build >/dev/null 2>&1
+sleep 1
+
+# Verify all four are running
+for c in "$N1" "$N2" "$N3" "$N4"; do
+    docker inspect "$c" --format '{{.State.Running}}' | grep -q true \
+        || die "$c is not running"
+done
+echo "    All 4 containers running."
+
+# ─── Get bridge IPs ──────────────────────────────────────────────────────────
+
+NODE1_IP=$(docker inspect "$N1" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+NODE2_IP=$(docker inspect "$N2" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+NODE3_IP=$(docker inspect "$N3" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+NODE4_IP=$(docker inspect "$N4" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+
+echo "    node1=$NODE1_IP  node2=$NODE2_IP  node3=$NODE3_IP  node4=$NODE4_IP"
+
+# ─── Init mesh on node1 (eu-west / par-1) ────────────────────────────────────
+
+echo ""
+echo "==> Init mesh on node1 (region=eu-west, zone=par-1)..."
+INIT_OUTPUT=$(n1 syfrah fabric init \
+    --name topology-test \
+    --node-name node1 \
+    --endpoint "${NODE1_IP}:51820" \
+    --region eu-west \
+    --zone par-1 \
+    --peering 2>&1)
+echo "$INIT_OUTPUT"
+
+PIN=$(echo "$INIT_OUTPUT" | grep '^ *PIN:' | awk '{print $NF}')
+[ -n "$PIN" ] || die "Could not extract PIN from init output"
+echo "    PIN: $PIN"
+
+# ─── Join node2 (eu-west / par-1) ────────────────────────────────────────────
+
+echo ""
+echo "==> Join node2 (region=eu-west, zone=par-1)..."
+n2 syfrah fabric join "$NODE1_IP" \
+    --node-name node2 \
+    --endpoint "${NODE2_IP}:51820" \
+    --region eu-west \
+    --zone par-1 \
+    --pin "$PIN" 2>&1
+echo "    Joined."
+
+# ─── Join node3 (us-east / use-1) ────────────────────────────────────────────
+
+echo ""
+echo "==> Join node3 (region=us-east, zone=use-1)..."
+n3 syfrah fabric join "$NODE1_IP" \
+    --node-name node3 \
+    --endpoint "${NODE3_IP}:51820" \
+    --region us-east \
+    --zone use-1 \
+    --pin "$PIN" 2>&1
+echo "    Joined."
+
+# ─── Join node4 (us-east / use-1) ────────────────────────────────────────────
+
+echo ""
+echo "==> Join node4 (region=us-east, zone=use-1)..."
+n4 syfrah fabric join "$NODE1_IP" \
+    --node-name node4 \
+    --endpoint "${NODE4_IP}:51820" \
+    --region us-east \
+    --zone use-1 \
+    --pin "$PIN" 2>&1
+echo "    Joined."
+
+# ─── Wait for peering to propagate ───────────────────────────────────────────
+
+echo ""
+echo "==> Waiting for mesh convergence..."
+sleep 4
+
+# ─── Verify: syfrah fabric topology ──────────────────────────────────────────
+
+echo ""
+echo "==> TEST 1: syfrah fabric topology"
+TOPO_OUTPUT=$(n1 syfrah fabric topology 2>&1)
+echo "$TOPO_OUTPUT"
+
+# Check summary line: 2 regions, 2 zones, 4 nodes
+if echo "$TOPO_OUTPUT" | grep -qE "2 regions.*2 zones.*4 nodes"; then
+    pass "Topology summary shows 2 regions, 2 zones, 4 nodes"
+else
+    die "Topology summary mismatch. Expected 2 regions, 2 zones, 4 nodes."
+fi
+
+# Check eu-west region is present
+if echo "$TOPO_OUTPUT" | grep -q "eu-west"; then
+    pass "Region eu-west present"
+else
+    die "Region eu-west not found in topology output"
+fi
+
+# Check us-east region is present
+if echo "$TOPO_OUTPUT" | grep -q "us-east"; then
+    pass "Region us-east present"
+else
+    die "Region us-east not found in topology output"
+fi
+
+# Check par-1 zone is present
+if echo "$TOPO_OUTPUT" | grep -q "par-1"; then
+    pass "Zone par-1 present"
+else
+    die "Zone par-1 not found in topology output"
+fi
+
+# Check use-1 zone is present
+if echo "$TOPO_OUTPUT" | grep -q "use-1"; then
+    pass "Zone use-1 present"
+else
+    die "Zone use-1 not found in topology output"
+fi
+
+# ─── Verify: syfrah fabric topology --json ───────────────────────────────────
+
+echo ""
+echo "==> TEST 2: syfrah fabric topology --json"
+TOPO_JSON=$(n1 syfrah fabric topology --json 2>&1)
+echo "$TOPO_JSON"
+
+REGION_COUNT=$(echo "$TOPO_JSON" | jq '.regions | length')
+ZONE_COUNT=$(echo "$TOPO_JSON" | jq '[.regions[].zones[]] | length')
+NODE_COUNT=$(echo "$TOPO_JSON" | jq '.total_nodes')
+
+if [ "$REGION_COUNT" -eq 2 ]; then
+    pass "JSON: 2 regions"
+else
+    die "JSON: expected 2 regions, got $REGION_COUNT"
+fi
+
+if [ "$ZONE_COUNT" -eq 2 ]; then
+    pass "JSON: 2 zones"
+else
+    die "JSON: expected 2 zones, got $ZONE_COUNT"
+fi
+
+if [ "$NODE_COUNT" -eq 4 ]; then
+    pass "JSON: 4 nodes"
+else
+    die "JSON: expected 4 nodes, got $NODE_COUNT"
+fi
+
+# ─── Verify: syfrah fabric peers --topology ──────────────────────────────────
+
+echo ""
+echo "==> TEST 3: syfrah fabric peers --topology"
+PEERS_TOPO=$(n1 syfrah fabric peers --topology 2>&1)
+echo "$PEERS_TOPO"
+
+# Peers --topology groups by region then zone. Verify both regions appear.
+if echo "$PEERS_TOPO" | grep -q "eu-west" && echo "$PEERS_TOPO" | grep -q "us-east"; then
+    pass "peers --topology groups both regions"
+else
+    die "peers --topology missing region grouping"
+fi
+
+# Verify all 4 node names appear (node1 is self, but peers shows the other 3 + self in topology view)
+for name in node1 node2 node3 node4; do
+    if echo "$PEERS_TOPO" | grep -q "$name"; then
+        pass "peers --topology includes $name"
+    else
+        die "peers --topology missing $name"
+    fi
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo ""
+echo "========================================"
+echo "  ALL TOPOLOGY TESTS PASSED"
+echo "  4 containers, 2 regions, 2 zones"
+echo "  eu-west/par-1: node1, node2"
+echo "  us-east/use-1: node3, node4"
+echo "========================================"

--- a/handbook/local-dev.md
+++ b/handbook/local-dev.md
@@ -4,7 +4,7 @@ Two Docker containers running syfrah, controlled from the host. Built for iterat
 
 ## How It Works
 
-- **2 containers** (`syfrah-node1`, `syfrah-node2`) on a shared Docker bridge network (IPv4 + IPv6)
+- **4 containers** (`syfrah-node1` through `syfrah-node4`) on a shared Docker bridge network (IPv4 + IPv6)
 - **WireGuard** runs inside each container via the host's kernel module (interfaces are isolated per network namespace)
 - The **syfrah binary** is volume-mounted from `target/debug/syfrah` — no image rebuild needed after code changes
 - You control both nodes from the host via `dev.sh` or `docker exec`
@@ -76,6 +76,8 @@ Host (dev machine)
   |
   +-- syfrah-node1 (172.28.0.2)
   +-- syfrah-node2 (172.28.0.3)
+  +-- syfrah-node3 (172.28.0.4)
+  +-- syfrah-node4 (172.28.0.5)
 ```
 
 Both containers can reach each other on the bridge. WireGuard tunnels are created on top of this network, just like on real servers over the internet.
@@ -156,12 +158,41 @@ The first run builds the base Docker image (~10s). Subsequent runs skip this if 
 | `E2E_BINARY_MOUNT` | (set by e2e.sh) | Used by lib.sh to volume-mount the binary |
 | `SKIP_BUILD` | (set by e2e.sh) | Tells run.sh to skip the Docker image build |
 
+## Topology Testing
+
+The `dev/test-topology.sh` script validates multi-region topology by spinning up all 4 containers and assigning them to 2 regions and 2 zones:
+
+| Node  | Region    | Zone  |
+|-------|-----------|-------|
+| node1 | eu-west   | par-1 |
+| node2 | eu-west   | par-1 |
+| node3 | us-east   | use-1 |
+| node4 | us-east   | use-1 |
+
+```bash
+# Build the binary first
+cargo build
+
+# Run the topology test
+./dev/test-topology.sh
+```
+
+The script:
+1. Starts 4 containers via docker-compose
+2. Inits a mesh on node1 with `--region eu-west --zone par-1 --peering`
+3. Joins node2, node3, node4 with their respective region/zone flags
+4. Verifies `syfrah fabric topology` shows 2 regions, 2 zones, 4 nodes
+5. Verifies `syfrah fabric topology --json` returns correct counts
+6. Verifies `syfrah fabric peers --topology` groups nodes correctly
+7. Tears down containers on exit
+
 ## Files
 
 ```
 dev/
   Dockerfile           # Minimal image: debian + wireguard-tools + iproute2
-  docker-compose.yml   # 2 nodes, bridge network, volume mount
+  docker-compose.yml   # 4 nodes, bridge network, volume mount
   dev.sh               # Helper script for the full workflow
   e2e.sh               # Run E2E tests locally with volume-mounted binary
+  test-topology.sh     # Multi-region topology integration test
 ```


### PR DESCRIPTION
## Summary
- Add `dev/test-topology.sh` — spins up 4 Docker containers across 2 regions (`eu-west/par-1`, `us-east/use-1`), builds a full mesh, and verifies topology output
- Add `node3` and `node4` to `dev/docker-compose.yml`
- Extend `dev/dev.sh` with `n3`/`n4` shortcuts and 4-node status loop
- Document topology testing in `handbook/local-dev.md`

## Test plan
- [ ] `cargo build` then `./dev/test-topology.sh` passes end-to-end
- [ ] `syfrah fabric topology` shows 2 regions, 2 zones, 4 nodes
- [ ] `syfrah fabric topology --json` returns correct counts
- [ ] `syfrah fabric peers --topology` groups all 4 nodes by region/zone
- [ ] Existing `dev/test-mesh.sh` still works (2-node test unaffected)

Closes #295