### PR TITLE
Add criterion performance benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +282,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -372,6 +411,73 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -506,6 +612,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -667,6 +779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +809,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -955,10 +1084,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1232,6 +1381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1406,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -1333,6 +1497,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "polyval"
@@ -1441,6 +1633,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1701,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1599,6 +1823,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1827,6 +2060,7 @@ dependencies = [
  "aes-gcm",
  "base64 0.22.1",
  "bs58",
+ "criterion",
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf",
@@ -1849,6 +2083,7 @@ dependencies = [
  "axum",
  "clap",
  "console",
+ "criterion",
  "dirs",
  "hostname",
  "http-body-util",
@@ -2028,6 +2263,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2346,6 +2591,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2474,6 +2739,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/layers/core/Cargo.toml
+++ b/layers/core/Cargo.toml
@@ -27,3 +27,8 @@ ipnet = { version = "2", features = ["serde"] }
 serde_json.workspace = true
 sha2 = "0.10"
 x25519-dalek = { version = "2", features = ["static_secrets"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "crypto_bench"
+harness = false

--- a/layers/core/benches/crypto_bench.rs
+++ b/layers/core/benches/crypto_bench.rs
@@ -1,0 +1,128 @@
+//! Criterion benchmarks for syfrah-core crypto operations.
+//!
+//! Covers AES-GCM encrypt/decrypt, HKDF key derivation, and peer list
+//! iteration at various scales.
+
+use std::net::{Ipv6Addr, SocketAddr};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use syfrah_core::mesh::{
+    decrypt_record, encrypt_record, PeerRecord, PeerStatus, Region, Topology, Zone,
+};
+use syfrah_core::secret::MeshSecret;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_peer(i: usize) -> PeerRecord {
+    PeerRecord {
+        name: format!("node-{i}"),
+        wg_public_key: format!("key-{i:040}"),
+        endpoint: SocketAddr::new(
+            std::net::IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, i as u16)),
+            51820,
+        ),
+        mesh_ipv6: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, i as u16),
+        last_seen: 1_700_000_000,
+        status: PeerStatus::Active,
+        region: Some("eu-west".to_owned()),
+        zone: Some("eu-west-1a".to_owned()),
+        topology: Some(Topology {
+            region: Region::new("eu-west").unwrap(),
+            zone: Zone::new("eu-west-1a").unwrap(),
+        }),
+    }
+}
+
+fn make_peer_list(n: usize) -> Vec<PeerRecord> {
+    (0..n).map(make_peer).collect()
+}
+
+// ---------------------------------------------------------------------------
+// AES-GCM encrypt / decrypt
+// ---------------------------------------------------------------------------
+
+fn bench_aes_gcm(c: &mut Criterion) {
+    let secret = MeshSecret::generate();
+    let key = secret.encryption_key();
+    let peer = make_peer(1);
+
+    let encrypted = encrypt_record(&peer, &key).expect("encrypt");
+
+    c.bench_function("aes_gcm_encrypt_record", |b| {
+        b.iter(|| encrypt_record(black_box(&peer), black_box(&key)).unwrap());
+    });
+
+    c.bench_function("aes_gcm_decrypt_record", |b| {
+        b.iter(|| decrypt_record(black_box(&encrypted), black_box(&key)).unwrap());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// HKDF key derivation
+// ---------------------------------------------------------------------------
+
+fn bench_hkdf(c: &mut Criterion) {
+    let secret_v2 = MeshSecret::from_bytes_v2([0xAB; 32]);
+    let secret_v1 = MeshSecret::from_bytes([0xAB; 32]);
+
+    c.bench_function("hkdf_v2_encryption_key", |b| {
+        b.iter(|| black_box(&secret_v2).encryption_key());
+    });
+
+    c.bench_function("hkdf_v2_mesh_id", |b| {
+        b.iter(|| black_box(&secret_v2).mesh_id());
+    });
+
+    c.bench_function("sha256_v1_encryption_key", |b| {
+        b.iter(|| black_box(&secret_v1).encryption_key());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Peer list iteration
+// ---------------------------------------------------------------------------
+
+fn bench_peer_iteration(c: &mut Criterion) {
+    let mut group = c.benchmark_group("peer_list_iteration");
+
+    for size in [100, 1000, 5000] {
+        let peers = make_peer_list(size);
+
+        group.bench_with_input(
+            BenchmarkId::new("count_active", size),
+            &peers,
+            |b, peers| {
+                b.iter(|| {
+                    peers
+                        .iter()
+                        .filter(|p| p.status == PeerStatus::Active)
+                        .count()
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("collect_public_keys", size),
+            &peers,
+            |b, peers| {
+                b.iter(|| {
+                    peers
+                        .iter()
+                        .map(|p| p.wg_public_key.as_str())
+                        .collect::<Vec<_>>()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(benches, bench_aes_gcm, bench_hkdf, bench_peer_iteration);
+criterion_main!(benches);

--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -42,3 +42,8 @@ tempfile = "3"
 tokio = { workspace = true, features = ["test-util"] }
 http-body-util = "0.1"
 tower = { version = "0.5", features = ["util"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "fabric_bench"
+harness = false

--- a/layers/fabric/benches/fabric_bench.rs
+++ b/layers/fabric/benches/fabric_bench.rs
@@ -1,0 +1,187 @@
+//! Criterion benchmarks for syfrah-fabric operations.
+//!
+//! Covers TopologyView construction, diff_peers, sanitize, and store upsert.
+
+use std::net::{Ipv6Addr, SocketAddr};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use syfrah_core::mesh::{PeerRecord, PeerStatus, Region, Topology, Zone};
+use syfrah_fabric::sanitize::sanitize;
+use syfrah_fabric::topology::TopologyView;
+use syfrah_fabric::wg::{diff_peers, PeerSummary};
+use wireguard_control::Key;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_peer(i: usize, region: &str, zone: &str) -> PeerRecord {
+    PeerRecord {
+        name: format!("node-{i}"),
+        wg_public_key: format!("key-{i:040}"),
+        endpoint: SocketAddr::new(
+            std::net::IpAddr::V6(Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, i as u16)),
+            51820,
+        ),
+        mesh_ipv6: Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, i as u16),
+        last_seen: 1_700_000_000,
+        status: PeerStatus::Active,
+        region: Some(region.to_owned()),
+        zone: Some(zone.to_owned()),
+        topology: Some(Topology {
+            region: Region::new(region).unwrap(),
+            zone: Zone::new(zone).unwrap(),
+        }),
+    }
+}
+
+fn make_peer_list(n: usize) -> Vec<PeerRecord> {
+    let regions = ["eu-west", "us-east", "ap-south"];
+    let zones = [
+        "eu-west-1a",
+        "eu-west-1b",
+        "us-east-1a",
+        "us-east-1b",
+        "ap-south-1a",
+    ];
+    (0..n)
+        .map(|i| make_peer(i, regions[i % regions.len()], zones[i % zones.len()]))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// TopologyView construction
+// ---------------------------------------------------------------------------
+
+fn bench_topology_view(c: &mut Criterion) {
+    let mut group = c.benchmark_group("topology_view_construction");
+
+    for size in [100, 1000, 5000] {
+        let peers = make_peer_list(size);
+
+        group.bench_with_input(BenchmarkId::new("from_peers", size), &peers, |b, peers| {
+            b.iter(|| TopologyView::from_peers(black_box(peers)));
+        });
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// diff_peers
+// ---------------------------------------------------------------------------
+
+fn bench_diff_peers(c: &mut Criterion) {
+    let mut group = c.benchmark_group("diff_peers");
+
+    for size in [100, 1000, 5000] {
+        let peers = make_peer_list(size);
+        // Simulate WG peers that match desired state (no diff scenario)
+        let wg_peers: Vec<PeerSummary> = peers
+            .iter()
+            .map(|p| PeerSummary {
+                public_key: p.wg_public_key.clone(),
+                endpoint: Some(p.endpoint),
+                allowed_ips: vec![format!("{}/128", p.mesh_ipv6)],
+                last_handshake: None,
+                rx_bytes: 0,
+                tx_bytes: 0,
+            })
+            .collect();
+        let self_key = Key::from_base64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=").unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("no_change", size),
+            &(&peers, &wg_peers, &self_key),
+            |b, (peers, wg_peers, self_key)| {
+                b.iter(|| diff_peers(black_box(self_key), black_box(peers), black_box(wg_peers)));
+            },
+        );
+
+        // Scenario where all peers are missing from WG (worst case)
+        let empty_wg: Vec<PeerSummary> = Vec::new();
+
+        group.bench_with_input(
+            BenchmarkId::new("all_missing", size),
+            &(&peers, &empty_wg, &self_key),
+            |b, (peers, wg_peers, self_key)| {
+                b.iter(|| diff_peers(black_box(self_key), black_box(peers), black_box(wg_peers)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// sanitize
+// ---------------------------------------------------------------------------
+
+fn bench_sanitize(c: &mut Criterion) {
+    let clean = "my-node-01.prod";
+    let dirty = "evil\n\x1b[31mRED\x1b[0m\rstuff\t\0end";
+    let long = "a".repeat(500);
+
+    c.bench_function("sanitize_clean_input", |b| {
+        b.iter(|| sanitize(black_box(clean)));
+    });
+
+    c.bench_function("sanitize_dirty_input", |b| {
+        b.iter(|| sanitize(black_box(dirty)));
+    });
+
+    c.bench_function("sanitize_long_input", |b| {
+        b.iter(|| sanitize(black_box(&long)));
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Store upsert (using LayerDb directly with a temp file)
+// ---------------------------------------------------------------------------
+
+fn bench_store_upsert(c: &mut Criterion) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("bench.redb");
+    let db = syfrah_state::LayerDb::open_at(&db_path).expect("open db");
+
+    let peer = make_peer(1, "eu-west", "eu-west-1a");
+
+    c.bench_function("store_upsert_peer", |b| {
+        b.iter(|| {
+            db.set("peers", &peer.wg_public_key, black_box(&peer))
+                .unwrap();
+        });
+    });
+
+    // Pre-populate 100 peers, then benchmark upsert of a new peer
+    for i in 0..100 {
+        let p = make_peer(i + 1000, "eu-west", "eu-west-1a");
+        db.set("peers", &p.wg_public_key, &p).unwrap();
+    }
+
+    let new_peer = make_peer(9999, "us-east", "us-east-1a");
+
+    c.bench_function("store_upsert_peer_100_existing", |b| {
+        b.iter(|| {
+            db.set("peers", &new_peer.wg_public_key, black_box(&new_peer))
+                .unwrap();
+        });
+    });
+
+    // Keep dir alive until end of benchmark
+    drop(db);
+    drop(dir);
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+criterion_group!(
+    benches,
+    bench_topology_view,
+    bench_diff_peers,
+    bench_sanitize,
+    bench_store_upsert,
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Adds criterion benchmark suite for `syfrah-core`: AES-GCM encrypt/decrypt, HKDF v2 and SHA-256 v1 key derivation, peer list iteration at 100/1000/5000 peers
- Adds criterion benchmark suite for `syfrah-fabric`: TopologyView construction, diff_peers comparison, sanitize function, and store upsert via LayerDb
- Benchmarks parameterized at 100, 1000, and 5000 peers to validate scalability claims

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets` clean
- [x] `cargo test -p syfrah-core -p syfrah-fabric` all passing
- [x] `cargo bench --bench crypto_bench -- --quick` runs successfully
- [x] `cargo bench --bench fabric_bench -- --quick` runs successfully

Closes #332