### PR TITLE
Remove hardcoded /v1/ from proto HTTP annotations

### DIFF
--- a/layers/compute/proto/compute.proto
+++ b/layers/compute/proto/compute.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.compute.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 

--- a/layers/fabric/proto/fabric.proto
+++ b/layers/fabric/proto/fabric.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.fabric.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 
@@ -14,85 +14,85 @@ service FabricService {
 
   // ListPeers returns all peers in the mesh.
   rpc ListPeers(ListPeersRequest) returns (ListPeersResponse) {
-    option (google.api.http) = { get: "/v1/fabric/peers" };
+    option (google.api.http) = { get: "/fabric/peers" };
   }
 
   // RemovePeer removes a peer from the mesh by name or public key.
   rpc RemovePeer(RemovePeerRequest) returns (RemovePeerResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peers/remove" body: "*" };
+    option (google.api.http) = { post: "/fabric/peers/remove" body: "*" };
   }
 
   // UpdatePeerEndpoint changes a peer's WireGuard endpoint address.
   rpc UpdatePeerEndpoint(UpdatePeerEndpointRequest) returns (UpdatePeerEndpointResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peers/update-endpoint" body: "*" };
+    option (google.api.http) = { post: "/fabric/peers/update-endpoint" body: "*" };
   }
 
   // --- Topology & status ---
 
   // GetTopology returns the current mesh topology graph.
   rpc GetTopology(GetTopologyRequest) returns (GetTopologyResponse) {
-    option (google.api.http) = { get: "/v1/fabric/topology" };
+    option (google.api.http) = { get: "/fabric/topology" };
   }
 
   // GetStatus returns the health and summary of the local node.
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse) {
-    option (google.api.http) = { get: "/v1/fabric/status" };
+    option (google.api.http) = { get: "/fabric/status" };
   }
 
   // --- Peering lifecycle ---
 
   // StartPeering opens the peering listener to accept join requests.
   rpc StartPeering(StartPeeringRequest) returns (StartPeeringResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peering/start" body: "*" };
+    option (google.api.http) = { post: "/fabric/peering/start" body: "*" };
   }
 
   // StopPeering closes the peering listener.
   rpc StopPeering(StopPeeringRequest) returns (StopPeeringResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peering/stop" body: "*" };
+    option (google.api.http) = { post: "/fabric/peering/stop" body: "*" };
   }
 
   // ListPendingJoins lists unapproved join requests.
   rpc ListPendingJoins(ListPendingJoinsRequest) returns (ListPendingJoinsResponse) {
-    option (google.api.http) = { get: "/v1/fabric/peering/requests" };
+    option (google.api.http) = { get: "/fabric/peering/requests" };
   }
 
   // AcceptJoin approves a pending join request.
   rpc AcceptJoin(AcceptJoinRequest) returns (AcceptJoinResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peering/accept" body: "*" };
+    option (google.api.http) = { post: "/fabric/peering/accept" body: "*" };
   }
 
   // RejectJoin denies a pending join request.
   rpc RejectJoin(RejectJoinRequest) returns (RejectJoinResponse) {
-    option (google.api.http) = { post: "/v1/fabric/peering/reject" body: "*" };
+    option (google.api.http) = { post: "/fabric/peering/reject" body: "*" };
   }
 
   // --- Operations ---
 
   // RotateSecret generates a new mesh secret and re-keys all peers.
   rpc RotateSecret(RotateSecretRequest) returns (RotateSecretResponse) {
-    option (google.api.http) = { post: "/v1/fabric/rotate-secret" body: "*" };
+    option (google.api.http) = { post: "/fabric/rotate-secret" body: "*" };
   }
 
   // ReloadConfig hot-reloads configuration from disk.
   rpc ReloadConfig(ReloadConfigRequest) returns (ReloadConfigResponse) {
-    option (google.api.http) = { post: "/v1/fabric/reload" body: "*" };
+    option (google.api.http) = { post: "/fabric/reload" body: "*" };
   }
 
   // --- Observability ---
 
   // GetEvents streams or lists recent fabric events.
   rpc GetEvents(GetEventsRequest) returns (GetEventsResponse) {
-    option (google.api.http) = { get: "/v1/fabric/events" };
+    option (google.api.http) = { get: "/fabric/events" };
   }
 
   // GetAudit returns the audit log of administrative actions.
   rpc GetAudit(GetAuditRequest) returns (GetAuditResponse) {
-    option (google.api.http) = { get: "/v1/fabric/audit" };
+    option (google.api.http) = { get: "/fabric/audit" };
   }
 
   // GetMetrics returns fabric metrics in a structured format.
   rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse) {
-    option (google.api.http) = { get: "/v1/fabric/metrics" };
+    option (google.api.http) = { get: "/fabric/metrics" };
   }
 }
 

--- a/layers/forge/proto/forge.proto
+++ b/layers/forge/proto/forge.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.forge.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 

--- a/layers/org/proto/org.proto
+++ b/layers/org/proto/org.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.org.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 

--- a/layers/overlay/proto/overlay.proto
+++ b/layers/overlay/proto/overlay.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.overlay.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 

--- a/layers/storage/proto/storage.proto
+++ b/layers/storage/proto/storage.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.storage.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 

--- a/scripts/gen-openapi.py
+++ b/scripts/gen-openapi.py
@@ -25,10 +25,16 @@ def parse_proto(proto_path: str) -> dict:
     result = {
         "service_name": "",
         "service_comment": "",
+        "version": "",
         "rpcs": [],
         "messages": {},
         "enums": {},
     }
+
+    # Extract version from package declaration (e.g. package syfrah.fabric.v1;)
+    pkg_match = re.search(r"^package\s+syfrah\.\w+\.(v\d+)\s*;", content, re.MULTILINE)
+    if pkg_match:
+        result["version"] = pkg_match.group(1)
 
     # Extract service name
     svc_match = re.search(r"service\s+(\w+)\s*\{", content)
@@ -202,6 +208,7 @@ def generate_openapi(proto_data: dict, layer_name: str, is_stub: bool) -> str:
     """Generate OpenAPI 3.0 YAML string from parsed proto data."""
     service = proto_data["service_name"]
     description = proto_data["service_comment"] or f"{service} API"
+    version = proto_data.get("version", "v1") or "v1"
 
     # Determine display name for the layer
     display_name = layer_name.capitalize()
@@ -237,7 +244,7 @@ def generate_openapi(proto_data: dict, layer_name: str, is_stub: bool) -> str:
     lines.append("paths:")
 
     if is_stub:
-        path = f"/v1/{layer_name}/status"
+        path = f"/{version}/{layer_name}/status"
         lines.append(f"  '{path}':")
         lines.append("    get:")
         lines.append(f"      operationId: get{display_name}Status")
@@ -264,7 +271,7 @@ def generate_openapi(proto_data: dict, layer_name: str, is_stub: bool) -> str:
             if not rpc["http_path"]:
                 continue
             method = rpc["http_method"].lower()
-            path = rpc["http_path"]
+            path = f"/{version}{rpc['http_path']}"
             tag = _rpc_tag(rpc["name"], layer_name)
             op_id = rpc["name"][0].lower() + rpc["name"][1:]
 


### PR DESCRIPTION
## Summary
- Removed hardcoded `/v1/` prefix from all HTTP annotations in proto files
- Updated proto package declarations to `syfrah.{layer}.v{N}` format (e.g. `syfrah.fabric.v1`)
- Updated `gen-openapi.py` to extract the version from the package line and prepend `/{version}/` to all generated OpenAPI paths
- Generated OpenAPI specs still produce `/v1/fabric/peers` etc., but the version is now derived rather than duplicated

## Test plan
- [x] Run `bash scripts/gen-openapi.sh` — generates successfully
- [x] Verify `api/openapi.yaml` still has `/v1/fabric/peers` and `/v1/{layer}/status` paths
- [x] Verify no `/v1/` remains in proto HTTP annotations

Closes #434