### PR TITLE
feat(api): add structured error codes and trace IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "syfrah-api"
+version = "0.2.0"
+dependencies = [
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "syfrah-bin"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "layers/api",
     "layers/core",
     "layers/state",
     "layers/fabric",

--- a/layers/api/Cargo.toml
+++ b/layers/api/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "syfrah-api"
+description = "API error types and structured responses for Syfrah"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+rand = "0.8"
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/layers/api/src/error.rs
+++ b/layers/api/src/error.rs
@@ -1,0 +1,165 @@
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Error code constants
+// ---------------------------------------------------------------------------
+
+pub const FABRIC_PEER_NOT_FOUND: &str = "FABRIC_PEER_NOT_FOUND";
+pub const FABRIC_DAEMON_NOT_RUNNING: &str = "FABRIC_DAEMON_NOT_RUNNING";
+pub const FABRIC_MESH_NOT_INITIALIZED: &str = "FABRIC_MESH_NOT_INITIALIZED";
+pub const FABRIC_HANDSHAKE_FAILED: &str = "FABRIC_HANDSHAKE_FAILED";
+pub const FABRIC_TUNNEL_TIMEOUT: &str = "FABRIC_TUNNEL_TIMEOUT";
+pub const STATE_STORE_UNAVAILABLE: &str = "STATE_STORE_UNAVAILABLE";
+pub const STATE_CONFLICT: &str = "STATE_CONFLICT";
+pub const AUTH_UNAUTHORIZED: &str = "AUTH_UNAUTHORIZED";
+pub const AUTH_FORBIDDEN: &str = "AUTH_FORBIDDEN";
+pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
+
+// ---------------------------------------------------------------------------
+// Trace ID generation
+// ---------------------------------------------------------------------------
+
+/// Generate a 12-character random hex trace ID prefixed with `req-`.
+///
+/// Example output: `req-a7f3e29b1c04`
+pub fn generate_trace_id() -> String {
+    let mut rng = rand::thread_rng();
+    let bytes: [u8; 6] = rng.gen();
+    format!("req-{}", hex_encode(&bytes))
+}
+
+/// Minimal hex encoder to avoid pulling in the `hex` crate.
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+
+/// Structured API error returned to clients.
+///
+/// Serialises to:
+/// ```json
+/// {"code":"FABRIC_PEER_NOT_FOUND","message":"peer xyz not found","trace_id":"req-a7f3e29b1c04"}
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ApiError {
+    /// Machine-readable error code (e.g. `FABRIC_PEER_NOT_FOUND`).
+    pub code: String,
+    /// Human-readable description of what went wrong.
+    pub message: String,
+    /// Per-request trace identifier for log correlation.
+    pub trace_id: String,
+}
+
+impl ApiError {
+    /// Create a new `ApiError`, automatically generating a trace ID.
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            trace_id: generate_trace_id(),
+        }
+    }
+
+    /// Create an `ApiError` with an explicit trace ID (useful in tests or
+    /// when propagating a trace ID from an incoming request).
+    pub fn with_trace_id(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        trace_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            trace_id: trace_id.into(),
+        }
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error [{}]: {}", self.trace_id, self.message)
+    }
+}
+
+impl std::error::Error for ApiError {}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn trace_id_format() {
+        let tid = generate_trace_id();
+        assert!(tid.starts_with("req-"), "should start with req-: {tid}");
+        // "req-" (4 chars) + 12 hex chars = 16 total
+        assert_eq!(tid.len(), 16, "unexpected length: {tid}");
+        assert!(
+            tid[4..].chars().all(|c| c.is_ascii_hexdigit()),
+            "non-hex chars in: {tid}"
+        );
+    }
+
+    #[test]
+    fn trace_id_uniqueness() {
+        let ids: HashSet<String> = (0..1000).map(|_| generate_trace_id()).collect();
+        assert_eq!(ids.len(), 1000, "generated duplicate trace IDs");
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let err = ApiError::with_trace_id(
+            FABRIC_PEER_NOT_FOUND,
+            "peer abc123 not found",
+            "req-aabbccddeeff",
+        );
+
+        let json = serde_json::to_string(&err).expect("serialize");
+        let back: ApiError = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(err, back);
+    }
+
+    #[test]
+    fn display_format() {
+        let err = ApiError::with_trace_id(
+            FABRIC_DAEMON_NOT_RUNNING,
+            "daemon is not running",
+            "req-000000000001",
+        );
+        assert_eq!(
+            err.to_string(),
+            "Error [req-000000000001]: daemon is not running"
+        );
+    }
+
+    #[test]
+    fn json_shape() {
+        let err = ApiError::with_trace_id(INTERNAL_ERROR, "something broke", "req-ffffffffffff");
+        let val: serde_json::Value = serde_json::to_value(&err).expect("to_value");
+
+        assert_eq!(val["code"], "INTERNAL_ERROR");
+        assert_eq!(val["message"], "something broke");
+        assert_eq!(val["trace_id"], "req-ffffffffffff");
+    }
+
+    #[test]
+    fn new_generates_trace_id() {
+        let err = ApiError::new(AUTH_UNAUTHORIZED, "bad token");
+        assert!(err.trace_id.starts_with("req-"));
+        assert_eq!(err.trace_id.len(), 16);
+    }
+}

--- a/layers/api/src/lib.rs
+++ b/layers/api/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod error;
+
+pub use error::ApiError;


### PR DESCRIPTION
## Summary
- Introduces the `syfrah-api` crate (`layers/api/`) with `ApiError` struct: `code`, `message`, `trace_id`
- Generates per-request trace IDs (`req-<12 hex chars>`) for log correlation
- Defines error code constants: `FABRIC_PEER_NOT_FOUND`, `FABRIC_DAEMON_NOT_RUNNING`, `FABRIC_MESH_NOT_INITIALIZED`, `FABRIC_HANDSHAKE_FAILED`, `FABRIC_TUNNEL_TIMEOUT`, `STATE_STORE_UNAVAILABLE`, `STATE_CONFLICT`, `AUTH_UNAUTHORIZED`, `AUTH_FORBIDDEN`, `INTERNAL_ERROR`
- Display impl formats as `Error [req-xxx]: message`

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -p syfrah-api` — no warnings
- [x] `cargo test -p syfrah-api` — 6 tests pass (trace ID format, uniqueness, serialization roundtrip, display format, JSON shape, auto-generation)

Closes #354