### PR TITLE
Phase 1.2: LayerHandler trait and LayerRequest dispatch

### DIFF
--- a/layers/api/Cargo.toml
+++ b/layers/api/Cargo.toml
@@ -16,6 +16,7 @@ tracing.workspace = true
 thiserror.workspace = true
 rand = "0.8"
 libc = "0.2"
+async-trait = "0.1"
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/layers/api/src/handler.rs
+++ b/layers/api/src/handler.rs
@@ -1,0 +1,33 @@
+/// Trait that each layer implements to handle incoming requests.
+///
+/// The daemon registers one `LayerHandler` per layer. Requests and responses
+/// are opaque byte vectors — the layer is responsible for deserialising the
+/// request and serialising the response (typically via `serde_json`).
+#[async_trait::async_trait]
+pub trait LayerHandler: Send + Sync {
+    /// Process a serialised request and return a serialised response.
+    async fn handle(&self, request: Vec<u8>) -> Vec<u8>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    struct EchoHandler;
+
+    #[async_trait::async_trait]
+    impl LayerHandler for EchoHandler {
+        async fn handle(&self, request: Vec<u8>) -> Vec<u8> {
+            request
+        }
+    }
+
+    #[tokio::test]
+    async fn echo_handler_returns_input() {
+        let handler: Arc<dyn LayerHandler> = Arc::new(EchoHandler);
+        let input = b"hello".to_vec();
+        let output = handler.handle(input.clone()).await;
+        assert_eq!(input, output);
+    }
+}

--- a/layers/api/src/lib.rs
+++ b/layers/api/src/lib.rs
@@ -1,4 +1,8 @@
 pub mod error;
+pub mod handler;
+pub mod router;
 pub mod transport;
 
 pub use error::ApiError;
+pub use handler::LayerHandler;
+pub use router::{LayerRequest, LayerResponse, LayerRouter};

--- a/layers/api/src/router.rs
+++ b/layers/api/src/router.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::handler::LayerHandler;
+
+// ---------------------------------------------------------------------------
+// LayerRequest / LayerResponse — the envelope that travels over the socket
+// ---------------------------------------------------------------------------
+
+/// Top-level request envelope. Each variant wraps an opaque payload that the
+/// corresponding [`LayerHandler`] knows how to deserialise.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LayerRequest {
+    /// Request destined for the Fabric layer.
+    Fabric(Vec<u8>),
+}
+
+/// Top-level response envelope returned to the client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum LayerResponse {
+    /// Response originating from the Fabric layer.
+    Fabric(Vec<u8>),
+    /// The requested layer is not registered in the router.
+    UnknownLayer(String),
+}
+
+// ---------------------------------------------------------------------------
+// LayerRouter
+// ---------------------------------------------------------------------------
+
+/// Dispatches incoming [`LayerRequest`]s to the correct [`LayerHandler`].
+pub struct LayerRouter {
+    handlers: HashMap<String, Arc<dyn LayerHandler>>,
+}
+
+impl LayerRouter {
+    /// Create an empty router.
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Register a handler for a named layer (e.g. `"fabric"`).
+    pub fn register(&mut self, layer: impl Into<String>, handler: Arc<dyn LayerHandler>) {
+        self.handlers.insert(layer.into(), handler);
+    }
+
+    /// Route a [`LayerRequest`] to the appropriate handler and return a
+    /// [`LayerResponse`].
+    pub async fn dispatch(&self, request: LayerRequest) -> LayerResponse {
+        match request {
+            LayerRequest::Fabric(payload) => {
+                if let Some(handler) = self.handlers.get("fabric") {
+                    LayerResponse::Fabric(handler.handle(payload).await)
+                } else {
+                    LayerResponse::UnknownLayer("fabric".into())
+                }
+            }
+        }
+    }
+}
+
+impl Default for LayerRouter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handler::LayerHandler;
+
+    struct UpperHandler;
+
+    #[async_trait::async_trait]
+    impl LayerHandler for UpperHandler {
+        async fn handle(&self, request: Vec<u8>) -> Vec<u8> {
+            request.iter().map(|b| b.to_ascii_uppercase()).collect()
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_to_fabric() {
+        let mut router = LayerRouter::new();
+        router.register("fabric", Arc::new(UpperHandler));
+
+        let req = LayerRequest::Fabric(b"hello".to_vec());
+        let resp = router.dispatch(req).await;
+
+        match resp {
+            LayerResponse::Fabric(data) => assert_eq!(data, b"HELLO"),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_unknown_layer() {
+        let router = LayerRouter::new(); // no handlers registered
+
+        let req = LayerRequest::Fabric(b"test".to_vec());
+        let resp = router.dispatch(req).await;
+
+        match resp {
+            LayerResponse::UnknownLayer(name) => assert_eq!(name, "fabric"),
+            other => panic!("unexpected response: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn layer_request_serde_roundtrip() {
+        let req = LayerRequest::Fabric(b"payload".to_vec());
+        let json = serde_json::to_vec(&req).unwrap();
+        let back: LayerRequest = serde_json::from_slice(&json).unwrap();
+        match back {
+            LayerRequest::Fabric(data) => assert_eq!(data, b"payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn layer_response_serde_roundtrip() {
+        let resp = LayerResponse::Fabric(b"result".to_vec());
+        let json = serde_json::to_vec(&resp).unwrap();
+        let back: LayerResponse = serde_json::from_slice(&json).unwrap();
+        match back {
+            LayerResponse::Fabric(data) => assert_eq!(data, b"result"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+}

--- a/layers/fabric/src/cli/init.rs
+++ b/layers/fabric/src/cli/init.rs
@@ -1,4 +1,4 @@
-use crate::control::{send_control_request, ControlRequest, ControlResponse};
+use crate::control::{send_control_request, FabricRequest, FabricResponse};
 use crate::daemon::{self, DaemonConfig};
 use crate::peering::generate_pin;
 use crate::store;
@@ -52,7 +52,7 @@ pub async fn wait_and_start_peering(endpoint: Option<SocketAddr>, peering_port: 
 
     let resp = send_control_request(
         &socket_path,
-        &ControlRequest::PeeringStart {
+        &FabricRequest::PeeringStart {
             port: peering_port,
             pin: Some(pin.clone()),
         },
@@ -61,8 +61,8 @@ pub async fn wait_and_start_peering(endpoint: Option<SocketAddr>, peering_port: 
     .map_err(|e| anyhow::anyhow!("failed to start peering via control socket: {e}"))?;
 
     match resp {
-        ControlResponse::Ok => {}
-        ControlResponse::Error { message } => anyhow::bail!("peering start failed: {message}"),
+        FabricResponse::Ok => {}
+        FabricResponse::Error { message } => anyhow::bail!("peering start failed: {message}"),
         _ => anyhow::bail!("unexpected response from daemon"),
     }
 

--- a/layers/fabric/src/cli/peering.rs
+++ b/layers/fabric/src/cli/peering.rs
@@ -1,4 +1,4 @@
-use crate::control::{send_control_request, ControlRequest, ControlResponse};
+use crate::control::{send_control_request, FabricRequest, FabricResponse};
 use crate::sanitize::sanitize;
 use crate::ui;
 use crate::{no_mesh_error, store};
@@ -15,14 +15,14 @@ pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
     let port = state.peering_port;
 
     // Start peering with optional PIN
-    let resp = send_request(ControlRequest::PeeringStart {
+    let resp = send_request(FabricRequest::PeeringStart {
         port,
         pin: pin.clone(),
     })
     .await?;
     match resp {
-        ControlResponse::Ok => {}
-        ControlResponse::Error { message } => anyhow::bail!("{message}"),
+        FabricResponse::Ok => {}
+        FabricResponse::Error { message } => anyhow::bail!("{message}"),
         _ => {}
     }
 
@@ -39,12 +39,12 @@ pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
             _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
         }
 
-        let resp = match send_request(ControlRequest::PeeringList).await {
+        let resp = match send_request(FabricRequest::PeeringList).await {
             Ok(r) => r,
             Err(_) => continue,
         };
 
-        if let ControlResponse::PeeringList { requests } = resp {
+        if let FabricResponse::PeeringList { requests } = resp {
             for req in &requests {
                 if seen.contains(&req.request_id) {
                     continue;
@@ -65,12 +65,12 @@ pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
                 if std::io::stdin().read_line(&mut input).is_ok() {
                     let trimmed = input.trim().to_lowercase();
                     if trimmed.is_empty() || trimmed == "y" || trimmed == "yes" {
-                        match send_request(ControlRequest::PeeringAccept {
+                        match send_request(FabricRequest::PeeringAccept {
                             request_id: req.request_id.clone(),
                         })
                         .await
                         {
-                            Ok(ControlResponse::PeeringAccepted { peer_name }) => {
+                            Ok(FabricResponse::PeeringAccepted { peer_name }) => {
                                 if ui::is_tty() {
                                     let green = console::Style::new().green();
                                     println!(
@@ -85,14 +85,14 @@ pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
                                     );
                                 }
                             }
-                            Ok(ControlResponse::Error { message }) => {
+                            Ok(FabricResponse::Error { message }) => {
                                 ui::warn(&format!("Error: {message}"));
                                 println!();
                             }
                             _ => {}
                         }
                     } else {
-                        match send_request(ControlRequest::PeeringReject {
+                        match send_request(FabricRequest::PeeringReject {
                             request_id: req.request_id.clone(),
                             reason: Some("rejected by operator".into()),
                         })
@@ -118,13 +118,13 @@ pub async fn watch(pin: Option<String>, continuous: bool) -> Result<()> {
 
 pub async fn start(port: u16, pin: Option<String>) -> Result<()> {
     let sp = ui::spinner(&format!("Starting peering on port {port}..."));
-    let resp = send_request(ControlRequest::PeeringStart {
+    let resp = send_request(FabricRequest::PeeringStart {
         port,
         pin: pin.clone(),
     })
     .await?;
     match resp {
-        ControlResponse::Ok => {
+        FabricResponse::Ok => {
             if let Some(ref p) = pin {
                 ui::step_ok(&sp, &format!("Peering started on port {port}"));
                 println!("  Mode: auto-accept with PIN");
@@ -134,7 +134,7 @@ pub async fn start(port: u16, pin: Option<String>) -> Result<()> {
                 println!("  Mode: manual approval (you must accept each join request)");
             }
         }
-        ControlResponse::Error { message } => {
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &format!("Failed: {message}"));
             anyhow::bail!("{message}");
         }
@@ -148,10 +148,10 @@ pub async fn start(port: u16, pin: Option<String>) -> Result<()> {
 
 pub async fn stop() -> Result<()> {
     let sp = ui::spinner("Stopping peering...");
-    let resp = send_request(ControlRequest::PeeringStop).await?;
+    let resp = send_request(FabricRequest::PeeringStop).await?;
     match resp {
-        ControlResponse::Ok => ui::step_ok(&sp, "Peering stopped."),
-        ControlResponse::Error { message } => {
+        FabricResponse::Ok => ui::step_ok(&sp, "Peering stopped."),
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &format!("Failed: {message}"));
             anyhow::bail!("{message}");
         }
@@ -164,9 +164,9 @@ pub async fn stop() -> Result<()> {
 }
 
 pub async fn list() -> Result<()> {
-    let resp = send_request(ControlRequest::PeeringList).await?;
+    let resp = send_request(FabricRequest::PeeringList).await?;
     match resp {
-        ControlResponse::PeeringList { requests } => {
+        FabricResponse::PeeringList { requests } => {
             if requests.is_empty() {
                 println!("No pending join requests.");
             } else {
@@ -187,7 +187,7 @@ pub async fn list() -> Result<()> {
                 println!("\n{} pending request(s)", requests.len());
             }
         }
-        ControlResponse::Error { message } => anyhow::bail!("{message}"),
+        FabricResponse::Error { message } => anyhow::bail!("{message}"),
         _ => anyhow::bail!("unexpected response"),
     }
     Ok(())
@@ -195,15 +195,15 @@ pub async fn list() -> Result<()> {
 
 pub async fn accept(request_id: &str) -> Result<()> {
     let sp = ui::spinner(&format!("Accepting request {request_id}..."));
-    let resp = send_request(ControlRequest::PeeringAccept {
+    let resp = send_request(FabricRequest::PeeringAccept {
         request_id: request_id.to_string(),
     })
     .await?;
     match resp {
-        ControlResponse::PeeringAccepted { peer_name } => {
+        FabricResponse::PeeringAccepted { peer_name } => {
             ui::step_ok(&sp, &format!("{} joined the mesh.", sanitize(&peer_name)));
         }
-        ControlResponse::Error { message } => {
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &format!("Failed: {message}"));
             anyhow::bail!("{message}");
         }
@@ -217,14 +217,14 @@ pub async fn accept(request_id: &str) -> Result<()> {
 
 pub async fn reject(request_id: &str, reason: Option<String>) -> Result<()> {
     let sp = ui::spinner(&format!("Rejecting request {request_id}..."));
-    let resp = send_request(ControlRequest::PeeringReject {
+    let resp = send_request(FabricRequest::PeeringReject {
         request_id: request_id.to_string(),
         reason,
     })
     .await?;
     match resp {
-        ControlResponse::Ok => ui::step_ok(&sp, &format!("Request {request_id} rejected.")),
-        ControlResponse::Error { message } => {
+        FabricResponse::Ok => ui::step_ok(&sp, &format!("Request {request_id} rejected.")),
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &format!("Failed: {message}"));
             anyhow::bail!("{message}");
         }
@@ -236,7 +236,7 @@ pub async fn reject(request_id: &str, reason: Option<String>) -> Result<()> {
     Ok(())
 }
 
-async fn send_request(req: ControlRequest) -> Result<ControlResponse> {
+async fn send_request(req: FabricRequest) -> Result<FabricResponse> {
     let path = store::control_socket_path();
     if !path.exists() {
         anyhow::bail!("daemon not running. Start with 'syfrah fabric start' first.");

--- a/layers/fabric/src/cli/peers_remove.rs
+++ b/layers/fabric/src/cli/peers_remove.rs
@@ -1,4 +1,4 @@
-use crate::control::{send_control_request, ControlRequest, ControlResponse};
+use crate::control::{send_control_request, FabricRequest, FabricResponse};
 use crate::{no_mesh_error, store, ui};
 use anyhow::Result;
 
@@ -35,7 +35,7 @@ pub async fn run(name_or_key: String, skip_confirm: bool) -> Result<()> {
 
     let resp = send_control_request(
         &socket_path,
-        &ControlRequest::RemovePeer {
+        &FabricRequest::RemovePeer {
             name_or_key: name_or_key.clone(),
         },
     )
@@ -43,7 +43,7 @@ pub async fn run(name_or_key: String, skip_confirm: bool) -> Result<()> {
     .map_err(|e| anyhow::anyhow!("failed to communicate with daemon: {e}"))?;
 
     match resp {
-        ControlResponse::PeerRemoved {
+        FabricResponse::PeerRemoved {
             peer_name,
             announced_to,
         } => {
@@ -53,7 +53,7 @@ pub async fn run(name_or_key: String, skip_confirm: bool) -> Result<()> {
             }
             Ok(())
         }
-        ControlResponse::Error { message } => {
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &message);
             anyhow::bail!("{message}");
         }

--- a/layers/fabric/src/cli/peers_update.rs
+++ b/layers/fabric/src/cli/peers_update.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use crate::control::{send_control_request, ControlRequest, ControlResponse};
+use crate::control::{send_control_request, FabricRequest, FabricResponse};
 use crate::{no_mesh_error, store, ui};
 use anyhow::Result;
 
@@ -22,7 +22,7 @@ pub async fn run(name_or_key: String, endpoint: SocketAddr) -> Result<()> {
 
     let resp = send_control_request(
         &socket_path,
-        &ControlRequest::UpdatePeerEndpoint {
+        &FabricRequest::UpdatePeerEndpoint {
             name_or_key: name_or_key.clone(),
             endpoint,
         },
@@ -31,7 +31,7 @@ pub async fn run(name_or_key: String, endpoint: SocketAddr) -> Result<()> {
     .map_err(|e| anyhow::anyhow!("failed to communicate with daemon: {e}"))?;
 
     match resp {
-        ControlResponse::PeerEndpointUpdated {
+        FabricResponse::PeerEndpointUpdated {
             peer_name,
             old_endpoint,
             new_endpoint,
@@ -45,7 +45,7 @@ pub async fn run(name_or_key: String, endpoint: SocketAddr) -> Result<()> {
             );
             Ok(())
         }
-        ControlResponse::Error { message } => {
+        FabricResponse::Error { message } => {
             ui::step_fail(&sp, &message);
             anyhow::bail!("{message}");
         }

--- a/layers/fabric/src/cli/reload.rs
+++ b/layers/fabric/src/cli/reload.rs
@@ -1,4 +1,4 @@
-use crate::control::{send_control_request, ControlRequest, ControlResponse};
+use crate::control::{send_control_request, FabricRequest, FabricResponse};
 use crate::store;
 use anyhow::Result;
 
@@ -8,12 +8,12 @@ pub async fn run() -> Result<()> {
         anyhow::bail!("Daemon is not running. Start it with 'syfrah fabric start' first.");
     }
 
-    let resp = send_control_request(&socket, &ControlRequest::Reload)
+    let resp = send_control_request(&socket, &FabricRequest::Reload)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to connect to daemon: {e}. Is the daemon running?"))?;
 
     match resp {
-        ControlResponse::ConfigReloaded { changes, skipped } => {
+        FabricResponse::ConfigReloaded { changes, skipped } => {
             if changes.is_empty() && skipped.is_empty() {
                 println!("OK: Configuration reloaded. No changes detected.");
             } else {
@@ -30,7 +30,7 @@ pub async fn run() -> Result<()> {
                 }
             }
         }
-        ControlResponse::Error { message } => {
+        FabricResponse::Error { message } => {
             eprintln!("{message}");
             std::process::exit(1);
         }

--- a/layers/fabric/src/cli/rotate.rs
+++ b/layers/fabric/src/cli/rotate.rs
@@ -1,5 +1,5 @@
 use crate::audit::{self as audit_log, AuditEventType};
-use crate::control::{self, ControlRequest, ControlResponse};
+use crate::control::{self, FabricRequest, FabricResponse};
 use crate::ui;
 use crate::{no_mesh_error, store};
 use anyhow::Result;
@@ -18,12 +18,12 @@ pub async fn run(skip_confirm: bool) -> Result<()> {
 
         let sp = ui::spinner("Rotating mesh secret (live)...");
         let socket_path = store::control_socket_path();
-        let resp = control::send_control_request(&socket_path, &ControlRequest::RotateSecret)
+        let resp = control::send_control_request(&socket_path, &FabricRequest::RotateSecret)
             .await
             .map_err(|e| anyhow::anyhow!("failed to contact daemon: {e}"))?;
 
         match resp {
-            ControlResponse::SecretRotated {
+            FabricResponse::SecretRotated {
                 new_secret,
                 new_ipv6,
                 peers_notified,
@@ -39,7 +39,7 @@ pub async fn run(skip_confirm: bool) -> Result<()> {
                     println!("Some peers could not be reached. They will need to rejoin.");
                 }
             }
-            ControlResponse::Error { message } => {
+            FabricResponse::Error { message } => {
                 ui::step_fail(&sp, "Secret rotation failed");
                 anyhow::bail!("{message}");
             }

--- a/layers/fabric/src/control.rs
+++ b/layers/fabric/src/control.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use syfrah_api::transport;
+use syfrah_api::{LayerHandler, LayerRequest, LayerResponse, LayerRouter};
 use tokio::net::UnixStream;
 use tracing::debug;
 
 use crate::peering::JoinRequestInfo;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum ControlRequest {
+pub enum FabricRequest {
     PeeringStart {
         port: u16,
         pin: Option<String>,
@@ -38,7 +39,7 @@ pub enum ControlRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum ControlResponse {
+pub enum FabricResponse {
     Ok,
     PeeringList {
         requests: Vec<JoinRequestInfo>,
@@ -72,16 +73,45 @@ pub enum ControlResponse {
     },
 }
 
-/// Handler trait for processing control commands. Implemented by the daemon.
+/// Handler trait for processing fabric commands. Implemented by the daemon.
 #[async_trait::async_trait]
-pub trait ControlHandler: Send + Sync {
-    async fn handle(&self, req: ControlRequest) -> ControlResponse;
+pub trait FabricHandler: Send + Sync {
+    async fn handle(&self, req: FabricRequest) -> FabricResponse;
 }
 
-/// Start the Unix domain socket control listener.
-pub async fn start_control_listener(socket_path: &Path, handler: Arc<dyn ControlHandler>) {
+/// Adapter that wraps a [`FabricHandler`] as a [`LayerHandler`], bridging the
+/// typed fabric request/response to the opaque byte-level handler interface.
+pub struct FabricLayerHandler<H: FabricHandler> {
+    inner: H,
+}
+
+impl<H: FabricHandler> FabricLayerHandler<H> {
+    pub fn new(inner: H) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait::async_trait]
+impl<H: FabricHandler + 'static> LayerHandler for FabricLayerHandler<H> {
+    async fn handle(&self, request: Vec<u8>) -> Vec<u8> {
+        let req: FabricRequest = match serde_json::from_slice(&request) {
+            std::result::Result::Ok(r) => r,
+            Err(e) => {
+                let resp = FabricResponse::Error {
+                    message: format!("invalid fabric request: {e}"),
+                };
+                return serde_json::to_vec(&resp).unwrap_or_default();
+            }
+        };
+        let resp = self.inner.handle(req).await;
+        serde_json::to_vec(&resp).unwrap_or_default()
+    }
+}
+
+/// Start the Unix domain socket control listener with a [`LayerRouter`].
+pub async fn start_control_listener(socket_path: &Path, router: Arc<LayerRouter>) {
     let listener = match transport::bind_unix_listener(socket_path) {
-        Ok(l) => l,
+        std::result::Result::Ok(l) => l,
         Err(_) => return,
     };
 
@@ -89,10 +119,10 @@ pub async fn start_control_listener(socket_path: &Path, handler: Arc<dyn Control
 
     loop {
         match listener.accept().await {
-            Ok((stream, _)) => {
-                let handler = handler.clone();
+            std::result::Result::Ok((stream, _)) => {
+                let router = router.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_control_connection(stream, handler).await {
+                    if let Err(e) = handle_control_connection(stream, router).await {
                         debug!("control connection error: {e}");
                     }
                 });
@@ -106,15 +136,15 @@ pub async fn start_control_listener(socket_path: &Path, handler: Arc<dyn Control
 
 async fn handle_control_connection(
     mut stream: UnixStream,
-    handler: Arc<dyn ControlHandler>,
+    router: Arc<LayerRouter>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let req = match tokio::time::timeout(
+    let req: LayerRequest = match tokio::time::timeout(
         transport::READ_TIMEOUT,
         transport::read_message(&mut stream),
     )
     .await
     {
-        Ok(result) => result?,
+        std::result::Result::Ok(result) => result?,
         Err(_) => {
             tracing::warn!(
                 "control client timed out after {:?}, dropping connection",
@@ -123,21 +153,37 @@ async fn handle_control_connection(
             return Err("control read timed out".into());
         }
     };
-    let resp = handler.handle(req).await;
+    let resp = router.dispatch(req).await;
     transport::write_message(&mut stream, &resp).await?;
     Ok(())
 }
 
-/// Send a control request to the daemon (CLI client side).
-pub async fn send_control_request(
+/// Send a fabric request to the daemon (CLI client side).
+///
+/// Wraps the [`FabricRequest`] in a [`LayerRequest::Fabric`] envelope before
+/// sending and unwraps the [`LayerResponse::Fabric`] on the way back.
+pub async fn send_fabric_request(
     socket_path: &Path,
-    req: &ControlRequest,
-) -> Result<ControlResponse, Box<dyn std::error::Error>> {
+    req: &FabricRequest,
+) -> Result<FabricResponse, Box<dyn std::error::Error>> {
+    let payload = serde_json::to_vec(req)?;
+    let envelope = LayerRequest::Fabric(payload);
+
     let mut stream = UnixStream::connect(socket_path).await?;
-    transport::write_message(&mut stream, req).await?;
-    let resp = transport::read_message(&mut stream).await?;
-    Ok(resp)
+    transport::write_message(&mut stream, &envelope).await?;
+    let resp: LayerResponse = transport::read_message(&mut stream).await?;
+
+    match resp {
+        LayerResponse::Fabric(data) => {
+            let fabric_resp: FabricResponse = serde_json::from_slice(&data)?;
+            Ok(fabric_resp)
+        }
+        LayerResponse::UnknownLayer(name) => Err(format!("unknown layer: {name}").into()),
+    }
 }
+
+// Keep the old name as an alias for backward compatibility during migration.
+pub use send_fabric_request as send_control_request;
 
 #[cfg(test)]
 mod tests {
@@ -145,23 +191,32 @@ mod tests {
     use tokio::io::duplex;
 
     #[tokio::test]
-    async fn control_roundtrip() {
+    async fn fabric_request_roundtrip() {
         let (mut client, mut server) = duplex(4096);
 
-        let req = ControlRequest::PeeringStart {
+        let req = FabricRequest::PeeringStart {
             port: 7946,
             pin: Some("1234".into()),
         };
-        transport::write_message(&mut client, &req).await.unwrap();
+        let payload = serde_json::to_vec(&req).unwrap();
+        let envelope = LayerRequest::Fabric(payload);
+        transport::write_message(&mut client, &envelope)
+            .await
+            .unwrap();
         drop(client);
 
-        let read_req: ControlRequest = transport::read_message(&mut server).await.unwrap();
-        match read_req {
-            ControlRequest::PeeringStart { port, pin } => {
-                assert_eq!(port, 7946);
-                assert_eq!(pin.as_deref(), Some("1234"));
+        let read_envelope: LayerRequest = transport::read_message(&mut server).await.unwrap();
+        match read_envelope {
+            LayerRequest::Fabric(data) => {
+                let read_req: FabricRequest = serde_json::from_slice(&data).unwrap();
+                match read_req {
+                    FabricRequest::PeeringStart { port, pin } => {
+                        assert_eq!(port, 7946);
+                        assert_eq!(pin.as_deref(), Some("1234"));
+                    }
+                    other => panic!("unexpected request: {other:?}"),
+                }
             }
-            other => panic!("unexpected request: {other:?}"),
         }
     }
 
@@ -175,7 +230,7 @@ mod tests {
             .unwrap();
         drop(client);
 
-        let result: Result<ControlRequest, _> = transport::read_message(&mut server).await;
+        let result: Result<LayerRequest, _> = transport::read_message(&mut server).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
@@ -198,7 +253,7 @@ mod tests {
             .unwrap();
         drop(client);
 
-        let result: Result<ControlRequest, _> = transport::read_message(&mut server).await;
+        let result: Result<LayerRequest, _> = transport::read_message(&mut server).await;
         assert!(result.is_err());
     }
 
@@ -207,7 +262,7 @@ mod tests {
         let (_client, mut server) = duplex(4096);
         drop(_client);
 
-        let result: Result<ControlRequest, _> = transport::read_message(&mut server).await;
+        let result: Result<LayerRequest, _> = transport::read_message(&mut server).await;
         assert!(result.is_err());
     }
 
@@ -224,15 +279,15 @@ mod tests {
             .unwrap();
         drop(client);
 
-        let result: Result<ControlRequest, _> = transport::read_message(&mut server).await;
+        let result: Result<LayerRequest, _> = transport::read_message(&mut server).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn control_response_roundtrip() {
+    async fn fabric_response_roundtrip() {
         let (mut client, mut server) = duplex(4096);
 
-        let resp = ControlResponse::PeeringList {
+        let resp = FabricResponse::PeeringList {
             requests: vec![JoinRequestInfo {
                 request_id: "req-1".into(),
                 node_name: "node-a".into(),
@@ -244,16 +299,26 @@ mod tests {
                 zone: None,
             }],
         };
-        transport::write_message(&mut client, &resp).await.unwrap();
+        let payload = serde_json::to_vec(&resp).unwrap();
+        let envelope = LayerResponse::Fabric(payload);
+        transport::write_message(&mut client, &envelope)
+            .await
+            .unwrap();
         drop(client);
 
-        let read_resp: ControlResponse = transport::read_message(&mut server).await.unwrap();
-        match read_resp {
-            ControlResponse::PeeringList { requests } => {
-                assert_eq!(requests.len(), 1);
-                assert_eq!(requests[0].node_name, "node-a");
+        let read_envelope: LayerResponse = transport::read_message(&mut server).await.unwrap();
+        match read_envelope {
+            LayerResponse::Fabric(data) => {
+                let read_resp: FabricResponse = serde_json::from_slice(&data).unwrap();
+                match read_resp {
+                    FabricResponse::PeeringList { requests } => {
+                        assert_eq!(requests.len(), 1);
+                        assert_eq!(requests[0].node_name, "node-a");
+                    }
+                    other => panic!("unexpected response: {other:?}"),
+                }
             }
-            other => panic!("unexpected response: {other:?}"),
+            other => panic!("unexpected envelope: {other:?}"),
         }
     }
 
@@ -270,16 +335,19 @@ mod tests {
         let handled = Arc::new(AtomicBool::new(false));
         let handled_clone = handled.clone();
 
-        struct NoOpHandler(Arc<AtomicBool>);
+        struct NoOpFabricHandler(Arc<AtomicBool>);
         #[async_trait::async_trait]
-        impl ControlHandler for NoOpHandler {
-            async fn handle(&self, _req: ControlRequest) -> ControlResponse {
+        impl FabricHandler for NoOpFabricHandler {
+            async fn handle(&self, _req: FabricRequest) -> FabricResponse {
                 self.0.store(true, Ordering::SeqCst);
-                ControlResponse::Ok
+                FabricResponse::Ok
             }
         }
 
-        let handler: Arc<dyn ControlHandler> = Arc::new(NoOpHandler(handled_clone));
+        let fabric_handler = FabricLayerHandler::new(NoOpFabricHandler(handled_clone));
+        let mut router = LayerRouter::new();
+        router.register("fabric", Arc::new(fabric_handler));
+        let router = Arc::new(router);
 
         let listener = UnixListener::bind(&sock).unwrap();
 
@@ -288,7 +356,7 @@ mod tests {
         let (stream, _) = listener.accept().await.unwrap();
         let result = tokio::time::timeout(
             transport::READ_TIMEOUT + std::time::Duration::from_secs(1),
-            handle_control_connection(stream, handler),
+            handle_control_connection(stream, router),
         )
         .await
         .expect("server should complete before outer timeout");
@@ -302,5 +370,26 @@ mod tests {
             !handled.load(Ordering::SeqCst),
             "handler must not be invoked for timed-out client"
         );
+    }
+
+    #[tokio::test]
+    async fn fabric_layer_handler_dispatches() {
+        struct EchoFabric;
+        #[async_trait::async_trait]
+        impl FabricHandler for EchoFabric {
+            async fn handle(&self, _req: FabricRequest) -> FabricResponse {
+                FabricResponse::Ok
+            }
+        }
+
+        let adapter = FabricLayerHandler::new(EchoFabric);
+        let req = FabricRequest::PeeringStop;
+        let payload = serde_json::to_vec(&req).unwrap();
+        let result = LayerHandler::handle(&adapter, payload).await;
+        let resp: FabricResponse = serde_json::from_slice(&result).unwrap();
+        match resp {
+            FabricResponse::Ok => {}
+            other => panic!("unexpected: {other:?}"),
+        }
     }
 }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -14,7 +14,7 @@ use syfrah_core::secret::MeshSecret;
 
 use crate::audit::{self as audit_log, AuditEventType};
 use crate::config::{self, Tuning};
-use crate::control::{self, ControlHandler, ControlRequest, ControlResponse};
+use crate::control::{self, FabricHandler, FabricLayerHandler, FabricRequest, FabricResponse};
 use crate::events::{self, EventType};
 use crate::http_api;
 use crate::peering::{self, AutoAcceptConfig, PeeringState};
@@ -23,6 +23,7 @@ use crate::sd_watchdog;
 use crate::store::{self, NodeState};
 use crate::ui;
 use crate::wg;
+use syfrah_api::LayerRouter;
 
 /// TLS certificate verifier that skips trust-anchor verification but still
 /// validates TLS 1.3 handshake signatures.  Used only during the join
@@ -952,8 +953,9 @@ pub async fn run_daemon(
     let shared_mesh_secret = Arc::new(tokio::sync::RwLock::new(mesh_secret.clone()));
     let shared_tls_client = Arc::new(tokio::sync::RwLock::new(tls_client_config.clone()));
 
-    // Control handler
-    let ctrl_handler = Arc::new(DaemonControlHandler {
+    // Control handler — wrap the fabric handler in a LayerRouter so the
+    // daemon multiplexes all layers over a single socket.
+    let ctrl_handler = DaemonFabricHandler {
         peering_state: peering_state.clone(),
         mesh_secret: shared_mesh_secret.clone(),
         my_record: my_record.clone(),
@@ -963,12 +965,16 @@ pub async fn run_daemon(
         tls_client_config: shared_tls_client.clone(),
         max_events: tuning.max_events,
         max_peers,
-    });
+    };
+
+    let fabric_layer_handler = FabricLayerHandler::new(ctrl_handler);
+    let mut router = LayerRouter::new();
+    router.register("fabric", Arc::new(fabric_layer_handler));
+    let router = Arc::new(router);
 
     let control_path = store::control_socket_path();
-    let control_handler: Arc<dyn ControlHandler> = ctrl_handler;
     let mut control_task = tokio::spawn(async move {
-        control::start_control_listener(&control_path, control_handler).await;
+        control::start_control_listener(&control_path, router).await;
     });
 
     // Bounded retry queue for announces that cannot be processed immediately.
@@ -1882,7 +1888,7 @@ pub async fn run_daemon(
 }
 
 /// Control handler for the daemon.
-struct DaemonControlHandler {
+struct DaemonFabricHandler {
     peering_state: Arc<PeeringState>,
     mesh_secret: Arc<tokio::sync::RwLock<MeshSecret>>,
     my_record: PeerRecord,
@@ -1895,15 +1901,15 @@ struct DaemonControlHandler {
 }
 
 #[async_trait::async_trait]
-impl ControlHandler for DaemonControlHandler {
-    async fn handle(&self, req: ControlRequest) -> ControlResponse {
+impl FabricHandler for DaemonFabricHandler {
+    async fn handle(&self, req: FabricRequest) -> FabricResponse {
         match req {
-            ControlRequest::PeeringStart { port: _, pin } => {
+            FabricRequest::PeeringStart { port: _, pin } => {
                 if let Some(pin_val) = pin {
                     let state = match store::load() {
                         Ok(s) => s,
                         Err(e) => {
-                            return ControlResponse::Error {
+                            return FabricResponse::Error {
                                 message: format!("{e}"),
                             }
                         }
@@ -1924,23 +1930,23 @@ impl ControlHandler for DaemonControlHandler {
                 }
                 self.peering_state.set_active(true).await;
                 audit_log::emit(AuditEventType::PeeringStarted, None, None, None);
-                ControlResponse::Ok
+                FabricResponse::Ok
             }
-            ControlRequest::PeeringStop => {
+            FabricRequest::PeeringStop => {
                 self.peering_state.set_active(false).await;
                 self.peering_state.set_auto_accept(None).await;
                 audit_log::emit(AuditEventType::PeeringStopped, None, None, None);
-                ControlResponse::Ok
+                FabricResponse::Ok
             }
-            ControlRequest::PeeringList => {
+            FabricRequest::PeeringList => {
                 let requests = self.peering_state.list_pending().await;
-                ControlResponse::PeeringList { requests }
+                FabricResponse::PeeringList { requests }
             }
-            ControlRequest::PeeringAccept { request_id } => {
+            FabricRequest::PeeringAccept { request_id } => {
                 let state = match store::load() {
                     Ok(s) => s,
                     Err(e) => {
-                        return ControlResponse::Error {
+                        return FabricResponse::Error {
                             message: format!("{e}"),
                         }
                     }
@@ -1964,7 +1970,7 @@ impl ControlHandler for DaemonControlHandler {
                         let new_wg_pub = match Key::from_base64(&info.wg_public_key) {
                             Ok(k) => k,
                             Err(_) => {
-                                return ControlResponse::Error {
+                                return FabricResponse::Error {
                                     message: "invalid WG key".into(),
                                 }
                             }
@@ -2008,16 +2014,16 @@ impl ControlHandler for DaemonControlHandler {
                             Some("approved_by=manual"),
                         );
                         (self.on_accepted)(new_record);
-                        ControlResponse::PeeringAccepted {
+                        FabricResponse::PeeringAccepted {
                             peer_name: info.node_name,
                         }
                     }
-                    Err(e) => ControlResponse::Error {
+                    Err(e) => FabricResponse::Error {
                         message: e.to_string(),
                     },
                 }
             }
-            ControlRequest::PeeringReject { request_id, reason } => {
+            FabricRequest::PeeringReject { request_id, reason } => {
                 match self.peering_state.reject(&request_id, reason.clone()).await {
                     Ok(()) => {
                         events::emit(
@@ -2033,19 +2039,19 @@ impl ControlHandler for DaemonControlHandler {
                             None,
                             reason.as_deref(),
                         );
-                        ControlResponse::Ok
+                        FabricResponse::Ok
                     }
-                    Err(e) => ControlResponse::Error {
+                    Err(e) => FabricResponse::Error {
                         message: e.to_string(),
                     },
                 }
             }
-            ControlRequest::Reload => handle_reload(self.max_events),
-            ControlRequest::RemovePeer { name_or_key } => {
+            FabricRequest::Reload => handle_reload(self.max_events),
+            FabricRequest::RemovePeer { name_or_key } => {
                 let state = match store::load() {
                     Ok(s) => s,
                     Err(e) => {
-                        return ControlResponse::Error {
+                        return FabricResponse::Error {
                             message: format!("{e}"),
                         }
                     }
@@ -2053,7 +2059,7 @@ impl ControlHandler for DaemonControlHandler {
 
                 // Prevent removing self
                 if name_or_key == state.node_name || name_or_key == state.wg_public_key {
-                    return ControlResponse::Error {
+                    return FabricResponse::Error {
                         message: "Cannot remove self. Use 'syfrah fabric leave' instead.".into(),
                     };
                 }
@@ -2099,30 +2105,30 @@ impl ControlHandler for DaemonControlHandler {
                         )
                         .await;
 
-                        ControlResponse::PeerRemoved {
+                        FabricResponse::PeerRemoved {
                             peer_name: removed_peer.name.clone(),
                             announced_to: announced,
                         }
                     }
-                    Ok(None) => ControlResponse::Error {
+                    Ok(None) => FabricResponse::Error {
                         message: format!(
                             "No peer named '{}'. Run 'syfrah fabric peers' to list peers.",
                             name_or_key
                         ),
                     },
-                    Err(e) => ControlResponse::Error {
+                    Err(e) => FabricResponse::Error {
                         message: format!("Failed to remove peer: {e}"),
                     },
                 }
             }
-            ControlRequest::UpdatePeerEndpoint {
+            FabricRequest::UpdatePeerEndpoint {
                 name_or_key,
                 endpoint,
             } => {
                 let state = match store::load() {
                     Ok(s) => s,
                     Err(e) => {
-                        return ControlResponse::Error {
+                        return FabricResponse::Error {
                             message: format!("{e}"),
                         }
                     }
@@ -2150,24 +2156,24 @@ impl ControlHandler for DaemonControlHandler {
                             Some(self.max_events),
                         );
 
-                        ControlResponse::PeerEndpointUpdated {
+                        FabricResponse::PeerEndpointUpdated {
                             peer_name: updated_peer.name.clone(),
                             old_endpoint: old_endpoint.to_string(),
                             new_endpoint: endpoint.to_string(),
                         }
                     }
-                    Ok(None) => ControlResponse::Error {
+                    Ok(None) => FabricResponse::Error {
                         message: format!(
                             "No peer named '{}'. Run 'syfrah fabric peers' to list peers.",
                             name_or_key
                         ),
                     },
-                    Err(e) => ControlResponse::Error {
+                    Err(e) => FabricResponse::Error {
                         message: format!("Failed to update peer endpoint: {e}"),
                     },
                 }
             }
-            ControlRequest::RotateSecret => {
+            FabricRequest::RotateSecret => {
                 // 1. Read current secret for encrypting the rotation broadcast.
                 let old_secret = self.mesh_secret.read().await.clone();
                 let old_enc_key = old_secret.encryption_key();
@@ -2186,7 +2192,7 @@ impl ControlHandler for DaemonControlHandler {
                     match syfrah_core::mesh::encrypt_secret(&new_secret_str, &old_enc_key) {
                         Ok(ct) => ct,
                         Err(e) => {
-                            return ControlResponse::Error {
+                            return FabricResponse::Error {
                                 message: format!("failed to encrypt new secret: {e}"),
                             }
                         }
@@ -2210,13 +2216,13 @@ impl ControlHandler for DaemonControlHandler {
                         state.mesh_prefix = new_prefix;
                         state.mesh_ipv6 = new_ipv6;
                         if let Err(e) = store::save(&state) {
-                            return ControlResponse::Error {
+                            return FabricResponse::Error {
                                 message: format!("secret broadcast succeeded but save failed: {e}"),
                             };
                         }
                     }
                     Err(e) => {
-                        return ControlResponse::Error {
+                        return FabricResponse::Error {
                             message: format!(
                                 "secret broadcast succeeded but state load failed: {e}"
                             ),
@@ -2252,7 +2258,7 @@ impl ControlHandler for DaemonControlHandler {
                     "secret rotation completed"
                 );
 
-                ControlResponse::SecretRotated {
+                FabricResponse::SecretRotated {
                     new_secret: new_secret_str,
                     new_ipv6: new_ipv6.to_string(),
                     peers_notified: notified,
@@ -2265,7 +2271,7 @@ impl ControlHandler for DaemonControlHandler {
 
 /// Handle a config reload request: re-read config.toml, diff with current,
 /// apply hot-reloadable changes, and report results.
-fn handle_reload(max_events: u64) -> ControlResponse {
+fn handle_reload(max_events: u64) -> FabricResponse {
     // Dry-run: parse and validate the config file before applying any changes.
     if let Err(e) = config::validate_config_file() {
         warn!("config reload rejected (validation failed): {e}");
@@ -2276,7 +2282,7 @@ fn handle_reload(max_events: u64) -> ControlResponse {
             Some(&e),
             Some(max_events),
         );
-        return ControlResponse::Error {
+        return FabricResponse::Error {
             message: format!("Config validation failed: {e}. Keeping current configuration."),
         };
     }
@@ -2321,7 +2327,7 @@ fn handle_reload(max_events: u64) -> ControlResponse {
             );
             audit_log::emit(AuditEventType::ConfigReloaded, None, None, Some(&detail));
 
-            ControlResponse::ConfigReloaded {
+            FabricResponse::ConfigReloaded {
                 changes: change_strs,
                 skipped: skip_strs,
             }
@@ -2335,7 +2341,7 @@ fn handle_reload(max_events: u64) -> ControlResponse {
                 Some(&e),
                 Some(max_events),
             );
-            ControlResponse::Error {
+            FabricResponse::Error {
                 message: format!("Config reload failed: {e}. Keeping current configuration."),
             }
         }


### PR DESCRIPTION
## Summary
- Adds `LayerHandler` async trait and `LayerRouter` dispatcher in `syfrah-api` so the daemon can multiplex multiple layers over a single Unix socket.
- Renames `ControlRequest`/`ControlResponse`/`ControlHandler` to `FabricRequest`/`FabricResponse`/`FabricHandler` across the fabric layer.
- Wraps fabric requests in `LayerRequest::Fabric(...)` at the socket boundary; the daemon creates a `LayerRouter`, registers the `FabricHandler`, and dispatches all incoming requests through the router.
- CLI `send_fabric_request` wraps/unwraps the `LayerRequest` envelope transparently.

## Test plan
- All existing fabric tests pass with the renamed types
- New unit tests for `LayerHandler`, `LayerRouter` dispatch, and serde roundtrips
- `cargo clippy` clean, `cargo fmt` applied

Closes #353