### PR TITLE
feat: beta/stable release channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/v*'
   workflow_dispatch:
 
 permissions:
@@ -18,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       next: ${{ steps.calc.outputs.next }}
+      tag: ${{ steps.calc.outputs.tag }}
+      channel: ${{ steps.calc.outputs.channel }}
       should_release: ${{ steps.calc.outputs.should_release }}
     steps:
       - uses: actions/checkout@v4
@@ -27,9 +31,14 @@ jobs:
       - name: Calculate next version
         id: calc
         run: |
-          # Get latest tag
-          LATEST=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          echo "Latest tag: $LATEST"
+          set -euo pipefail
+
+          # Skip release: commits (loop prevention)
+          if git log -1 --pretty=%s | grep -q '^release:'; then
+            echo "Release commit detected — skipping"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Skip if HEAD is already tagged
           HEAD_TAGS=$(git tag --points-at HEAD)
@@ -39,14 +48,30 @@ jobs:
             exit 0
           fi
 
-          # Parse semver
+          # Detect channel from branch
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" == release/v* ]]; then
+            CHANNEL="stable"
+          else
+            CHANNEL="beta"
+          fi
+          echo "Branch: $BRANCH → Channel: $CHANNEL"
+
+          # Get latest stable tag (ignore beta tags for base version)
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | grep -v 'beta' | head -1 || echo "v0.0.0")
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+          fi
+          echo "Latest stable tag: $LATEST"
+
+          # Parse semver from latest stable tag
           SEMVER=${LATEST#v}
           MAJOR=$(echo "$SEMVER" | cut -d. -f1)
           MINOR=$(echo "$SEMVER" | cut -d. -f2)
-          PATCH=$(echo "$SEMVER" | cut -d. -f3)
+          PATCH=$(echo "$SEMVER" | cut -d. -f3 | cut -d- -f1)
 
-          # Check commit messages since last tag
-          COMMITS=$(git log "${LATEST}..HEAD" --oneline)
+          # Check commit messages since last tag for bump type
+          COMMITS=$(git log "${LATEST}..HEAD" --oneline 2>/dev/null || echo "")
           echo "Commits since $LATEST:"
           echo "$COMMITS"
 
@@ -58,10 +83,37 @@ jobs:
             PATCH=$((PATCH + 1))
           fi
 
-          NEXT="${MAJOR}.${MINOR}.${PATCH}"
-          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+          BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+          if [ "$CHANNEL" = "beta" ]; then
+            # Find the highest beta N for this base version
+            LAST_BETA=$(git tag -l "v${BASE_VERSION}-beta.*" --sort=-v:refname | head -1 || echo "")
+            if [ -n "$LAST_BETA" ]; then
+              # Extract N from vX.Y.Z-beta.N
+              LAST_N=$(echo "$LAST_BETA" | sed 's/.*-beta\.//')
+              NEXT_N=$((LAST_N + 1))
+            else
+              NEXT_N=1
+            fi
+            NEXT_VERSION="${BASE_VERSION}-beta.${NEXT_N}"
+            TAG="v${NEXT_VERSION}"
+          else
+            NEXT_VERSION="${BASE_VERSION}"
+            TAG="v${NEXT_VERSION}"
+
+            # For stable, check this exact tag doesn't exist already
+            if git tag -l "$TAG" | grep -q .; then
+              echo "Tag $TAG already exists — skipping"
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "next=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "should_release=true" >> "$GITHUB_OUTPUT"
-          echo "Next version: v$NEXT"
+          echo "Next version: $TAG ($CHANNEL)"
 
   # ── Build all targets ─────────────────────────────────────
   build:
@@ -150,14 +202,16 @@ jobs:
 
       - name: Create git tag
         env:
-          VERSION: ${{ needs.version.outputs.next }}
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
+          git tag "$TAG"
+          git push origin "$TAG"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.version.outputs.next }}
+          tag_name: ${{ needs.version.outputs.tag }}
+          name: ${{ needs.version.outputs.tag }}
+          prerelease: ${{ needs.version.outputs.channel == 'beta' }}
           generate_release_notes: true
           files: release/*

--- a/handbook/releasing.md
+++ b/handbook/releasing.md
@@ -4,15 +4,43 @@
 
 Syfrah follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html). All crates in the workspace share a single version defined in the root `Cargo.toml` under `[workspace.package]`. Individual crates inherit the version with `version.workspace = true`.
 
-## Automated releases
+The **release workflow is the source of truth** for version numbers. It computes the next version from git tags and commit messages, then stamps it into the build via the `SYFRAH_VERSION` env var. `Cargo.toml` is not required to match — the workflow overrides the compiled-in version at build time. The version in `Cargo.toml` is only used for local `cargo build` during development.
 
-Every merge to `main` automatically produces a new GitHub Release. There is no manual version bump required.
+## Release channels
+
+Syfrah uses two release channels:
+
+| Channel | Branch | Tag format | GitHub Release | Purpose |
+|---|---|---|---|---|
+| **Beta** | `main` | `vX.Y.Z-beta.N` | Pre-release | Continuous delivery of latest changes for testing |
+| **Stable** | `release/vX.Y` | `vX.Y.Z` | Latest release | Production-ready, explicitly cut by a maintainer |
+
+### Beta (main)
+
+Every merge to `main` automatically produces a **pre-release** on GitHub. These are tagged `vX.Y.Z-beta.N` where N auto-increments. Beta releases are not installed by default — users must opt in.
+
+**How N is computed:** the workflow lists all existing `vX.Y.Z-beta.*` tags for the current minor version and picks `max(N) + 1`. If no beta tag exists yet for this minor, N starts at 1. Example: if `v0.3.0-beta.4` is the latest tag and the next push to main is a patch, the new tag is `v0.3.1-beta.1`. If it's still the same computed version, it becomes `v0.3.0-beta.5`.
+
+### Stable (release branch)
+
+When a set of changes is ready for production, a maintainer creates or updates a `release/vX.Y` branch from `main`. Pushing to this branch triggers a **stable release** tagged `vX.Y.Z`. Stable releases are what `install.sh` downloads by default.
+
+### Release flow
+
+```
+feature branch → PR → merge to main → beta vX.Y.Z-beta.N (pre-release)
+                                         ↓
+                              when ready for prod:
+                              merge main → release/vX.Y → stable vX.Y.Z
+```
+
+## Automated releases
 
 ### How it works
 
-1. **Trigger** -- the `Release` workflow runs on every push to `main` and on `workflow_dispatch`.
-2. **Loop prevention** -- if the HEAD commit message starts with `release:`, the workflow exits immediately. This prevents the version-bump commit from triggering another release.
-3. **Version calculation** -- the workflow inspects commit messages since the last git tag and determines the next version:
+1. **Trigger** -- the `Release` workflow runs on push to `main` (beta) and push to `release/v*` (stable), plus `workflow_dispatch`.
+2. **Loop prevention** -- if the HEAD commit message starts with `release:`, the workflow exits immediately.
+3. **Version calculation** -- the workflow inspects commit messages since the last git tag and determines the base version:
 
    | Commit message contains | Bump | Example |
    |--------------------------|------|---------|
@@ -20,35 +48,57 @@ Every merge to `main` automatically produces a new GitHub Release. There is no m
    | `[Feature]` or `feat:` | Minor (0.X.0) | `0.2.0 -> 0.3.0` |
    | Anything else | Patch (0.0.X) | `0.2.0 -> 0.2.1` |
 
-4. **Version validation** -- each build job verifies that the version in `Cargo.toml` matches the calculated release version. The build fails immediately if they differ.
-5. **Build** -- all four targets are built in parallel (same matrix as CI).
-6. **Release** -- binaries are packaged into `.tar.gz` archives, `SHA256SUMS.txt` is generated, a git tag `vX.Y.Z` is created, and a GitHub Release is published with all artifacts.
+   This convention relies on contributors following [Conventional Commits](https://www.conventionalcommits.org/). If nobody writes `feat:` or `breaking:`, every release is a patch bump. This is intentional — patch is the safe default. For important version bumps, the maintainer cutting the release should verify the computed version makes sense before pushing.
 
-### Keeping Cargo.toml in sync
-
-The binary version reported by `syfrah --version` comes from `CARGO_PKG_VERSION`, which is baked in at compile time from `Cargo.toml`. The release workflow validates that `Cargo.toml` matches the computed release version and **will fail the build if they differ**.
-
-**Before merging a version-bumping PR**, update `version` in `[workspace.package]` in the root `Cargo.toml` to match the version that the release workflow will compute. All crates inherit this version via `version.workspace = true`.
-
-### Influencing the version bump
-
-To trigger a minor version bump, include `feat:` or `[Feature]` in at least one commit message in your PR:
-
-```
-feat: add mesh event log
-```
-
-To trigger a major version bump, include `BREAKING` or `breaking:` in a commit message:
-
-```
-breaking: remove legacy peering protocol
-```
-
-If no commit matches these patterns, the patch version is incremented.
+4. **Channel detection**:
+   - Push to `main` → append `-beta.N` suffix (auto-incremented), mark GitHub Release as `prerelease: true`
+   - Push to `release/v*` → stable version (no suffix), mark as `latest`
+5. **Build** -- all four targets are built in parallel. The version is injected via `SYFRAH_VERSION` env var at compile time.
+6. **Release** -- binaries are packaged into `.tar.gz` archives, `SHA256SUMS.txt` is generated, a git tag is created, and a GitHub Release is published with all artifacts.
 
 ### Manual release
 
 You can also trigger a release manually via the GitHub Actions UI using `workflow_dispatch`. This uses the same auto-increment logic.
+
+## Cutting a stable release
+
+Only the project maintainer cuts stable releases. The decision is based on:
+- All planned features for the minor version are merged and tested
+- No known P0/P1 bugs open
+- E2E tests passing on main
+
+```bash
+# Create the release branch from main (first time for vX.Y)
+git checkout main && git pull
+git checkout -b release/v0.3
+git push -u origin release/v0.3
+# → triggers stable release v0.3.0
+```
+
+### Hotfixes
+
+For critical fixes on an already-released stable version:
+
+```bash
+# Cherry-pick the fix onto the release branch
+git checkout release/v0.3
+git cherry-pick <fix-commit-sha>
+git push
+# → triggers stable release v0.3.1
+```
+
+Do NOT merge all of main into a release branch for a hotfix. Cherry-pick only the specific fix to avoid shipping untested changes.
+
+### Patch releases
+
+For planned patch releases (batching several fixes):
+
+```bash
+git checkout release/v0.3
+git cherry-pick <sha1> <sha2> <sha3>
+git push
+# → triggers stable release v0.3.1 (or .2, .3, etc.)
+```
 
 ## Targets
 
@@ -66,12 +116,20 @@ Linux binaries are statically linked via musl so they run on any Linux distribut
 Each release contains:
 
 ```
-syfrah-vX.Y.Z-x86_64-unknown-linux-musl.tar.gz
-syfrah-vX.Y.Z-aarch64-unknown-linux-musl.tar.gz
-syfrah-vX.Y.Z-x86_64-apple-darwin.tar.gz
-syfrah-vX.Y.Z-aarch64-apple-darwin.tar.gz
+syfrah-vX.Y.Z-{target}.tar.gz        # stable
+syfrah-vX.Y.Z-beta.N-{target}.tar.gz # beta
 SHA256SUMS.txt
 install.sh
+```
+
+## Installing
+
+```bash
+# Stable (default)
+curl -fsSL https://get.syfrah.dev | bash
+
+# Beta
+curl -fsSL https://get.syfrah.dev | bash -s -- --beta
 ```
 
 ## Verifying a download
@@ -79,6 +137,18 @@ install.sh
 ```bash
 sha256sum -c SHA256SUMS.txt
 ```
+
+## SDK and API versioning (planned)
+
+Not yet implemented. When SDKs are published, they will follow the same beta/stable channel model:
+
+| Component | Beta (main) | Stable (release/*) | Status |
+|---|---|---|---|
+| Go SDK | `sdk/go/vX.Y.Z-beta.N` tag | `sdk/go/vX.Y.Z` tag | Not published yet |
+| Python SDK | PyPI `syfrah==X.Y.ZbN` | PyPI `syfrah==X.Y.Z` | Not published yet |
+| JS/TS SDK | npm `@syfrah/sdk@X.Y.Z-beta.N` | npm `@syfrah/sdk@X.Y.Z` | Not published yet |
+| Docker image | `ghcr.io/sacha-ops/syfrah:beta` | `ghcr.io/sacha-ops/syfrah:latest` + `:vX.Y.Z` | Not published yet |
+| OpenAPI spec | Bundled in beta release | Bundled in stable release | Generated, not versioned separately |
 
 ## crates.io (future)
 


### PR DESCRIPTION
## Summary

- Push to `main` → pre-release `vX.Y.Z-beta.N` (auto-incremented)
- Push to `release/vX.Y` → stable release `vX.Y.Z`
- Version computed dynamically from git tags + commit messages
- `Cargo.toml` no longer needs to be kept in sync — workflow injects version at build time

## Changes

- **`.github/workflows/release.yml`** — rewritten with channel detection, beta N auto-increment, `prerelease` flag
- **`handbook/releasing.md`** — full strategy doc: channels, hotfix flow, governance, SDK roadmap

## Test plan

- [ ] Push to main triggers beta pre-release
- [ ] Push to `release/v*` triggers stable release
- [ ] Beta N increments correctly
- [ ] `prerelease: true` set on beta GitHub Releases