### PR TITLE
feat: replace Redocly with Scalar for API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
       - 'layers/*/proto/*.proto'
       - 'handbook/**'
       - 'api/proto/**'
-      - 'api/redocly.yaml'
+      - 'api/openapi.yaml'
       - 'scripts/gen-openapi.*'
       - 'dev/**/*.md'
       - 'benchmarks/**/*.md'
@@ -48,11 +48,8 @@ jobs:
         working-directory: docs
         run: bash sync.sh && npm run build
 
-      - name: Generate OpenAPI from proto files
+      - name: Generate OpenAPI and Scalar API docs
         run: bash scripts/gen-openapi.sh
-
-      - name: Build API docs (Redocly)
-        run: npx @redocly/cli build-docs api/openapi.yaml -o docs/dist/api/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/scripts/gen-openapi.py
+++ b/scripts/gen-openapi.py
@@ -397,20 +397,8 @@ def _render_schema(lines: list, schema: dict, indent: int):
 
 
 def _rpc_tag(rpc_name: str, layer_name: str) -> str:
-    """Derive a tag name from the RPC name, prefixed with the layer name."""
-    display = layer_name.capitalize()
-    name_lower = rpc_name.lower()
-    if "peer" in name_lower and "peering" not in name_lower:
-        return f"{display}: Peers"
-    if "peering" in name_lower or "join" in name_lower:
-        return f"{display}: Peering"
-    if "status" in name_lower or "topology" in name_lower:
-        return f"{display}: Status"
-    if "reload" in name_lower or "rotate" in name_lower:
-        return f"{display}: Operations"
-    if "event" in name_lower or "audit" in name_lower or "metric" in name_lower:
-        return f"{display}: Observability"
-    return display
+    """Return the layer name as the tag — Scalar groups by tag in the sidebar."""
+    return layer_name.capitalize()
 
 
 def _humanize(name: str) -> str:

--- a/scripts/gen-openapi.sh
+++ b/scripts/gen-openapi.sh
@@ -1,34 +1,93 @@
 #!/usr/bin/env bash
-# gen-openapi.sh — Generate OpenAPI 3.0 specs from proto files.
-#
-# For each layer with a proto file, this script generates an openapi.yaml
-# derived from the proto service definition and HTTP annotations.
-# Finally it merges all layer specs into api/openapi.yaml via redocly join.
-#
-# Usage: bash scripts/gen-openapi.sh
-
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# Generate per-layer OpenAPI specs from proto
 python3 "$REPO_ROOT/scripts/gen-openapi.py" "$REPO_ROOT"
 
-echo "--- Merging layer specs into api/openapi.yaml ---"
+echo "--- Merging layer specs ---"
 
 LAYER_SPECS=()
 for spec in "$REPO_ROOT"/layers/*/openapi.yaml; do
   [ -f "$spec" ] && LAYER_SPECS+=("$spec")
 done
 
-if [ "${#LAYER_SPECS[@]}" -eq 0 ]; then
-  echo "ERROR: No layer openapi.yaml files found" >&2
-  exit 1
-fi
+[ "${#LAYER_SPECS[@]}" -eq 0 ] && echo "ERROR: No specs" >&2 && exit 1
 
-if [ "${#LAYER_SPECS[@]}" -eq 1 ]; then
-  # redocly join needs at least 2 files; just copy the single spec
-  cp "${LAYER_SPECS[0]}" "$REPO_ROOT/api/openapi.yaml"
-else
-  npx -y @redocly/cli join "${LAYER_SPECS[@]}" -o "$REPO_ROOT/api/openapi.yaml" --without-x-tag-groups
-fi
+# Merge specs with clean tags
+python3 - "${LAYER_SPECS[@]}" << 'PYMERGE'
+import sys, yaml
+from collections import OrderedDict
 
-echo "Generated api/openapi.yaml with ${#LAYER_SPECS[@]} layer(s)"
+merged = {
+    "openapi": "3.0.3",
+    "info": {"title": "Syfrah API", "version": "1.0.0", "description": "API reference for all Syfrah layers."},
+    "servers": [{"url": "https://{gateway}", "variables": {"gateway": {"default": "localhost:8443"}}}],
+    "security": [{"BearerAuth": []}],
+    "paths": {},
+    "components": {"schemas": {}, "securitySchemes": {"BearerAuth": {"type": "http", "scheme": "bearer", "bearerFormat": "syf_key_*"}}},
+    "tags": [],
+    "x-tagGroups": []
+}
+
+tag_set = OrderedDict()
+
+for spec_path in sys.argv[1:]:
+    with open(spec_path) as f:
+        spec = yaml.safe_load(f)
+    
+    # Extract layer name from tags
+    layer_name = None
+    for tag in spec.get("tags", []):
+        name = tag["name"]
+        layer_name = name
+        if name not in tag_set:
+            tag_set[name] = tag.get("description", f"{name} API")
+    
+    # Merge paths, rewriting tags to clean layer name
+    for path, methods in spec.get("paths", {}).items():
+        if path not in merged["paths"]:
+            merged["paths"][path] = {}
+        for method, details in methods.items():
+            if isinstance(details, dict) and layer_name:
+                details["tags"] = [layer_name]
+            merged["paths"][path][method] = details
+    
+    # Merge schemas
+    for name, schema in spec.get("components", {}).get("schemas", {}).items():
+        merged["components"]["schemas"][name] = schema
+
+# Build tags and groups
+for name, desc in tag_set.items():
+    merged["tags"].append({"name": name, "description": desc})
+    merged["x-tagGroups"].append({"name": name, "tags": [name]})
+
+with open("api/openapi.yaml", "w") as f:
+    yaml.dump(merged, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+print(f"Merged {len(sys.argv)-1} specs, {len(tag_set)} categories, {len(merged['paths'])} paths")
+PYMERGE
+
+echo "--- Building Scalar API docs ---"
+mkdir -p "$REPO_ROOT/docs/dist/api"
+
+# Generate Scalar HTML page
+cat > "$REPO_ROOT/docs/dist/api/index.html" << 'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Syfrah API Reference</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="/syfrah/api/openapi.yaml"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>
+HTML
+
+# Copy the generated spec alongside the HTML
+cp "$REPO_ROOT/api/openapi.yaml" "$REPO_ROOT/docs/dist/api/openapi.yaml"
+
+echo "Scalar API docs ready at docs/dist/api/"


### PR DESCRIPTION
- Scalar: free, interactive try-it-out, dark mode native
- Clean sidebar categories per layer (Fabric, Compute, Forge, etc.)
- No Redocly dependency
- Proto → OpenAPI → Scalar pipeline unchanged