### PR TITLE
feat: zone health status aggregation and events

### DIFF
--- a/layers/fabric/src/cli/status.rs
+++ b/layers/fabric/src/cli/status.rs
@@ -152,6 +152,41 @@ pub async fn run(opts: StatusOpts) -> Result<()> {
     }
     ui::box_bottom();
 
+    // ── Verbose: Zone Health ────────────────────────────────────────
+    if opts.verbose {
+        if let Ok(zone_statuses) = store::list_zone_health() {
+            if !zone_statuses.is_empty() {
+                ui::box_top("Zone Health");
+                let mut sorted = zone_statuses;
+                sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                for (zone_name, status) in &sorted {
+                    let label = status.to_string();
+                    if ui::is_tty() {
+                        let styled = match status {
+                            crate::events::ZoneHealthStatus::Healthy => {
+                                let s = console::Style::new().green();
+                                format!("{}", s.apply_to(&label))
+                            }
+                            crate::events::ZoneHealthStatus::Degraded => {
+                                let s = console::Style::new().yellow();
+                                format!("{}", s.apply_to(&label))
+                            }
+                            _ => {
+                                let s = console::Style::new().red().bold();
+                                format!("{}", s.apply_to(&label))
+                            }
+                        };
+                        ui::box_row(&format!("{zone_name}: {styled}"));
+                    } else {
+                        ui::box_row(&format!("{zone_name}: {label}"));
+                    }
+                }
+                ui::box_bottom();
+                println!();
+            }
+        }
+    }
+
     // ── Verbose: Metrics ────────────────────────────────────────────
     if opts.verbose && m.daemon_started_at > 0 {
         println!();

--- a/layers/fabric/src/cli/topology.rs
+++ b/layers/fabric/src/cli/topology.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use syfrah_core::mesh::{PeerStatus, Region, Zone};
 
 use crate::cli::ui::truncate;
+use crate::events::ZoneHealthStatus;
 use crate::topology::TopologyView;
 use crate::{no_mesh_error, store, ui, wg};
 
@@ -123,7 +124,22 @@ fn run_tree(mesh_name: &str, view: &TopologyView, opts: &TopologyOpts) -> Result
             let peers = view.peers_in_zone(zone);
             let zone_count = peers.len();
             let zone_word = if zone_count == 1 { "node" } else { "nodes" };
-            println!("  {} ({} {})", zone.as_str(), zone_count, zone_word);
+            let zone_health = store::get_zone_health(zone.as_str()).ok().flatten();
+            let health_tag = match zone_health {
+                Some(status) => format_zone_health(status),
+                None => String::new(),
+            };
+            if health_tag.is_empty() {
+                println!("  {} ({} {})", zone.as_str(), zone_count, zone_word);
+            } else {
+                println!(
+                    "  {} ({} {}) [{}]",
+                    zone.as_str(),
+                    zone_count,
+                    zone_word,
+                    health_tag,
+                );
+            }
 
             for peer in peers {
                 let name = truncate(&peer.name, 20);
@@ -219,8 +235,13 @@ fn run_json(mesh_name: &str, view: &TopologyView, opts: &TopologyOpts) -> Result
                             status: format_status(p.status),
                         })
                         .collect();
+                    let health = store::get_zone_health(zone.as_str())
+                        .ok()
+                        .flatten()
+                        .map(|s| s.to_string());
                     JsonZone {
                         name: zone.as_str().to_owned(),
+                        health,
                         nodes,
                     }
                 })
@@ -241,6 +262,31 @@ fn run_json(mesh_name: &str, view: &TopologyView, opts: &TopologyOpts) -> Result
 
     println!("{}", serde_json::to_string_pretty(&output)?);
     Ok(())
+}
+
+fn format_zone_health(status: ZoneHealthStatus) -> String {
+    let label = status.to_string();
+    if !ui::is_tty() {
+        return label;
+    }
+    match status {
+        ZoneHealthStatus::Healthy => {
+            let style = console::Style::new().green();
+            format!("{}", style.apply_to(label))
+        }
+        ZoneHealthStatus::Degraded => {
+            let style = console::Style::new().yellow();
+            format!("{}", style.apply_to(label))
+        }
+        ZoneHealthStatus::Critical => {
+            let style = console::Style::new().red().bold();
+            format!("{}", style.apply_to(label))
+        }
+        ZoneHealthStatus::Failed => {
+            let style = console::Style::new().red().bold();
+            format!("{}", style.apply_to(label))
+        }
+    }
 }
 
 fn format_status(status: PeerStatus) -> String {
@@ -319,6 +365,8 @@ struct JsonRegion {
 #[derive(Serialize)]
 struct JsonZone {
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    health: Option<String>,
     nodes: Vec<JsonNode>,
 }
 

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1431,6 +1431,64 @@ pub async fn run_daemon(
                 }
             }
 
+            // ── Zone health aggregation ──────────────────────────────
+            {
+                use crate::events::ZoneHealthStatus;
+                use crate::topology::TopologyView;
+
+                let view = TopologyView::from_peers(&peers);
+                let mut all_zones: Vec<&syfrah_core::mesh::Zone> = view
+                    .regions()
+                    .iter()
+                    .flat_map(|r| view.zones_in_region(r))
+                    .collect();
+                all_zones.sort_by_key(|z| z.as_str());
+                all_zones.dedup_by_key(|z| z.as_str());
+
+                for zone in all_zones {
+                    let zone_peers = view.peers_in_zone(zone);
+                    let total = zone_peers.len();
+                    let active = view.active_count_in_zone(zone);
+                    let new_status = ZoneHealthStatus::from_counts(active, total);
+
+                    let prev_status = store::get_zone_health(zone.as_str()).unwrap_or(None);
+
+                    // Persist the new status
+                    if let Err(e) = store::set_zone_health(zone.as_str(), new_status) {
+                        warn!(zone = %zone.as_str(), error = %e, "failed to persist zone health");
+                    }
+
+                    // Emit event on transition (skip initial Healthy → Healthy)
+                    if let Some(prev) = prev_status {
+                        if prev != new_status {
+                            if let Some(event_type) = new_status.transition_event() {
+                                info!(
+                                    zone = %zone.as_str(),
+                                    from = %prev,
+                                    to = %new_status,
+                                    active,
+                                    total,
+                                    "zone health transition"
+                                );
+                                events::emit(
+                                    event_type,
+                                    None,
+                                    None,
+                                    Some(&format!(
+                                        "zone={} active={}/{} status={}",
+                                        zone.as_str(),
+                                        active,
+                                        total,
+                                        new_status,
+                                    )),
+                                    Some(health_max_events),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
             events::emit(
                 EventType::HealthCheckRun,
                 None,

--- a/layers/fabric/src/events.rs
+++ b/layers/fabric/src/events.rs
@@ -28,7 +28,7 @@ pub struct MeshEvent {
 }
 
 /// All event types tracked by the fabric layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EventType {
     DaemonStarted,
     DaemonStopped,
@@ -52,6 +52,10 @@ pub enum EventType {
     PeerLimitReached,
     ConfigReloaded,
     ConfigReloadFailed,
+    ZoneDegraded,
+    ZoneCritical,
+    ZoneFailed,
+    ZoneRecovered,
 }
 
 impl std::fmt::Display for EventType {
@@ -79,6 +83,10 @@ impl std::fmt::Display for EventType {
             EventType::PeerLimitReached => "peer-limit-reached",
             EventType::ConfigReloaded => "config-reloaded",
             EventType::ConfigReloadFailed => "config-reload-failed",
+            EventType::ZoneDegraded => "zone-degraded",
+            EventType::ZoneCritical => "zone-critical",
+            EventType::ZoneFailed => "zone-failed",
+            EventType::ZoneRecovered => "zone-recovered",
         };
         write!(f, "{s}")
     }
@@ -143,6 +151,64 @@ pub fn emit(
     record(event, max_events);
 }
 
+/// Zone-level health status, computed from the ratio of active peers in a zone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ZoneHealthStatus {
+    /// >= 80% of peers are active.
+    Healthy,
+    /// 50-79% of peers are active.
+    Degraded,
+    /// 25-49% of peers are active.
+    Critical,
+    /// < 25% of peers are active (includes 0%).
+    Failed,
+}
+
+impl std::fmt::Display for ZoneHealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            ZoneHealthStatus::Healthy => "healthy",
+            ZoneHealthStatus::Degraded => "degraded",
+            ZoneHealthStatus::Critical => "critical",
+            ZoneHealthStatus::Failed => "failed",
+        };
+        write!(f, "{s}")
+    }
+}
+
+impl ZoneHealthStatus {
+    /// Compute zone health from the number of active peers and total peers.
+    ///
+    /// Returns `Healthy` for zones with no peers (vacuously healthy).
+    pub fn from_counts(active: usize, total: usize) -> Self {
+        if total == 0 {
+            return ZoneHealthStatus::Healthy;
+        }
+        // Use integer arithmetic: active * 100 / total gives the percentage.
+        let pct = (active * 100) / total;
+        if pct >= 80 {
+            ZoneHealthStatus::Healthy
+        } else if pct >= 50 {
+            ZoneHealthStatus::Degraded
+        } else if pct >= 25 {
+            ZoneHealthStatus::Critical
+        } else {
+            ZoneHealthStatus::Failed
+        }
+    }
+
+    /// Return the event type for transitioning *to* this status, if any.
+    /// Transitions to `Healthy` emit `ZoneRecovered`; no event for staying healthy.
+    pub fn transition_event(&self) -> Option<EventType> {
+        match self {
+            ZoneHealthStatus::Healthy => Some(EventType::ZoneRecovered),
+            ZoneHealthStatus::Degraded => Some(EventType::ZoneDegraded),
+            ZoneHealthStatus::Critical => Some(EventType::ZoneCritical),
+            ZoneHealthStatus::Failed => Some(EventType::ZoneFailed),
+        }
+    }
+}
+
 fn now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -162,6 +228,99 @@ mod tests {
             "join-request-received"
         );
         assert_eq!(EventType::PeerRecovered.to_string(), "peer-recovered");
+    }
+
+    #[test]
+    fn zone_health_event_display() {
+        assert_eq!(EventType::ZoneDegraded.to_string(), "zone-degraded");
+        assert_eq!(EventType::ZoneCritical.to_string(), "zone-critical");
+        assert_eq!(EventType::ZoneFailed.to_string(), "zone-failed");
+        assert_eq!(EventType::ZoneRecovered.to_string(), "zone-recovered");
+    }
+
+    #[test]
+    fn zone_health_status_display() {
+        assert_eq!(ZoneHealthStatus::Healthy.to_string(), "healthy");
+        assert_eq!(ZoneHealthStatus::Degraded.to_string(), "degraded");
+        assert_eq!(ZoneHealthStatus::Critical.to_string(), "critical");
+        assert_eq!(ZoneHealthStatus::Failed.to_string(), "failed");
+    }
+
+    #[test]
+    fn zone_health_from_counts_thresholds() {
+        // 3 nodes: 3 active = 100% = healthy
+        assert_eq!(
+            ZoneHealthStatus::from_counts(3, 3),
+            ZoneHealthStatus::Healthy
+        );
+        // 3 nodes: 2 active = 66% = degraded
+        assert_eq!(
+            ZoneHealthStatus::from_counts(2, 3),
+            ZoneHealthStatus::Degraded
+        );
+        // 3 nodes: 1 active = 33% = critical
+        assert_eq!(
+            ZoneHealthStatus::from_counts(1, 3),
+            ZoneHealthStatus::Critical
+        );
+        // 3 nodes: 0 active = 0% = failed
+        assert_eq!(
+            ZoneHealthStatus::from_counts(0, 3),
+            ZoneHealthStatus::Failed
+        );
+        // 0 nodes = healthy (vacuous)
+        assert_eq!(
+            ZoneHealthStatus::from_counts(0, 0),
+            ZoneHealthStatus::Healthy
+        );
+        // Edge: 5 nodes, 4 active = 80% = healthy
+        assert_eq!(
+            ZoneHealthStatus::from_counts(4, 5),
+            ZoneHealthStatus::Healthy
+        );
+        // Edge: 4 nodes, 3 active = 75% = degraded
+        assert_eq!(
+            ZoneHealthStatus::from_counts(3, 4),
+            ZoneHealthStatus::Degraded
+        );
+        // Edge: 4 nodes, 2 active = 50% = degraded
+        assert_eq!(
+            ZoneHealthStatus::from_counts(2, 4),
+            ZoneHealthStatus::Degraded
+        );
+        // Edge: 4 nodes, 1 active = 25% = critical
+        assert_eq!(
+            ZoneHealthStatus::from_counts(1, 4),
+            ZoneHealthStatus::Critical
+        );
+    }
+
+    #[test]
+    fn zone_health_transition_events() {
+        assert_eq!(
+            ZoneHealthStatus::Healthy.transition_event(),
+            Some(EventType::ZoneRecovered)
+        );
+        assert_eq!(
+            ZoneHealthStatus::Degraded.transition_event(),
+            Some(EventType::ZoneDegraded)
+        );
+        assert_eq!(
+            ZoneHealthStatus::Critical.transition_event(),
+            Some(EventType::ZoneCritical)
+        );
+        assert_eq!(
+            ZoneHealthStatus::Failed.transition_event(),
+            Some(EventType::ZoneFailed)
+        );
+    }
+
+    #[test]
+    fn zone_health_status_serialization_roundtrip() {
+        let status = ZoneHealthStatus::Degraded;
+        let json = serde_json::to_string(&status).unwrap();
+        let deserialized: ZoneHealthStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, status);
     }
 
     #[test]

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -461,6 +461,38 @@ pub fn get_peers() -> Result<Vec<PeerRecord>, StoreError> {
     Ok(entries.into_iter().map(|(_, p)| p).collect())
 }
 
+// ── Zone health persistence ─────────────────────────────────
+
+/// Persist the health status for a zone.
+pub fn set_zone_health(
+    zone_name: &str,
+    status: crate::events::ZoneHealthStatus,
+) -> Result<(), StoreError> {
+    let db = open_db()?;
+    db.set("zone_health", zone_name, &status)?;
+    Ok(())
+}
+
+/// Load the health status for a specific zone.
+pub fn get_zone_health(
+    zone_name: &str,
+) -> Result<Option<crate::events::ZoneHealthStatus>, StoreError> {
+    if !LayerDb::layer_exists(LAYER_NAME) {
+        return Ok(None);
+    }
+    let db = open_db()?;
+    Ok(db.get("zone_health", zone_name)?)
+}
+
+/// Load all persisted zone health statuses.
+pub fn list_zone_health() -> Result<Vec<(String, crate::events::ZoneHealthStatus)>, StoreError> {
+    if !LayerDb::layer_exists(LAYER_NAME) {
+        return Ok(vec![]);
+    }
+    let db = open_db()?;
+    Ok(db.list("zone_health")?)
+}
+
 // ── Metrics (atomic) ────────────────────────────────────────
 
 /// Increment a metric atomically.


### PR DESCRIPTION
## Summary
- Add zone-level health aggregation: computes `ZoneHealthStatus` (healthy/degraded/critical/failed) from the ratio of active peers per zone after each health check cycle
- Emit `ZoneDegraded`, `ZoneCritical`, `ZoneFailed`, and `ZoneRecovered` events on status transitions (no false positives on startup)
- Persist zone health in redb (`zone_health` table) for control plane queries
- Display zone health in `syfrah fabric topology` (inline `[status]` tag per zone), `syfrah fabric status --verbose` (Zone Health box), and topology JSON output

## Files changed
- `layers/fabric/src/events.rs` — `ZoneHealthStatus` enum, 4 new event types, threshold logic, unit tests
- `layers/fabric/src/store.rs` — `set_zone_health`, `get_zone_health`, `list_zone_health` persistence functions
- `layers/fabric/src/daemon.rs` — zone aggregation block in health check loop
- `layers/fabric/src/cli/topology.rs` — zone health display in tree and JSON views
- `layers/fabric/src/cli/status.rs` — zone health summary in verbose mode

## Test plan
- [x] Unit tests for `ZoneHealthStatus::from_counts` thresholds (3 nodes: 3=healthy, 2=degraded, 1=critical, 0=failed; edge cases at 80%/50%/25% boundaries)
- [x] Unit tests for transition event mapping
- [x] Unit tests for serialization roundtrip
- [x] `cargo fmt && cargo clippy && cargo test` all green (pre-existing `readonly_file_write_fails_clean` failure in syfrah-state is unrelated)

Closes #297