### PR TITLE
docs: add dev/README.md with E2E test guide

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,154 @@
+# Dev Environment
+
+Local development tools for Syfrah.
+
+## E2E Tests
+
+Run the same E2E tests that CI runs, locally on your machine.
+
+### Prerequisites
+
+```bash
+# Docker (required)
+docker --version
+
+# WireGuard kernel module
+sudo modprobe wireguard
+
+# Rust musl target (one-time setup)
+rustup target add x86_64-unknown-linux-musl
+apt install musl-tools
+```
+
+### Quick start
+
+```bash
+# Build the static binary
+cargo build --release --target x86_64-unknown-linux-musl
+
+# Run ALL tests
+./dev/e2e.sh
+
+# Run a specific test
+./dev/e2e.sh 01_fabric_mesh_formation
+
+# Run a group of tests
+./dev/e2e.sh fabric-basic
+```
+
+### Run by CI group
+
+These are the same groups the CI pipeline uses. Each group runs as a separate job in CI.
+
+| Group | Command | What it tests |
+|-------|---------|---------------|
+| `fabric-basic` | `./dev/e2e.sh "0[1-7]_fabric"` | Mesh formation, connectivity, leave, restart, large mesh, partition, concurrent joins |
+| `fabric-rotation` | `./dev/e2e.sh "08_fabric"` | Secret rotation |
+| `fabric-recovery` | `./dev/e2e.sh "09_fabric\|10_fabric\|11_fabric"` | State corruption, stale PID, rejoin with new key |
+| `fabric-perf` | `./dev/e2e.sh "1[23]_fabric"` | Convergence time, tunnel throughput |
+| `fabric-scale` | `./dev/e2e.sh "1[4-9]_fabric\|20_fabric"` | Rapid scale down, two meshes, stress tests |
+| `fabric-reconcile` | `./dev/e2e.sh "2[5-7]_fabric"` | Reconciliation, peer recovery, last seen |
+| `fabric-zones` | `./dev/e2e.sh "2[89]_fabric\|3[0-7]_fabric"` | Zones: default, auto-increment, manual, mixed, persist, display, propagation |
+| `fabric-misc` | `./dev/e2e.sh "3[89]_fabric\|4[0-9]_fabric\|59_fabric_pid"` | Concurrent joins stress, redb/json consistency, announcements, custom intervals, PID safety |
+| `fabric-topology` | `./dev/e2e.sh "5[0-9]_fabric_topology"` | Topology: basic, multi-region, filter, JSON, backward compat, validation, peers |
+| `state` | `./dev/e2e.sh "2[1-4]_state"` | State CLI: list, get, drop, help |
+| `quickstart` | `./dev/e2e.sh "90_quickstart"` | README quickstart validation |
+| `ux-output` | `./dev/e2e.sh "9[1-7]_ux"` | CLI output: init, join, peers, status, peering, lifecycle, help |
+| `ux-flows` | `./dev/e2e.sh "9[89]_ux\|10[0-4]_ux"` | User flows: first mesh, leave/rejoin, reboot, scaling, PIN, rotation, churn |
+| `ux-errors` | `./dev/e2e.sh "10[5-9]_ux\|110_ux"` | Error scenarios: init, join, lifecycle, commands, no raw errors, consistency |
+| `install` | `./dev/e2e.sh "test_install"` | Install script checksum verification |
+
+### Run a single test
+
+```bash
+# By exact name (without .sh)
+./dev/e2e.sh 01_fabric_mesh_formation
+
+# By partial match
+./dev/e2e.sh mesh_formation
+./dev/e2e.sh topology_json
+./dev/e2e.sh state_cli
+```
+
+### Run all tests
+
+```bash
+./dev/e2e.sh
+```
+
+This runs all 74 scenarios sequentially. Takes ~15-20 minutes.
+
+### Workflow for development
+
+```bash
+# 1. Make your changes
+vim layers/fabric/src/daemon.rs
+
+# 2. Build
+cargo build --release --target x86_64-unknown-linux-musl
+
+# 3. Run the relevant test group
+./dev/e2e.sh fabric-basic
+
+# 4. If it passes, run all tests before pushing
+./dev/e2e.sh
+```
+
+For faster iteration, use debug builds (slower binary but faster compile):
+
+```bash
+cargo build --target x86_64-unknown-linux-musl
+E2E_BINARY=target/x86_64-unknown-linux-musl/debug/syfrah ./dev/e2e.sh 01_fabric
+```
+
+### How it works
+
+`dev/e2e.sh` does three things:
+
+1. Builds a lightweight Docker image (Debian + wireguard-tools + iproute2, ~10s)
+2. Volume-mounts your local binary into the containers (no recompilation inside Docker)
+3. Delegates to `tests/e2e/run.sh` — the exact same runner that CI uses
+
+Each test scenario spins up Docker containers on a bridge network, runs `syfrah` commands inside them, and asserts the results. Containers are cleaned up after each test.
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `E2E_BINARY` | auto-detected | Path to the syfrah binary to test |
+| `SKIP_BUILD` | set by e2e.sh | Skips Docker image build (already handled) |
+| `E2E_BINARY_MOUNT` | set by e2e.sh | Tells lib.sh to volume-mount instead of bake |
+
+### Troubleshooting
+
+**"No syfrah binary found"**
+```bash
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+**"Binary appears to be dynamically linked"**
+```bash
+# You built without musl. Rebuild:
+cargo build --release --target x86_64-unknown-linux-musl
+```
+
+**"Cannot connect to the Docker daemon"**
+```bash
+sudo systemctl start docker
+```
+
+**Tests hang or timeout**
+```bash
+# Kill leftover containers
+docker kill $(docker ps -q --filter name=e2e) 2>/dev/null
+docker rm $(docker ps -aq --filter name=e2e) 2>/dev/null
+docker network rm syfrah-e2e 2>/dev/null
+```
+
+## Other dev tools
+
+| Script | Description |
+|--------|-------------|
+| `dev/dev.sh` | Start/stop a local 4-node dev cluster via docker-compose |
+| `dev/test-mesh.sh` | Quick manual mesh test |
+| `dev/test-topology.sh` | Test topology features with 4 nodes in 2 regions |


### PR DESCRIPTION
Adds documentation for running E2E tests locally, matching the CI pipeline groups.