### PR TITLE
docs: replace Firecracker with libkrun

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The CLI binary in `bin/syfrah` composes these crates and contains no logic of it
 The layers below are architecturally designed with concept documentation but have no implementation yet. Each has a README in its `layers/` directory describing the planned design.
 
 - **Forge** — per-node REST API for managing local resources
-- **Compute** — Firecracker microVMs
+- **Compute** — KVM-based microVMs via libkrun
 - **Storage** — S3-backed block devices (ZeroFS)
 - **Overlay** — VXLAN, VPCs, security groups, private DNS
 - **Control Plane** — Raft consensus + SWIM gossip, embedded on every node

--- a/handbook/ARCHITECTURE.md
+++ b/handbook/ARCHITECTURE.md
@@ -20,13 +20,13 @@ This document describes the global architecture. Each layer has its own `README.
 
 These are deliberate choices, not missing features:
 
-- **No live migration.** Firecracker does not support it. VM migration is stop → move volume (S3-backed, no data copy) → start. Downtime is ~5-30 seconds.
+- **No live migration.** libkrun does not support it. VM migration is stop → move volume (S3-backed, no data copy) → start. Downtime is ~5-30 seconds.
 - **No custom IAM policy language.** 4 built-in roles, per-org/project scoping. No JSON policies, no policy simulator, no condition keys.
 - **No L2 flood-and-learn networking.** FDB entries are statically populated by the control plane. ARP is proxied. Zero broadcast traffic in steady state.
 - **No distributed storage cluster.** No Ceph, no GlusterFS. Storage durability is delegated to the provider's S3. ZeroFS handles caching and block device abstraction.
 - **No hyperscaler-style AZ guarantees.** Zones and regions are operator-defined labels. The platform does not enforce physical isolation between AZs — the operator's choice of providers and locations determines actual fault domain boundaries.
-- **No Windows guests.** Firecracker boots Linux kernels directly (ELF), with no BIOS/UEFI. Windows requires UEFI, which Firecracker does not provide. The only non-Linux guest supported is OSv (a unikernel).
-- **No GPU passthrough in v1.** Firecracker has no PCI passthrough by design (minimal attack surface). GPU workloads would require Cloud Hypervisor or QEMU with VFIO — a future consideration, not a current goal. This is the same split used by Koyeb and AWS (Firecracker for CPU, different stack for GPU).
+- **No Windows guests.** libkrun boots Linux kernels directly, with no BIOS/UEFI. Windows requires UEFI, which libkrun does not provide.
+- **No GPU passthrough in v1.** libkrun has no PCI passthrough support. GPU workloads would require Cloud Hypervisor or QEMU with VFIO — a future consideration, not a current goal.
 
 ## The stack
 
@@ -62,7 +62,7 @@ These are deliberate choices, not missing features:
     │          │                  │                               │
     │  Compute │     Overlay      │        Storage                │
     │          │                  │                               │
-    │  Firecracker   VXLAN/VPC    │  ZeroFS + S3                  │
+    │  libkrun       VXLAN/VPC    │  ZeroFS + S3                  │
     │  microVMs      Security     │  Block devices backed         │
     │  <125ms boot   groups       │  by object storage            │
     │  ~5MB overhead  Private DNS │  Local SSD cache              │
@@ -71,7 +71,7 @@ These are deliberate choices, not missing features:
     │                                                             │
     │   Forge                                                     │
     │   Per-node REST API on the fabric                           │
-    │   Manages Firecracker, bridges, VXLAN, ZeroFS, nftables    │
+    │   Manages libkrun VMs, bridges, VXLAN, ZeroFS, nftables    │
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
@@ -105,7 +105,7 @@ The **fabric** is a WireGuard full-mesh connecting all nodes. It replaces the ph
 The **forge** runs on every node. It exposes a REST API bound exclusively to the fabric interface (`syfrah0`), invisible from the internet.
 
 The forge is the bridge between the control plane and the local hardware. It manages:
-- Firecracker processes (VM lifecycle)
+- libkrun VM processes (VM lifecycle)
 - Linux bridges and TAP devices (overlay networking)
 - VXLAN interfaces (VPC isolation)
 - ZeroFS volumes (block storage)
@@ -115,15 +115,13 @@ The forge is intentionally generic: it manages compute, storage, and networking 
 
 **Concept doc:** [`layers/forge/README.md`](../layers/forge/README.md)
 
-### Compute — Firecracker microVMs
+### Compute — libkrun microVMs
 
-Every workload runs as a **Firecracker microVM**. Firecracker provides hardware-level isolation via KVM with minimal overhead (~5 MB per VM, <125ms boot).
+Every workload runs as a **KVM-based microVM via [libkrun](https://github.com/containers/libkrun/)**. libkrun is a library that embeds directly into the host process, providing hardware-level isolation via KVM with minimal overhead (~5 MB per VM, <125ms boot).
 
-- One Firecracker process per VM (3 threads: API, VMM, vCPU)
-- 5 emulated devices only (virtio-net, virtio-block, virtio-vsock, serial, i8042)
-- Jailer for OS-level isolation (namespaces, chroot, cgroups, seccomp)
+- libkrun embeds into the forge process — no separate daemon, no API socket, no jailer
+- virtio devices: virtio-fs (filesystem passthrough), virtio-vsock (host-guest communication), virtio-net, virtio-block
 - Shared read-only kernel across all VMs
-- Snapshots with lazy memory restore (<30ms)
 - VM migration via stop → move volume → start (no live migration)
 
 **Concept doc:** [`layers/compute/README.md`](../layers/compute/README.md)
@@ -134,7 +132,7 @@ Block storage is backed by **S3-compatible object storage** (from the same provi
 
 - Data is chunked (256KB), compressed (LZ4), and encrypted (XChaCha20-Poly1305)
 - Local SSD + memory cache absorbs >95% of I/O
-- NBD (Network Block Device) endpoints connect directly to Firecracker's virtio-block
+- NBD (Network Block Device) endpoints connect directly to libkrun's virtio-block
 - Volumes can move between nodes without copying data (S3 is the source of truth)
 - Snapshots are lightweight (no data copy, just SST file metadata)
 
@@ -258,7 +256,7 @@ Regions and availability zones are logical labels on nodes. They represent where
        ├── Creates TAP device, attaches to VPC bridge
        ├── Adds VXLAN FDB entries on remote nodes (via gossip)
        ├── Creates ZeroFS NBD volume (backed by S3)
-       ├── Starts Firecracker process (jailer + seccomp)
+       ├── Starts libkrun microVM (embedded in the forge process)
        ├── Configures VM: kernel, rootfs, data volume, network
        └── Applies security group rules (nftables)
          │
@@ -304,7 +302,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 ```
     VM writes to /dev/vdb
          │
-    Firecracker virtio-block
+    libkrun virtio-block
          │
     ZeroFS NBD device
          │
@@ -325,7 +323,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 
     Dedicated servers                Fabric (WireGuard mesh)
     (OVH, Hetzner, Scaleway,        Forge (per-node control)
-     or any provider)                Compute (Firecracker)
+     or any provider)                Compute (libkrun)
                                      Overlay (VXLAN, VPC, DNS)
     S3 bucket                        Storage (ZeroFS)
     (same provider or any            Control plane (Raft + gossip)
@@ -345,7 +343,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 | Gossip | `foca` | Transport-agnostic SWIM, works over WireGuard |
 | State store | `redb` | Embedded KV, pure Rust, ACID, no C deps |
 | API server | `axum` | HTTP framework, tokio-native |
-| Compute | Firecracker | MicroVMs, <125ms boot, ~5MB overhead, Apache 2.0 |
+| Compute | [libkrun](https://github.com/containers/libkrun/) | KVM-based microVM library, embeds into host process, virtio-fs/vsock, Apache 2.0 |
 | Storage engine | ZeroFS | S3-backed block devices, Rust, local cache |
 | Overlay encap | VXLAN | Standard, kernel-native, 16M VNIs |
 | Firewall | nftables | Per-VM security groups, stateful, conntrack |
@@ -367,7 +365,7 @@ The repo is organized by architectural layer. Each layer is a self-contained fol
     │   │                         Implemented. The first layer.
     │   │
     │   ├── forge/                Per-node debug/ops (planned)
-    │   ├── compute/              Firecracker microVMs (planned)
+    │   ├── compute/              libkrun microVMs (planned)
     │   ├── storage/              ZeroFS + S3 block storage (planned)
     │   ├── overlay/              VXLAN, VPC, security groups (planned)
     │   ├── controlplane/         Raft + gossip + scheduler (planned)
@@ -403,7 +401,7 @@ The architecture assumes a hostile operational environment. Nodes are rented mac
 
 - **The Raft leader may change during an operation.** Leader election takes 1-5 seconds. In-flight writes are retried by the client. The new leader replays uncommitted entries. Operations are designed to be re-entrant.
 
-- **Forge actions must be idempotent.** Creating a bridge that already exists is a no-op. Starting a Firecracker process that is already running is a no-op. The reconciliation loop can run any number of times and produce the same result.
+- **Forge actions must be idempotent.** Creating a bridge that already exists is a no-op. Starting a libkrun VM that is already running is a no-op. The reconciliation loop can run any number of times and produce the same result.
 
 - **Derived state must be rebuildable from scratch.** FDB entries, nftables rules, DNS zone files, VXLAN bridges — all are derived from Raft state. If a node loses all derived state (reboot, crash), the next reconciliation loop rebuilds everything from Raft.
 

--- a/handbook/cli.md
+++ b/handbook/cli.md
@@ -56,7 +56,7 @@ syfrah
 │
 ├── forge                         Per-node debug and ops (planned)
 │   ├── status                    This node's health and resources
-│   ├── vms                       Firecracker processes on this node
+│   ├── vms                       libkrun microVM processes on this node
 │   ├── bridges                   Active bridges, VXLAN, TAP devices
 │   ├── volumes                   Mounted ZeroFS volumes, cache stats
 │   ├── nftables                  Active security group rules
@@ -384,7 +384,7 @@ vm-g7h8i9      db-primary 4     8192     running   14780   5d 12h
 vm-j0k1l2      worker-1   1     1024     stopped   -       -
 ```
 
-Shows actual Firecracker processes, not Raft desired state.
+Shows actual libkrun microVM processes, not Raft desired state.
 
 ### `syfrah forge bridges`
 

--- a/handbook/repository.md
+++ b/handbook/repository.md
@@ -278,7 +278,7 @@ syfrah/
 │   │           └── drop.rs          syfrah state drop
 │   │
 │   ├── forge/                       Per-node control (planned, README only)
-│   ├── compute/                     Firecracker microVMs (planned, README only)
+│   ├── compute/                     libkrun microVMs (planned, README only)
 │   ├── storage/                     ZeroFS + S3 (planned, README only)
 │   ├── overlay/                     VXLAN, VPC, SG, DNS (planned, README only)
 │   ├── controlplane/                Raft + gossip (planned, README only)

--- a/handbook/state-and-reconciliation.md
+++ b/handbook/state-and-reconciliation.md
@@ -32,7 +32,7 @@ Every piece of state in Syfrah has exactly one **source of truth**. Some state i
 | VM desired spec (vCPU, memory, image, network) | Tenant API → Raft | Raft log | What the user asked for. Immutable until user updates it. |
 | VM scheduling decision (which node) | Scheduler → Raft | Raft log | Authoritative placement. One node per VM. |
 | VM runtime status (running, stopped, error) | Forge on the hosting node | Gossip | Observed reality. May lag behind desired state. |
-| VM Firecracker process state | Forge (local) | Not persisted (reconstructed on start) | The forge recreates from desired spec on restart. |
+| VM libkrun process state | Forge (local) | Not persisted (reconstructed on start) | The forge recreates from desired spec on restart. |
 | Kernel images | Platform-provided (local filesystem) | Each node's disk | Shared read-only across VMs. Not in Raft. |
 | Rootfs images | Platform-provided (local or S3) | Each node's disk or S3 | Pulled on demand. Not in Raft. |
 
@@ -141,7 +141,7 @@ Each node runs a **reconciliation loop** in the forge. It continuously compares 
     ┌────────────────────────────────────┐
     │        Local reality (observed)     │
     │                                    │
-    │  Firecracker processes, bridges,   │
+    │  libkrun VM processes, bridges,     │
     │  TAP devices, nftables rules,      │
     │  ZeroFS volumes, DNS zone files    │
     └────────────────────────────────────┘
@@ -162,7 +162,7 @@ The forge reads the subset of Raft state relevant to this node:
 **Step 2 — Read actual state from local system**
 
 The forge inspects what actually exists:
-- Running Firecracker processes (ps / PID files)
+- Running libkrun VM processes (ps / PID files)
 - Linux bridges and VXLAN interfaces (`ip link`)
 - TAP devices (`ip link`)
 - nftables rules (`nft list ruleset`)
@@ -173,19 +173,19 @@ The forge inspects what actually exists:
 
 | Situation | Action |
 |---|---|
-| VM in Raft but no Firecracker process | Create TAP, attach to bridge, start Firecracker |
-| Firecracker running but VM not in Raft | Stop Firecracker, cleanup TAP |
+| VM in Raft but no libkrun process | Create TAP, attach to bridge, start libkrun VM |
+| libkrun VM running but VM not in Raft | Stop libkrun VM, cleanup TAP |
 | VPC in Raft but no bridge on this node | Create VXLAN interface + bridge |
 | Bridge exists but VPC removed from Raft | Delete bridge + VXLAN interface |
 | Security group rules changed in Raft | Recompute and atomically replace nftables rules |
 | FDB entries stale (VM moved to another node) | Remove old FDB, add new |
-| Volume attached in Raft but not mounted | Connect ZeroFS NBD, attach to Firecracker |
+| Volume attached in Raft but not mounted | Connect ZeroFS NBD, attach to libkrun VM |
 | DNS record in Raft but not in zone file | Regenerate zone file, reload CoreDNS |
 
 **Step 4 — Report actual state**
 
 After reconciliation, the forge gossips the actual state of each resource:
-- VM `web-1` is `Running` (or `Error` if Firecracker crashed)
+- VM `web-1` is `Running` (or `Error` if the libkrun VM crashed)
 - Node has 24 vCPU free, 48 GB RAM free
 - Health: `Up`
 
@@ -229,10 +229,10 @@ Every resource type follows a phase model. Phases are linear — a resource move
 |---|---|---|
 | **Pending** | Raft (on create) | VM definition exists. Waiting for scheduler. |
 | **Scheduled** | Raft (scheduler) | Scheduler picked a node. Waiting for forge to act. |
-| **Provisioning** | Forge (gossip) | Forge is creating TAP, bridge, volume, starting Firecracker. |
-| **Running** | Forge (gossip) | Firecracker process is alive. VM is operational. |
+| **Provisioning** | Forge (gossip) | Forge is creating TAP, bridge, volume, starting libkrun VM. |
+| **Running** | Forge (gossip) | libkrun VM process is alive. VM is operational. |
 | **Stopping** | Raft (on stop request) | User requested stop. Forge sending shutdown signal. |
-| **Stopped** | Forge (gossip) | Firecracker process exited cleanly. Resources still allocated. |
+| **Stopped** | Forge (gossip) | libkrun VM process exited cleanly. Resources still allocated. |
 | **Deleting** | Raft (on delete request) | User requested deletion. Forge cleaning up. |
 | **Deleted** | Raft (after cleanup confirmed) | All resources released. VM record can be garbage collected. |
 | **Failed** | Forge (gossip) | Something went wrong. Error message attached. |
@@ -251,8 +251,8 @@ Every resource type follows a phase model. Phases are linear — a resource move
 |---|---|---|
 | **Pending** | Raft (on create) | Volume definition exists. ZeroFS file not yet created. |
 | **Available** | Forge (gossip) | ZeroFS NBD file created on S3. Not attached to any VM. |
-| **Attaching** | Raft (on attach request) | Volume being connected to a VM's Firecracker process. |
-| **Attached** | Forge (gossip) | NBD device connected to Firecracker. VM can read/write. |
+| **Attaching** | Raft (on attach request) | Volume being connected to a VM's libkrun process. |
+| **Attached** | Forge (gossip) | NBD device connected to libkrun VM. VM can read/write. |
 | **Detaching** | Raft (on detach request) | Volume being disconnected. ZeroFS flushing cache. |
 | **Deleting** | Raft (on delete request) | Volume being removed from S3. |
 | **Deleted** | Raft (after cleanup) | S3 data removed. Record can be garbage collected. |
@@ -342,14 +342,14 @@ The phases are the **language** the reconciliation loop speaks. The loop's job i
 
     Forge on Node B sees:
       vm-web-1: phase = Scheduled (just assigned to this node)
-      No local Firecracker process exists.
+      No local libkrun VM process exists.
 
     Reconciliation:
       1. Phase is Scheduled → target is Running
-      2. No Firecracker process → need to provision
+      2. No libkrun VM process → need to provision
       3. Create TAP, bridge (if needed), volume
-      4. Start Firecracker → set phase to Provisioning (gossip)
-      5. Firecracker boots → set phase to Running (gossip)
+      4. Start libkrun VM → set phase to Provisioning (gossip)
+      5. libkrun VM boots → set phase to Running (gossip)
       6. Done. Next loop iteration: Running == Running, no action.
 ```
 

--- a/handbook/testing.md
+++ b/handbook/testing.md
@@ -313,7 +313,7 @@ The `just e2e-local` command uses `dev/e2e.sh`, which volume-mounts a locally-co
 | **core** | Types, validation, crypto, addressing | Serialization roundtrips | -- |
 | **fabric** | Key generation, address derivation | WireGuard interface (root), peering protocol, state persistence | Multi-node mesh, connectivity, rejoin, secret rotation, stress tests |
 | **state** | -- | -- | `syfrah state list/get/drop` |
-| **compute** (planned) | VM spec validation | Firecracker process lifecycle (root) | VM create/start/stop/delete |
+| **compute** (planned) | VM spec validation | libkrun VM lifecycle (root) | VM create/start/stop/delete |
 | **storage** (planned) | Volume spec validation | ZeroFS NBD management (root) | Volume attach, detach, migrate |
 | **overlay** (planned) | IPAM allocation, MAC derivation | Bridge/VXLAN creation (root), nftables rules (root) | VPC isolation, cross-node connectivity |
 | **controlplane** (planned) | Scheduler scoring, state machine | Raft consensus (multi-instance) | Leader election, failover |

--- a/layers/compute/README.md
+++ b/layers/compute/README.md
@@ -2,9 +2,9 @@
 
 ## What is the compute layer?
 
-The compute layer runs tenant workloads. Every VM, every managed database, every load balancer ultimately runs as a **Firecracker microVM** on a node in the fabric.
+The compute layer runs tenant workloads. Every VM, every managed database, every load balancer ultimately runs as a **KVM-based microVM via [libkrun](https://github.com/containers/libkrun/)** on a node in the fabric.
 
-Firecracker is an open-source Virtual Machine Monitor (VMM) written in Rust, created by AWS. It powers AWS Lambda (trillions of requests/month) and AWS Fargate. It provides hardware-level isolation via KVM with minimal overhead.
+libkrun is an open-source library (maintained by the containers community, with Red Hat backing) that allows running workloads inside lightweight microVMs using KVM. Unlike standalone VMMs, libkrun embeds directly into the host process — no separate daemon, no API socket, no jailer. It provides hardware-level isolation via KVM with minimal overhead.
 
 ```
     ┌──────────────────────────────────────────────────────┐
@@ -16,7 +16,7 @@ Firecracker is an open-source Virtual Machine Monitor (VMM) written in Rust, cre
     │  │ 4 GB   │  │ 1 GB   │  │ 8 GB   │  │ 512 MB │     │
     │  └───┬────┘  └───┬────┘  └───┬────┘  └───┬────┘     │
     │      │           │           │           │           │
-    │  Each VM is a separate Firecracker process.           │
+    │  Each VM is a separate libkrun microVM instance.       │
     │  Hardware isolation via KVM.                          │
     │  ~5 MB overhead per VM.                               │
     │                                                       │
@@ -27,44 +27,49 @@ Firecracker is an open-source Virtual Machine Monitor (VMM) written in Rust, cre
     └──────────────────────────────────────────────────────┘
 ```
 
-## Why Firecracker
+## Why libkrun
 
-| | **Firecracker** | **QEMU** | **Cloud Hypervisor** |
-|---|---|---|---|
-| **Overhead per VM** | ~5 MB | ~130 MB | ~13 MB |
-| **Boot time** | <125 ms | Seconds | ~200 ms |
-| **Snapshot restore** | <30 ms | Seconds | Supported |
-| **Device model** | 5 devices (minimal) | Hundreds (full PC) | Moderate |
-| **Attack surface** | Minimal | Large | Moderate |
-| **Language** | Rust | C | Rust |
-| **GPU passthrough** | No | Yes | Yes |
-| **Live migration** | No | Yes | Yes |
-| **License** | Apache 2.0 | GPL 2.0 | Apache 2.0 |
+| | **libkrun** | **QEMU** | **Cloud Hypervisor** | **Firecracker** |
+|---|---|---|---|---|
+| **Architecture** | Library (embeds in host) | Standalone process | Standalone process | Standalone process + jailer |
+| **Overhead per VM** | ~5 MB | ~130 MB | ~13 MB | ~5 MB |
+| **Boot time** | <125 ms | Seconds | ~200 ms | <125 ms |
+| **Device model** | Minimal (virtio only) | Hundreds (full PC) | Moderate | 5 devices |
+| **Attack surface** | Minimal | Large | Moderate | Minimal |
+| **Language** | Rust + C | C | Rust | Rust |
+| **virtio-fs** | Yes | Yes | Yes | No |
+| **GPU passthrough** | No | Yes | Yes | No |
+| **Live migration** | No | Yes | Yes | No |
+| **License** | Apache 2.0 | GPL 2.0 | Apache 2.0 | Apache 2.0 |
 
-Firecracker's trade-off is clear: **maximum density and security at the cost of flexibility**. No GPU, no live migration, no Windows guests. For a cloud platform running Linux VMs, databases, and load balancers on dedicated servers, these trade-offs are acceptable.
+libkrun's trade-off is clear: **maximum density, security, and integration simplicity at the cost of flexibility**. No GPU, no live migration, no Windows guests. For a cloud platform running Linux VMs, databases, and load balancers on dedicated servers, these trade-offs are acceptable.
 
-The minimal device model (5 devices instead of hundreds) means fewer lines of code between the guest and the host — a smaller attack surface for multi-tenant workloads.
+Key advantages over standalone VMMs: libkrun embeds directly into the forge process — no separate daemon to manage, no API socket to configure, no jailer to set up. The forge calls libkrun as a library to create and manage VMs. This simplifies the compute stack and reduces the operational surface area.
 
 ## Architecture of a microVM
 
-Each Firecracker microVM is a single Linux process with three thread types:
+Each libkrun microVM runs as threads within the forge process:
 
 ```
-    Firecracker process (one per VM)
+    Forge process (hosts all VMs on this node)
     ┌──────────────────────────────────────────────┐
     │                                              │
-    │  API thread          ← REST API over Unix    │
-    │  (configuration,       domain socket         │
-    │   lifecycle control)                         │
+    │  libkrun VM instance (one per VM)            │
+    │  ┌────────────────────────────────────────┐  │
+    │  │                                        │  │
+    │  │  VMM thread        ← device emulation  │  │
+    │  │  (virtio-net,        and machine model │  │
+    │  │   virtio-block,                        │  │
+    │  │   virtio-vsock,                        │  │
+    │  │   virtio-fs)                           │  │
+    │  │                                        │  │
+    │  │  vCPU thread(s)    ← one per vCPU,     │  │
+    │  │  (KVM_RUN loop)      runs guest code   │  │
+    │  │                                        │  │
+    │  └────────────────────────────────────────┘  │
     │                                              │
-    │  VMM thread          ← device emulation      │
-    │  (virtio-net,          and machine model     │
-    │   virtio-block,                              │
-    │   virtio-vsock,                              │
-    │   serial console)                            │
-    │                                              │
-    │  vCPU thread(s)      ← one per vCPU,         │
-    │  (KVM_RUN loop)        runs guest code       │
+    │  Configuration is done via libkrun's C API   │
+    │  directly — no socket, no REST, no IPC.      │
     │                                              │
     └──────────────────────────────────────────────┘
 ```
@@ -88,22 +93,21 @@ When the forge creates a VM, this is what happens:
          │
     2. Create/attach NBD volume (storage, via ZeroFS)
          │
-    3. Start Firecracker process with jailer
+    3. Configure libkrun VM via library API:
+         ├── krun_set_vm_config()    → vCPU count, memory
+         ├── krun_set_root()         → root filesystem
+         ├── krun_set_mapped_volumes() → data volume (ZeroFS NBD)
+         ├── krun_set_port_map()     → network configuration
+         └── krun_start_enter()      → start the VM
          │
-    4. Configure via Unix socket API:
-         ├── PUT /machine-config     → vCPU count, memory
-         ├── PUT /boot-source        → kernel path, boot args
-         ├── PUT /drives/rootfs      → root filesystem image
-         ├── PUT /drives/data        → data volume (ZeroFS NBD)
-         ├── PUT /network-interfaces → TAP device
-         └── PUT /actions            → InstanceStart
+    4. VM boots in <125 ms
          │
-    5. VM boots in <125 ms
-         │
-    6. Guest init runs (cloud-init, agent, or application)
+    5. Guest init runs (cloud-init, agent, or application)
 
     Total time from API call to running VM: ~200-500 ms
 ```
+
+No jailer, no Unix socket, no separate process. The forge calls libkrun's C API directly to configure and start VMs. This eliminates the complexity of managing external VMM processes.
 
 ## Networking
 
@@ -137,14 +141,12 @@ The VM sees a standard network interface (`eth0`). The guest configures it with 
 
 ### Rate limiting
 
-Firecracker supports per-VM rate limiting on both network and block devices:
+Rate limiting is applied per-VM on both network and block devices:
 
-- **Network**: bandwidth (bytes/sec) and packet rate (ops/sec), configurable for ingress and egress
-- **Block I/O**: bandwidth (bytes/sec) and IOPS (ops/sec)
+- **Network**: bandwidth (bytes/sec) and packet rate (ops/sec), configurable for ingress and egress via tc/nftables on the host
+- **Block I/O**: bandwidth (bytes/sec) and IOPS (ops/sec) via cgroups v2
 
-Rate limits are applied via the Firecracker API and can be updated at runtime without restarting the VM.
-
-CPU limiting is handled by **cgroups** configured by the jailer.
+CPU limiting is handled by **cgroups v2** configured by the forge.
 
 ## Storage integration
 
@@ -160,17 +162,17 @@ A read-only (or copy-on-write) ext4 image containing the base OS. The platform p
 | `alpine-3.20` | Alpine Linux | ~50 MB |
 | `debian-12` | Debian 12 minimal | ~300 MB |
 
-Kernels are shared across all VMs. A single `vmlinux` binary on disk is referenced by every Firecracker instance — read-only, no duplication.
+Kernels are shared across all VMs. A single `vmlinux` binary on disk is referenced by every libkrun instance — read-only, no duplication.
 
 ### Data volumes (via ZeroFS)
 
 Persistent storage backed by S3. See [storage.md](storage.md) for the full storage design.
 
-Firecracker's `virtio-block` connects directly to ZeroFS's NBD devices — standard Linux block device semantics, no custom integration:
+libkrun's `virtio-block` connects directly to ZeroFS's NBD devices — standard Linux block device semantics, no custom integration:
 
 ```
-    Guest                 Firecracker              Host                  Durable
-    ─────                 ───────────              ────                  ───────
+    Guest                 libkrun                  Host                  Durable
+    ─────                 ───────                  ────                  ───────
 
     /dev/vda ──────► virtio-block ──────► rootfs.ext4            Local image file
     (root fs)             drive:rootfs    (read-only or CoW)
@@ -185,7 +187,7 @@ The write path through the full stack:
 
 ```
     1. VM writes to /dev/vdb
-    2. Firecracker virtio-block passes write to /dev/nbd0
+    2. libkrun virtio-block passes write to /dev/nbd0
     3. ZeroFS buffers in memory (microseconds)
     4. On fsync: ZeroFS WAL flush to S3 (~10-50ms)
     5. Background: ZeroFS compacts and flushes SST chunks to S3
@@ -195,7 +197,7 @@ The read path:
 
 ```
     1. VM reads from /dev/vdb
-    2. Firecracker virtio-block reads from /dev/nbd0
+    2. libkrun virtio-block reads from /dev/nbd0
     3. ZeroFS checks memory cache → hit? return (microseconds)
     4. ZeroFS checks SSD cache    → hit? return (~100μs)
     5. ZeroFS fetches from S3     → miss? fetch, cache, return (~10-100ms)
@@ -212,78 +214,61 @@ For most workloads, the cache absorbs >95% of I/O. The S3 latency only matters f
 | Large sequential reads (analytics) | Cold data from S3 | Limited by S3 throughput |
 | Boot + init | Rootfs is local, no S3 | <125ms boot, instant rootfs reads |
 
-Firecracker's per-drive rate limiting (bandwidth + IOPS) is applied **before** the NBD device, so it caps the VM's I/O regardless of whether the data comes from cache or S3.
+Per-drive rate limiting (bandwidth + IOPS via cgroups v2) is applied **before** the NBD device, so it caps the VM's I/O regardless of whether the data comes from cache or S3.
 
 ## Security
 
-Firecracker's security model is layered:
+libkrun's security model is layered:
 
 ### Layer 1 — Hardware isolation (KVM)
 
 Each VM runs in its own KVM virtual machine. The guest kernel has no direct access to host memory, devices, or other VMs. This is the same isolation used by all major cloud providers.
 
-### Layer 2 — The jailer
+### Layer 2 — Process-level isolation (cgroups + namespaces)
 
-The jailer is a companion binary that wraps each Firecracker process with OS-level isolation:
+The forge configures OS-level isolation for each VM:
 
-```
-    jailer
-    ├── Creates new namespaces (mount, PID, network, IPC, UTS)
-    ├── Sets up a chroot jail (minimal filesystem)
-    ├── Configures cgroups (CPU, memory, I/O limits)
-    ├── Drops privileges to an unprivileged user
-    └── Executes Firecracker inside the jail
-```
+- **cgroups v2**: CPU, memory, and I/O limits per VM
+- **namespaces**: mount, PID, network isolation where applicable
+- **seccomp**: syscall filtering to restrict what the host process can do
 
-Even if an attacker escapes the VM (breaks out of KVM), they land inside an isolated namespace with no privileges, no filesystem access, and a restrictive seccomp filter.
+Since libkrun embeds into the forge process, there is no separate jailer binary. Instead, the forge itself manages the isolation boundaries using standard Linux primitives.
 
 ### Layer 3 — Seccomp (syscall filtering)
 
-A strict allowlist of system calls is enforced per-thread. Any syscall not on the list kills the process immediately. This limits what a compromised Firecracker process can do, even after a KVM escape.
+A strict allowlist of system calls is enforced. Any syscall not on the list kills the process immediately. This limits what can happen even after a KVM escape.
 
 ### Layer 4 — Minimal attack surface
 
-Firecracker emulates only 5 devices. No PCI bus, no USB, no ACPI, no legacy hardware. Every device that doesn't exist is attack surface that doesn't exist.
+libkrun emulates only virtio devices. No PCI bus, no USB, no ACPI, no legacy hardware. Every device that doesn't exist is attack surface that doesn't exist.
 
 ## VM lifecycle
 
 | Operation | How | Time |
 |---|---|---|
-| **Create** | Forge calls Firecracker API via Unix socket | ~50 ms |
-| **Start** | `PUT /actions` → InstanceStart | <125 ms |
-| **Stop** | `PUT /actions` → SendCtrlAltDel (graceful) or kill process (force) | Instant |
+| **Create** | Forge calls libkrun API to configure VM | ~50 ms |
+| **Start** | `krun_start_enter()` | <125 ms |
+| **Stop** | Graceful shutdown signal or force stop | Instant |
 | **Reboot** | Stop + Start | <250 ms |
-| **Delete** | Kill process, cleanup TAP device, release NBD volume | Instant |
-| **Snapshot** | `PUT /snapshot/create` → saves memory + device state to files | Seconds (depends on memory size) |
-| **Restore** | Start new Firecracker, `PUT /snapshot/load` → lazy memory load | <30 ms |
-
-### Snapshots
-
-Firecracker can snapshot a running VM's entire state (memory + device state) to disk. This enables:
-
-- **Fast restore**: boot a VM from a snapshot in <30ms instead of cold-booting in 125ms
-- **Clone**: create multiple identical VMs from one snapshot (with care — see limitations)
-- **Backup**: save VM state for disaster recovery
-
-Memory is restored lazily — pages are loaded from the snapshot file on demand as the guest accesses them. This means the VM resumes almost instantly and pages fault in gradually.
+| **Delete** | Stop VM, cleanup TAP device, release NBD volume | Instant |
 
 ### VM migration between nodes
 
-Firecracker does not support live migration. Syfrah compensates with the storage design: since data volumes are backed by S3 (via ZeroFS), migration is a stop-move-start sequence with no data copy.
+libkrun does not support live migration. Syfrah compensates with the storage design: since data volumes are backed by S3 (via ZeroFS), migration is a stop-move-start sequence with no data copy.
 
 ```
     Node A                                  Node B
     ──────                                  ──────
 
     1. Stop VM
-       ├── Firecracker process killed
+       ├── libkrun VM stopped
        └── ZeroFS flushes cache to S3
                                             2. Attach volume
                                                └── ZeroFS connects NBD
                                                    to same S3 data
 
                                             3. Start VM
-                                               ├── Firecracker boots (<125ms)
+                                               ├── libkrun boots (<125ms)
                                                └── Cache warms up gradually
                                                    (first reads hit S3,
                                                     then cached locally)
@@ -293,14 +278,14 @@ Firecracker does not support live migration. Syfrah compensates with the storage
 ```
 
 This is possible because **compute state and storage state are separated**:
-- Firecracker manages compute (CPU, memory, devices) — ephemeral, recreated on boot
+- libkrun manages compute (CPU, memory, devices) — ephemeral, recreated on boot
 - ZeroFS manages storage (volumes) — durable in S3, accessible from any node
 
 The only cost of migration is **cache warmup** on the new node. Active working set data loads progressively from S3 into the local SSD cache over the first minutes of operation.
 
 ## Guest-host communication (vsock)
 
-Firecracker provides `virtio-vsock` for communication between the VM and the host without using the network:
+libkrun provides `virtio-vsock` for communication between the VM and the host without using the network:
 
 ```
     Host                              Guest
@@ -328,7 +313,7 @@ Vsock avoids the complexity of setting up a metadata HTTP endpoint on a link-loc
 | **No memory/CPU hotplug** | Cannot resize a running VM | Stop → reconfigure → start |
 | **No nested virtualization** | Cannot run VMs inside VMs | Not needed for target use cases |
 
-The most impactful limitation is **no live migration**. Syfrah mitigates this through the storage design: since volumes are backed by S3 (via ZeroFS), moving a VM between nodes only requires stopping the VM, detaching the volume, reattaching on the new node, and starting. The data doesn't need to be copied — just the cache needs to warm up.
+The most impactful limitation is **no live migration**. Syfrah mitigates this through the storage design: since volumes are backed by S3 (via ZeroFS), moving a VM between nodes only requires stopping the VM, detaching the volume, reattaching on the new node, and starting. The data does not need to be copied — just the cache needs to warm up.
 
 ## Relationship to other concepts
 
@@ -341,7 +326,7 @@ The most impactful limitation is **no live migration**. Syfrah mitigates this th
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Compute         ◄── this document                  │
-    │   Firecracker microVMs on each node                  │
+    │   libkrun microVMs on each node                      │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │
@@ -351,7 +336,7 @@ The most impactful limitation is **no live migration**. Syfrah mitigates this th
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Forge           ◄── forge.md         │
-    │   Manages Firecracker lifecycle on each node         │
+    │   Manages libkrun VM lifecycle on each node           │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │

--- a/layers/forge/README.md
+++ b/layers/forge/README.md
@@ -16,7 +16,7 @@ The forge is the bridge between the control plane and the local compute stack. I
     │          http://[fd12:3456:...:node]:7100/               │
     ├─────────────────────────────────────────────────────────┤
     │                  Internal Compute Stack                   │
-    │       Firecracker  │  Networking  │  Storage             │
+    │       libkrun      │  Networking  │  Storage             │
     │       (microVMs)   │  (bridges,   │  (volumes,           │
     │                    │   VXLAN)     │   snapshots)         │
     ├─────────────────────────────────────────────────────────┤
@@ -86,7 +86,7 @@ Each node runs three layers, from bottom to top:
     │  ┌────────────┐ ┌───────────┐ ┌──────────────┐  │
     │  │ Compute    │ │ Network   │ │ Storage      │  │
     │  │            │ │           │ │              │  │
-    │  │ Firecracker│ │ bridges   │ │ local disks  │  │
+    │  │ libkrun    │ │ bridges   │ │ local disks  │  │
     │  │ microVMs   │ │ tap devs  │ │ volumes      │  │
     │  │ lifecycle  │ │ VXLAN     │ │ snapshots    │  │
     │  └────────────┘ └───────────┘ └──────────────┘  │
@@ -98,7 +98,7 @@ Each node runs three layers, from bottom to top:
 
 **Forge API** — The REST layer. Receives requests from the control plane (or from operators via curl). Translates API calls into operations on the internal compute stack.
 
-**Internal Compute Stack** — The actual machinery: Firecracker for VMs, Linux bridges and tap devices for networking, local disks for storage. This layer is never exposed directly — it's only accessible through the forge.
+**Internal Compute Stack** — The actual machinery: libkrun for VMs, Linux bridges and tap devices for networking, local disks for storage. This layer is never exposed directly — it's only accessible through the forge.
 
 **Fabric** — The transport. Provides encrypted, authenticated connectivity between nodes.
 
@@ -201,7 +201,7 @@ The forge is **stateless in terms of intent** — it doesn't persist "desired st
       "id": "vm-a1b2c3",                       Allocate resources
       "vcpu": 2,                                Create rootfs volume
       "memory_mb": 2048,                        Create tap interface
-      "rootfs_image": "ubuntu-24.04",           Configure Firecracker
+      "rootfs_image": "ubuntu-24.04",           Configure libkrun VM
       "network": {                              Start microVM
         "vpc_id": "vpc-xyz",
         "subnet_id": "subnet-1",            ◄── 201 Created
@@ -227,9 +227,9 @@ The forge is **stateless in terms of intent** — it doesn't persist "desired st
 
 The forge delegates to the internal compute stack. This stack is not exposed via API — it's a set of local subsystems managed by the agent:
 
-### Compute subsystem (Firecracker)
+### Compute subsystem (libkrun)
 
-- Manages Firecracker microVM processes
+- Manages libkrun microVM instances (embedded in the forge process)
 - Handles VM lifecycle: create, start, stop, delete
 - Manages kernel images and root filesystem images
 - Configures vCPU count, memory, and boot parameters
@@ -292,7 +292,7 @@ Future: the control plane will be the only caller of forge APIs. Access control 
 
 ### Blast radius
 
-The forge has root-level access to the local machine (it manages WireGuard, Firecracker, bridges, volumes). A compromised agent means a compromised node. This is inherent to the hypervisor agent model — same as AWS Nitro, GCP Borglet, or any host agent.
+The forge has root-level access to the local machine (it manages WireGuard, libkrun VMs, bridges, volumes). A compromised agent means a compromised node. This is inherent to the hypervisor agent model — same as AWS Nitro, GCP Borglet, or any host agent.
 
 Mitigations:
 - Agent bound to fabric only (no internet exposure)
@@ -337,4 +337,4 @@ This makes the forge immediately useful even before the control plane exists. An
 | Protocol | Custom binary | Protobuf/gRPC | REST/HTTP + JSON |
 | Encryption | Hardware-level | Internal network | WireGuard (ChaCha20) |
 | Reachability | Internal only | Internal only | Fabric only (syfrah0) |
-| Manages | EC2 instances | Borg tasks/containers | Firecracker microVMs |
+| Manages | EC2 instances | Borg tasks/containers | libkrun microVMs |

--- a/layers/overlay/README.md
+++ b/layers/overlay/README.md
@@ -441,7 +441,7 @@ The bottleneck is WireGuard encryption (ChaCha20-Poly1305), not VXLAN encapsulat
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Compute          ◄── compute.md      │
-    │   Firecracker VMs connect via TAP → bridge           │
+    │   libkrun VMs connect via TAP → bridge                │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │

--- a/layers/storage/README.md
+++ b/layers/storage/README.md
@@ -36,7 +36,7 @@ Instead of building a distributed block storage system, Syfrah uses the provider
     │              │   ZeroFS   │                               │
     │              │            │                               │
     │              │  NBD block │  ← exposes /dev/nbd* devices  │
-    │              │  devices   │     to VMs via Firecracker    │
+    │              │  devices   │     to VMs via libkrun        │
     │              │            │                               │
     │              ├────────────┤                               │
     │              │   Cache    │                               │
@@ -103,7 +103,7 @@ When a tenant creates a volume (via the forge API), ZeroFS creates a sparse file
       "size_gb": 100
     }                                    → /dev/nbd0 ready
 
-    POST /compute/vms                    Firecracker:
+    POST /compute/vms                    libkrun:
     {                                      attach /dev/nbd0 as /dev/vda
       "id": "vm-xyz",
       "volumes": ["vol-abc123"]
@@ -112,15 +112,15 @@ When a tenant creates a volume (via the forge API), ZeroFS creates a sparse file
 
 Inside the VM, the tenant sees a normal block device (`/dev/vda`) and formats it with ext4, XFS, or whatever they want. They don't know about ZeroFS, S3, or caching.
 
-### How it connects to Firecracker
+### How it connects to libkrun
 
-Firecracker uses `virtio-block` to expose block devices to VMs. It accepts any block device or file on the host. ZeroFS exposes NBD devices (`/dev/nbd*`). The two connect directly — no custom integration, standard Linux block device semantics:
+libkrun uses `virtio-block` to expose block devices to VMs. It accepts any block device or file on the host. ZeroFS exposes NBD devices (`/dev/nbd*`). The two connect directly — no custom integration, standard Linux block device semantics:
 
 ```
-    Firecracker                  ZeroFS                       S3
+    libkrun                      ZeroFS                       S3
     (virtio-block)               (NBD + cache + LSM)          (durable backend)
 
-    PUT /drives/data             /dev/nbd0                    s3://bucket/vol-abc
+    block device config          /dev/nbd0                    s3://bucket/vol-abc
     {                                │                            │
       path_on_host: "/dev/nbd0"      ├── memory cache             │
     }                                ├── SSD cache (/dev/nvme1)   │
@@ -130,7 +130,7 @@ Firecracker uses `virtio-block` to expose block devices to VMs. It accepts any b
     (normal block device)
 ```
 
-Firecracker's per-drive rate limiting (bandwidth + IOPS via token bucket) is applied at the `virtio-block` layer, **before** the NBD device. This caps VM I/O regardless of whether data comes from cache or S3. See [compute.md](compute.md) for details on rate limiting.
+Per-drive rate limiting (bandwidth + IOPS via token bucket) is applied at the `virtio-block` layer, **before** the NBD device. This caps VM I/O regardless of whether data comes from cache or S3. See [compute.md](compute.md) for details on rate limiting.
 
 ### How data flows
 
@@ -140,7 +140,7 @@ Firecracker's per-drive rate limiting (bandwidth + IOPS via token bucket) is app
     VM writes to /dev/vdb
          │
          ▼
-    Firecracker virtio-block → rate limit check
+    libkrun virtio-block → rate limit check
          │
          ▼
     ZeroFS NBD receives write
@@ -157,7 +157,7 @@ Firecracker's per-drive rate limiting (bandwidth + IOPS via token bucket) is app
     VM reads from /dev/vdb
          │
          ▼
-    Firecracker virtio-block → rate limit check
+    libkrun virtio-block → rate limit check
          │
          ▼
     ZeroFS NBD checks:
@@ -182,18 +182,18 @@ Restoring a snapshot means pointing a new volume at the recorded SST files.
 
 ### Moving volumes between nodes
 
-Because the durable data is in S3 (not on local disk), a volume can be detached from one node and attached to another. This compensates for Firecracker's lack of live migration — see [compute.md](compute.md) for the full migration flow.
+Because the durable data is in S3 (not on local disk), a volume can be detached from one node and attached to another. This compensates for libkrun's lack of live migration — see [compute.md](compute.md) for the full migration flow.
 
 ```
     Node A                                 Node B
     ──────                                 ──────
 
-    1. Stop VM (Firecracker process killed)
+    1. Stop VM (libkrun process stopped)
     2. ZeroFS flushes cache to S3
     3. Disconnect NBD on Node A
                                            4. ZeroFS connects NBD
                                               to same S3 data
-                                           5. Start VM (Firecracker
+                                           5. Start VM (libkrun
                                               boots in <125ms)
 
     Data copied: zero
@@ -203,7 +203,7 @@ Because the durable data is in S3 (not on local disk), a volume can be detached 
 
 The volume data is the same — only the cache is different. First reads on Node B will hit S3 (~10-100ms), then cache locally for subsequent access. Within minutes, the active working set is cached and performance returns to near-native.
 
-This design makes **compute and storage independent**: Firecracker can be killed and restarted on any node, and ZeroFS reconnects to the same data in S3. No shared filesystem, no distributed block device, no data replication between nodes.
+This design makes **compute and storage independent**: a libkrun VM can be stopped and restarted on any node, and ZeroFS reconnects to the same data in S3. No shared filesystem, no distributed block device, no data replication between nodes.
 
 ## Operator setup
 


### PR DESCRIPTION
## Summary

- Replace all Firecracker references with libkrun across 10 documentation files
- Adapt descriptions to match libkrun's architecture: embedded library (no separate daemon, no API socket, no jailer) instead of standalone process
- Update comparison tables, boot sequences, security model, reconciliation examples, and ASCII diagrams
- Keep Firecracker only in the comparison table (as a competing technology)

## Files changed

- `README.md` — roadmap line
- `handbook/ARCHITECTURE.md` — stack diagram, non-goals, technology table, compute section, failure model
- `handbook/cli.md` — forge vms description
- `handbook/repository.md` — repo tree
- `handbook/state-and-reconciliation.md` — compute state, reconciliation loop, VM phases, volume phases
- `handbook/testing.md` — test matrix
- `layers/compute/README.md` — full rewrite of VMM architecture, boot sequence, security model, lifecycle
- `layers/forge/README.md` — internal compute stack, API example, comparison table
- `layers/overlay/README.md` — relationship diagram
- `layers/storage/README.md` — storage-to-compute integration, data flow diagrams, migration flow

## Context

libkrun (https://github.com/containers/libkrun/) is a KVM-based microVM library that embeds directly into the host process. Key differences from Firecracker:
- Library, not a standalone daemon
- No jailer (isolation via cgroups v2 + namespaces managed by the forge)
- No API socket (configured via C API calls)
- Supports virtio-fs for filesystem passthrough
- Maintained by the containers community (Red Hat backing)

Closes #447

## Test plan

- [x] `grep -ri firecracker` returns only the comparison table entry in `layers/compute/README.md`
- [ ] Documentation reads coherently with libkrun terminology