### PR TITLE
test(api): unit tests for API framework (Phase 1.5)

### DIFF
--- a/layers/api/src/error.rs
+++ b/layers/api/src/error.rs
@@ -162,4 +162,23 @@ mod tests {
         assert!(err.trace_id.starts_with("req-"));
         assert_eq!(err.trace_id.len(), 16);
     }
+
+    #[test]
+    fn error_code_constants_are_non_empty() {
+        let codes = [
+            FABRIC_PEER_NOT_FOUND,
+            FABRIC_DAEMON_NOT_RUNNING,
+            FABRIC_MESH_NOT_INITIALIZED,
+            FABRIC_HANDSHAKE_FAILED,
+            FABRIC_TUNNEL_TIMEOUT,
+            STATE_STORE_UNAVAILABLE,
+            STATE_CONFLICT,
+            AUTH_UNAUTHORIZED,
+            AUTH_FORBIDDEN,
+            INTERNAL_ERROR,
+        ];
+        for code in codes {
+            assert!(!code.is_empty(), "error code constant must not be empty");
+        }
+    }
 }

--- a/layers/api/src/router.rs
+++ b/layers/api/src/router.rs
@@ -132,4 +132,78 @@ mod tests {
             other => panic!("unexpected: {other:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn register_fabric_send_request_get_response() {
+        let mut router = LayerRouter::new();
+        router.register("fabric", Arc::new(UpperHandler));
+
+        // Send a fabric request and verify we get the uppercased response.
+        let req = LayerRequest::Fabric(b"syfrah".to_vec());
+        let resp = router.dispatch(req, Some(1000)).await;
+
+        match resp {
+            LayerResponse::Fabric(data) => {
+                assert_eq!(data, b"SYFRAH");
+            }
+            other => panic!("expected Fabric response, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replacing_handler_uses_latest() {
+        struct ReverseHandler;
+
+        #[async_trait::async_trait]
+        impl LayerHandler for ReverseHandler {
+            async fn handle(&self, request: Vec<u8>, _caller_uid: Option<u32>) -> Vec<u8> {
+                request.into_iter().rev().collect()
+            }
+        }
+
+        let mut router = LayerRouter::new();
+        // Register first handler (uppercase).
+        router.register("fabric", Arc::new(UpperHandler));
+        // Replace with second handler (reverse).
+        router.register("fabric", Arc::new(ReverseHandler));
+
+        let req = LayerRequest::Fabric(b"abc".to_vec());
+        let resp = router.dispatch(req, None).await;
+
+        match resp {
+            LayerResponse::Fabric(data) => {
+                assert_eq!(data, b"cba", "should use the latest registered handler");
+            }
+            other => panic!("expected Fabric response, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn caller_uid_forwarded_to_handler() {
+        struct UidEchoHandler;
+
+        #[async_trait::async_trait]
+        impl LayerHandler for UidEchoHandler {
+            async fn handle(&self, _request: Vec<u8>, caller_uid: Option<u32>) -> Vec<u8> {
+                match caller_uid {
+                    Some(uid) => uid.to_be_bytes().to_vec(),
+                    None => vec![],
+                }
+            }
+        }
+
+        let mut router = LayerRouter::new();
+        router.register("fabric", Arc::new(UidEchoHandler));
+
+        let req = LayerRequest::Fabric(vec![]);
+        let resp = router.dispatch(req, Some(42)).await;
+
+        match resp {
+            LayerResponse::Fabric(data) => {
+                let uid = u32::from_be_bytes(data.try_into().unwrap());
+                assert_eq!(uid, 42);
+            }
+            other => panic!("expected Fabric response, got: {other:?}"),
+        }
+    }
 }

--- a/layers/api/src/transport.rs
+++ b/layers/api/src/transport.rs
@@ -167,6 +167,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn empty_message_roundtrip() {
+        let (mut client, mut server) = duplex(4096);
+
+        // An empty JSON object serialised as a TestMsg won't work, but we can
+        // write a zero-length payload (len prefix = 0) and verify it fails
+        // gracefully at the JSON parse stage (empty slice is not valid JSON).
+        let len: u32 = 0;
+        tokio::io::AsyncWriteExt::write_all(&mut client, &len.to_be_bytes())
+            .await
+            .unwrap();
+        drop(client);
+
+        let result: Result<TestMsg, _> = read_message(&mut server).await;
+        assert!(
+            result.is_err(),
+            "zero-length payload should fail JSON parse"
+        );
+    }
+
+    #[tokio::test]
     async fn bind_unix_listener_creates_socket() {
         let dir = tempfile::tempdir().unwrap();
         let sock_path = dir.path().join("test.sock");


### PR DESCRIPTION
## Summary
- Add error code constants non-empty validation test in `error.rs`
- Add router tests: handler replacement, caller_uid forwarding, register-send-response roundtrip in `router.rs`
- Add zero-length (empty) message handling test in `transport.rs`
- Builds on existing test coverage from prior phases (transport roundtrip, oversized rejection, trace ID format, auth authorize_local, dispatch/unknown layer)

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` — all 26 API tests pass (26/26 ok)

Closes #380