### PR TITLE
Phase 6.1: Add buf generate CI pipeline for multi-language SDKs

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -1,0 +1,89 @@
+name: SDK Generate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api/proto/**"
+      - "buf.gen.yaml"
+      - "buf.yaml"
+  pull_request:
+    paths:
+      - "api/proto/**"
+      - "buf.gen.yaml"
+      - "buf.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    name: buf generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SDKs
+        run: buf generate
+
+      - name: Verify generated code is up-to-date
+        run: |
+          if [ -n "$(git status --porcelain sdk/)" ]; then
+            echo "::error::Generated SDK code is stale. Run 'buf generate' locally and commit the result."
+            git diff --stat sdk/
+            exit 1
+          fi
+          echo "SDK code is up-to-date."
+
+  publish:
+    name: Publish SDK packages
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: generate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Go — tag-based, no registry publish needed
+      - name: Tag Go module (if changed)
+        run: |
+          if git diff HEAD~1 --quiet -- sdk/go/; then
+            echo "No Go SDK changes, skipping tag."
+          else
+            echo "Go SDK changed — tag manually via release workflow."
+          fi
+
+      # Python — publish to PyPI
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Publish Python SDK
+        if: false  # enable once PyPI token is configured
+        run: |
+          pip install build twine
+          cd sdk/python && python -m build && twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+
+      # JS/TS — publish to npm
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Publish JS SDK
+        if: false  # enable once npm token is configured
+        run: cd sdk/js && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -4,13 +4,28 @@ managed:
   enabled: true
 
 plugins:
-  - remote: buf.build/protocolbuffers/rust
-    out: gen/rust
+  # --- Go ---
   - remote: buf.build/protocolbuffers/go
-    out: gen/go
+    out: sdk/go
     opt:
       - paths=source_relative
   - remote: buf.build/grpc/go
-    out: gen/go
+    out: sdk/go
     opt:
       - paths=source_relative
+
+  # --- Rust ---
+  - remote: buf.build/protocolbuffers/rust
+    out: sdk/rust
+
+  # --- Python ---
+  - remote: buf.build/protocolbuffers/python
+    out: sdk/python
+  - remote: buf.build/grpc/python
+    out: sdk/python
+
+  # --- JS/TS ---
+  - remote: buf.build/protocolbuffers/es
+    out: sdk/js
+  - remote: buf.build/connectrpc/es
+    out: sdk/js

--- a/handbook/sdk-generation.md
+++ b/handbook/sdk-generation.md
@@ -1,0 +1,58 @@
+# SDK Generation
+
+Syfrah exposes gRPC APIs defined as Protobuf files in `api/proto/`. Language-specific
+SDKs are generated with [Buf](https://buf.build/) and committed to the repository
+under `sdk/`.
+
+## Output directories
+
+| Language  | Directory    | Plugin(s)                                      |
+|-----------|--------------|-------------------------------------------------|
+| Go        | `sdk/go/`    | `protocolbuffers/go`, `grpc/go`                |
+| Rust      | `sdk/rust/`  | `protocolbuffers/rust`                         |
+| Python    | `sdk/python/`| `protocolbuffers/python`, `grpc/python`        |
+| JS/TS     | `sdk/js/`    | `protocolbuffers/es`, `connectrpc/es`          |
+
+## Prerequisites
+
+Install the Buf CLI:
+
+```bash
+# macOS / Linux
+brew install bufbuild/buf/buf
+
+# or via npm
+npm install -g @bufbuild/buf
+```
+
+## Generating SDKs locally
+
+From the repository root:
+
+```bash
+buf generate
+```
+
+This reads `buf.gen.yaml`, finds the proto files referenced by `buf.yaml`, and
+writes generated code into the `sdk/` sub-directories listed above.
+
+**Always commit the regenerated files.** CI will fail if the committed SDK code
+is stale compared to the proto definitions.
+
+## CI pipeline
+
+The workflow `.github/workflows/sdk.yml` runs on every push or PR that touches
+`api/proto/**`, `buf.gen.yaml`, or `buf.yaml`.
+
+1. **generate** job — runs `buf generate` and verifies no diff in `sdk/`.
+   If stale, the job fails with a clear error message.
+2. **publish** job (main branch only) — publishes packages to their registries.
+   Publishing is gated behind secrets (`PYPI_TOKEN`, `NPM_TOKEN`) and disabled
+   by default until those secrets are configured.
+
+## Adding a new language
+
+1. Add the appropriate Buf plugin to `buf.gen.yaml` with `out: sdk/<lang>`.
+2. Create `sdk/<lang>/README.md`.
+3. Run `buf generate` and commit the output.
+4. Update this document.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,22 @@
+# Syfrah Go SDK
+
+This package is **auto-generated** from the Protobuf definitions in `api/proto/`.
+
+Do not edit files in this directory by hand — they will be overwritten on the
+next `buf generate` run.
+
+## Usage
+
+```go
+import "github.com/sacha-ops/syfrah/sdk/go/syfrah/v1"
+```
+
+## Regenerating
+
+From the repository root:
+
+```bash
+buf generate
+```
+
+See `handbook/sdk-generation.md` for full details.

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -1,0 +1,22 @@
+# Syfrah JS/TS SDK
+
+This package is **auto-generated** from the Protobuf definitions in `api/proto/`.
+
+Do not edit files in this directory by hand — they will be overwritten on the
+next `buf generate` run.
+
+## Usage
+
+```typescript
+import { NodeService } from "@syfrah/sdk";
+```
+
+## Regenerating
+
+From the repository root:
+
+```bash
+buf generate
+```
+
+See `handbook/sdk-generation.md` for full details.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,22 @@
+# Syfrah Python SDK
+
+This package is **auto-generated** from the Protobuf definitions in `api/proto/`.
+
+Do not edit files in this directory by hand — they will be overwritten on the
+next `buf generate` run.
+
+## Usage
+
+```python
+from syfrah.v1 import node_pb2
+```
+
+## Regenerating
+
+From the repository root:
+
+```bash
+buf generate
+```
+
+See `handbook/sdk-generation.md` for full details.

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,0 +1,22 @@
+# Syfrah Rust SDK
+
+This package is **auto-generated** from the Protobuf definitions in `api/proto/`.
+
+Do not edit files in this directory by hand — they will be overwritten on the
+next `buf generate` run.
+
+## Usage
+
+```rust
+use syfrah_sdk::syfrah::v1::*;
+```
+
+## Regenerating
+
+From the repository root:
+
+```bash
+buf generate
+```
+
+See `handbook/sdk-generation.md` for full details.


### PR DESCRIPTION
## Summary
- Created `sdk/{go,rust,python,js}/` directories with placeholder READMEs explaining the generated code origin
- Updated `buf.gen.yaml` to output generated code into `sdk/` directories for Go, Rust, Python, and JS/TS (replacing the old `gen/` paths)
- Added `.github/workflows/sdk.yml` that runs `buf generate` on proto changes and fails if generated code is stale; includes a publish job (gated behind secrets) for PyPI and npm
- Documented the full SDK generation workflow in `handbook/sdk-generation.md`

## Test plan
- [ ] Verify `buf generate` produces output in `sdk/` directories when buf is installed
- [ ] Verify CI workflow triggers on changes to `api/proto/**`, `buf.gen.yaml`, or `buf.yaml`
- [ ] Verify staleness check fails when SDK code is out of date
- [ ] Confirm publish steps remain disabled until secrets are configured

Closes #369