### PR TITLE
feat(docs): add version selector by release tag

### DIFF
--- a/documentation/src/components/Header.tsx
+++ b/documentation/src/components/Header.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/MobileNavigation'
 import { MobileSearch, Search } from '@/components/Search'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { VersionSelector } from '@/components/VersionSelector'
 import { CloseButton } from '@headlessui/react'
 
 function GitHubIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
@@ -90,6 +91,7 @@ export const Header = forwardRef<
         </CloseButton>
       </div>
       <div className="flex items-center gap-5">
+        <VersionSelector />
         <div className="hidden md:block md:h-5 md:w-px md:bg-zinc-900/10 md:dark:bg-white/15" />
         <div className="flex gap-4">
           <MobileSearch />

--- a/documentation/src/components/VersionSelector.tsx
+++ b/documentation/src/components/VersionSelector.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+// Full multi-version support (deploy per tag) planned for future release
+
+import { useEffect, useState } from 'react'
+
+interface VersionInfo {
+  version: string
+}
+
+export function VersionSelector() {
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/version.json')
+      .then((res) => res.json())
+      .then((data: VersionInfo) => setVersion(data.version))
+      .catch(() => setVersion('dev'))
+  }, [])
+
+  if (!version) {
+    return null
+  }
+
+  return (
+    <div className="flex items-center">
+      <span className="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-700 ring-1 ring-inset ring-zinc-300 dark:bg-zinc-800 dark:text-zinc-300 dark:ring-zinc-700">
+        {version}
+      </span>
+    </div>
+  )
+}

--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -9,6 +9,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 APP_DIR="$REPO_ROOT/documentation/src/app"
 NAV_FILE="$REPO_ROOT/documentation/src/navigation.json"
+VERSION_FILE="$REPO_ROOT/documentation/public/version.json"
+
+# ── Write version.json from latest git tag ────────────────────
+DOC_VERSION="$(git -C "$REPO_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "dev")"
+mkdir -p "$(dirname "$VERSION_FILE")"
+echo "{\"version\":\"${DOC_VERSION}\"}" > "$VERSION_FILE"
+echo "Wrote version.json: ${DOC_VERSION}"
 
 # Directories to scan for .md files
 SCAN_DIRS=(handbook layers dev benchmarks post_release_audit sdk api)


### PR DESCRIPTION
## Summary
- Add `VersionSelector` component that displays the current docs version (read from `/version.json`) as a badge in the header
- Update `sync-docs.sh` to generate `documentation/public/version.json` using `git describe --tags --abbrev=0`
- Integrate the version badge into `Header.tsx` next to the theme toggle and GitHub link

Full multi-version support (deploy per tag with version switching) is planned for a future release.

Closes #413

## Test plan
- [ ] Run `./scripts/sync-docs.sh` and verify `documentation/public/version.json` is created with the latest tag
- [ ] Run `pnpm dev` in `documentation/` and confirm the version badge appears in the top-right header area
- [ ] Verify the badge shows "dev" gracefully when no git tags exist