### PR TITLE
docs: add beta install instructions to README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ cargo build --release
 
 Requires Rust stable (version pinned in [rust-toolchain.toml](rust-toolchain.toml)).
 
+### Beta channel
+
+To install the latest beta (built from `main`, pre-release, may contain breaking changes):
+
+```bash
+curl -fsSL https://github.com/sifrah/syfrah/releases/latest/download/install.sh | sh -s -- --beta
+syfrah --version   # verify the installed version
+```
+
+See [handbook/releasing.md](handbook/releasing.md) for the full release strategy.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a "Beta channel" subsection under Install in the README
- Shows the `--beta` flag for the install script and how to verify the installed version
- Links to `handbook/releasing.md` for the full release strategy

Closes #445

## Test plan

- [ ] Verify the new section renders correctly on GitHub
- [ ] Confirm the link to `handbook/releasing.md` resolves