### PR TITLE
Replace libkrun with Cloud Hypervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The CLI binary in `bin/syfrah` composes these crates and contains no logic of it
 The layers below are architecturally designed with concept documentation but have no implementation yet. Each has a README in its `layers/` directory describing the planned design.
 
 - **Forge** — per-node REST API for managing local resources
-- **Compute** — KVM-based microVMs via libkrun
+- **Compute** — KVM-based microVMs via Cloud Hypervisor
 - **Storage** — S3-backed block devices (ZeroFS)
 - **Overlay** — VXLAN, VPCs, security groups, private DNS
 - **Control Plane** — Raft consensus + SWIM gossip, embedded on every node

--- a/handbook/ARCHITECTURE.md
+++ b/handbook/ARCHITECTURE.md
@@ -20,13 +20,13 @@ This document describes the global architecture. Each layer has its own `README.
 
 These are deliberate choices, not missing features:
 
-- **No live migration.** libkrun does not support it. VM migration is stop → move volume (S3-backed, no data copy) → start. Downtime is ~5-30 seconds.
+- **No live migration in v1.** VM migration is stop → move volume (S3-backed, no data copy) → start. Downtime is ~5-30 seconds. Cloud Hypervisor supports live migration for future enhancement.
 - **No custom IAM policy language.** 4 built-in roles, per-org/project scoping. No JSON policies, no policy simulator, no condition keys.
 - **No L2 flood-and-learn networking.** FDB entries are statically populated by the control plane. ARP is proxied. Zero broadcast traffic in steady state.
 - **No distributed storage cluster.** No Ceph, no GlusterFS. Storage durability is delegated to the provider's S3. ZeroFS handles caching and block device abstraction.
 - **No hyperscaler-style AZ guarantees.** Zones and regions are operator-defined labels. The platform does not enforce physical isolation between AZs — the operator's choice of providers and locations determines actual fault domain boundaries.
-- **No Windows guests.** libkrun boots Linux kernels directly, with no BIOS/UEFI. Windows requires UEFI, which libkrun does not provide.
-- **No GPU passthrough in v1.** libkrun has no PCI passthrough support. GPU workloads would require Cloud Hypervisor or QEMU with VFIO — a future consideration, not a current goal.
+- **No Windows guests in v1.** Cloud Hypervisor boots Linux kernels directly. Windows guest support via UEFI is a future consideration.
+- **GPU passthrough is supported but optional.** Cloud Hypervisor supports VFIO GPU passthrough for CUDA/ML workloads. Nodes without GPUs run standard compute VMs.
 
 ## The stack
 
@@ -62,16 +62,16 @@ These are deliberate choices, not missing features:
     │          │                  │                               │
     │  Compute │     Overlay      │        Storage                │
     │          │                  │                               │
-    │  libkrun       VXLAN/VPC    │  ZeroFS + S3                  │
-    │  microVMs      Security     │  Block devices backed         │
-    │  <125ms boot   groups       │  by object storage            │
-    │  ~5MB overhead  Private DNS │  Local SSD cache              │
+    │  Cloud         VXLAN/VPC    │  ZeroFS + S3                  │
+    │  Hypervisor    Security     │  Block devices backed         │
+    │  microVMs      groups       │  by object storage            │
+    │  ~200ms boot   Private DNS  │  Local SSD cache              │
     │          │                  │                               │
     ├──────────┴──────────────────┴───────────────────────────────┤
     │                                                             │
     │   Forge                                                     │
     │   Per-node REST API on the fabric                           │
-    │   Manages libkrun VMs, bridges, VXLAN, ZeroFS, nftables    │
+    │   Manages Cloud Hypervisor VMs, bridges, VXLAN, ZeroFS, nftables │
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
@@ -105,7 +105,7 @@ The **fabric** is a WireGuard full-mesh connecting all nodes. It replaces the ph
 The **forge** runs on every node. It exposes a REST API bound exclusively to the fabric interface (`syfrah0`), invisible from the internet.
 
 The forge is the bridge between the control plane and the local hardware. It manages:
-- libkrun VM processes (VM lifecycle)
+- Cloud Hypervisor child processes (VM lifecycle, one process per VM)
 - Linux bridges and TAP devices (overlay networking)
 - VXLAN interfaces (VPC isolation)
 - ZeroFS volumes (block storage)
@@ -115,14 +115,16 @@ The forge is intentionally generic: it manages compute, storage, and networking 
 
 **Concept doc:** [`layers/forge/README.md`](../layers/forge/README.md)
 
-### Compute — libkrun microVMs
+### Compute — Cloud Hypervisor microVMs
 
-Every workload runs as a **KVM-based microVM via [libkrun](https://github.com/containers/libkrun/)**. libkrun is a library that embeds directly into the host process, providing hardware-level isolation via KVM with minimal overhead (~5 MB per VM, <125ms boot).
+Every workload runs as a **KVM-based microVM via [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)**. Cloud Hypervisor is a Rust-based VMM that runs as a separate process per VM, providing hardware-level isolation via KVM with minimal overhead (~13 MB per VM, ~200ms boot).
 
-- libkrun embeds into the forge process — no separate daemon, no API socket, no jailer
+- Each VM is a separate `cloud-hypervisor` child process managed by the forge via REST API
+- VMs survive forge restarts — critical for zero-downtime platform updates
 - virtio devices: virtio-fs (filesystem passthrough), virtio-vsock (host-guest communication), virtio-net, virtio-block
+- GPU support: virtio-gpu (shared) + VFIO passthrough (dedicated, CUDA/ML)
 - Shared read-only kernel across all VMs
-- VM migration via stop → move volume → start (no live migration)
+- VM migration via stop → move volume → start (live migration available as future enhancement)
 
 **Concept doc:** [`layers/compute/README.md`](../layers/compute/README.md)
 
@@ -132,7 +134,7 @@ Block storage is backed by **S3-compatible object storage** (from the same provi
 
 - Data is chunked (256KB), compressed (LZ4), and encrypted (XChaCha20-Poly1305)
 - Local SSD + memory cache absorbs >95% of I/O
-- NBD (Network Block Device) endpoints connect directly to libkrun's virtio-block
+- NBD (Network Block Device) endpoints connect directly to Cloud Hypervisor's virtio-block
 - Volumes can move between nodes without copying data (S3 is the source of truth)
 - Snapshots are lightweight (no data copy, just SST file metadata)
 
@@ -256,11 +258,11 @@ Regions and availability zones are logical labels on nodes. They represent where
        ├── Creates TAP device, attaches to VPC bridge
        ├── Adds VXLAN FDB entries on remote nodes (via gossip)
        ├── Creates ZeroFS NBD volume (backed by S3)
-       ├── Starts libkrun microVM (embedded in the forge process)
+       ├── Spawns cloud-hypervisor process (separate process per VM)
        ├── Configures VM: kernel, rootfs, data volume, network
        └── Applies security group rules (nftables)
          │
-    4. VM boots (<125ms), gets IP via config drive
+    4. VM boots (~200ms), gets IP via config drive
          │
     5. DNS record auto-created: web-1.prod.syfrah.internal
          │
@@ -302,7 +304,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 ```
     VM writes to /dev/vdb
          │
-    libkrun virtio-block
+    Cloud Hypervisor virtio-block
          │
     ZeroFS NBD device
          │
@@ -323,7 +325,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 
     Dedicated servers                Fabric (WireGuard mesh)
     (OVH, Hetzner, Scaleway,        Forge (per-node control)
-     or any provider)                Compute (libkrun)
+     or any provider)                Compute (Cloud Hypervisor)
                                      Overlay (VXLAN, VPC, DNS)
     S3 bucket                        Storage (ZeroFS)
     (same provider or any            Control plane (Raft + gossip)
@@ -343,7 +345,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 | Gossip | `foca` | Transport-agnostic SWIM, works over WireGuard |
 | State store | `redb` | Embedded KV, pure Rust, ACID, no C deps |
 | API server | `axum` | HTTP framework, tokio-native |
-| Compute | [libkrun](https://github.com/containers/libkrun/) | KVM-based microVM library, embeds into host process, virtio-fs/vsock, Apache 2.0 |
+| Compute | [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) | Rust-based VMM, separate process per VM with REST API, VFIO GPU passthrough, virtio-fs/vsock, Apache 2.0 |
 | Storage engine | ZeroFS | S3-backed block devices, Rust, local cache |
 | Overlay encap | VXLAN | Standard, kernel-native, 16M VNIs |
 | Firewall | nftables | Per-VM security groups, stateful, conntrack |
@@ -365,7 +367,7 @@ The repo is organized by architectural layer. Each layer is a self-contained fol
     │   │                         Implemented. The first layer.
     │   │
     │   ├── forge/                Per-node debug/ops (planned)
-    │   ├── compute/              libkrun microVMs (planned)
+    │   ├── compute/              Cloud Hypervisor microVMs (planned)
     │   ├── storage/              ZeroFS + S3 block storage (planned)
     │   ├── overlay/              VXLAN, VPC, security groups (planned)
     │   ├── controlplane/         Raft + gossip + scheduler (planned)
@@ -401,7 +403,7 @@ The architecture assumes a hostile operational environment. Nodes are rented mac
 
 - **The Raft leader may change during an operation.** Leader election takes 1-5 seconds. In-flight writes are retried by the client. The new leader replays uncommitted entries. Operations are designed to be re-entrant.
 
-- **Forge actions must be idempotent.** Creating a bridge that already exists is a no-op. Starting a libkrun VM that is already running is a no-op. The reconciliation loop can run any number of times and produce the same result.
+- **Forge actions must be idempotent.** Creating a bridge that already exists is a no-op. Starting a Cloud Hypervisor VM that is already running is a no-op. The reconciliation loop can run any number of times and produce the same result.
 
 - **Derived state must be rebuildable from scratch.** FDB entries, nftables rules, DNS zone files, VXLAN bridges — all are derived from Raft state. If a node loses all derived state (reboot, crash), the next reconciliation loop rebuilds everything from Raft.
 

--- a/handbook/cli.md
+++ b/handbook/cli.md
@@ -56,7 +56,7 @@ syfrah
 │
 ├── forge                         Per-node debug and ops (planned)
 │   ├── status                    This node's health and resources
-│   ├── vms                       libkrun microVM processes on this node
+│   ├── vms                       Cloud Hypervisor microVM processes on this node
 │   ├── bridges                   Active bridges, VXLAN, TAP devices
 │   ├── volumes                   Mounted ZeroFS volumes, cache stats
 │   ├── nftables                  Active security group rules
@@ -384,7 +384,7 @@ vm-g7h8i9      db-primary 4     8192     running   14780   5d 12h
 vm-j0k1l2      worker-1   1     1024     stopped   -       -
 ```
 
-Shows actual libkrun microVM processes, not Raft desired state.
+Shows actual Cloud Hypervisor microVM processes, not Raft desired state.
 
 ### `syfrah forge bridges`
 

--- a/handbook/repository.md
+++ b/handbook/repository.md
@@ -14,7 +14,7 @@ The repository is organized by architectural layer. Each layer is a self-contain
     layers/fabric/                        Fabric layer                  Implemented
     layers/state/                         State inspection              Implemented
     layers/forge/                         Forge layer                   Planned (README only)
-    layers/compute/                       Compute layer                 Planned (README only)
+    layers/compute/                       Compute layer (Cloud Hypervisor) Planned (README only)
     layers/storage/                       Storage layer                 Planned (README only)
     layers/overlay/                       Overlay layer                 Planned (README only)
     layers/controlplane/                  Control plane layer           Planned (README only)
@@ -278,7 +278,7 @@ syfrah/
 │   │           └── drop.rs          syfrah state drop
 │   │
 │   ├── forge/                       Per-node control (planned, README only)
-│   ├── compute/                     libkrun microVMs (planned, README only)
+│   ├── compute/                     Cloud Hypervisor microVMs (planned, README only)
 │   ├── storage/                     ZeroFS + S3 (planned, README only)
 │   ├── overlay/                     VXLAN, VPC, SG, DNS (planned, README only)
 │   ├── controlplane/                Raft + gossip (planned, README only)

--- a/handbook/state-and-reconciliation.md
+++ b/handbook/state-and-reconciliation.md
@@ -32,7 +32,7 @@ Every piece of state in Syfrah has exactly one **source of truth**. Some state i
 | VM desired spec (vCPU, memory, image, network) | Tenant API → Raft | Raft log | What the user asked for. Immutable until user updates it. |
 | VM scheduling decision (which node) | Scheduler → Raft | Raft log | Authoritative placement. One node per VM. |
 | VM runtime status (running, stopped, error) | Forge on the hosting node | Gossip | Observed reality. May lag behind desired state. |
-| VM libkrun process state | Forge (local) | Not persisted (reconstructed on start) | The forge recreates from desired spec on restart. |
+| VM cloud-hypervisor process state | Forge (local) | Not persisted (reconstructed on start) | The forge reconnects to surviving cloud-hypervisor processes on restart. |
 | Kernel images | Platform-provided (local filesystem) | Each node's disk | Shared read-only across VMs. Not in Raft. |
 | Rootfs images | Platform-provided (local or S3) | Each node's disk or S3 | Pulled on demand. Not in Raft. |
 
@@ -141,7 +141,7 @@ Each node runs a **reconciliation loop** in the forge. It continuously compares 
     ┌────────────────────────────────────┐
     │        Local reality (observed)     │
     │                                    │
-    │  libkrun VM processes, bridges,     │
+    │  cloud-hypervisor VM processes,      │
     │  TAP devices, nftables rules,      │
     │  ZeroFS volumes, DNS zone files    │
     └────────────────────────────────────┘
@@ -162,7 +162,7 @@ The forge reads the subset of Raft state relevant to this node:
 **Step 2 — Read actual state from local system**
 
 The forge inspects what actually exists:
-- Running libkrun VM processes (ps / PID files)
+- Running cloud-hypervisor VM processes (ps / PID files / REST API)
 - Linux bridges and VXLAN interfaces (`ip link`)
 - TAP devices (`ip link`)
 - nftables rules (`nft list ruleset`)
@@ -173,19 +173,19 @@ The forge inspects what actually exists:
 
 | Situation | Action |
 |---|---|
-| VM in Raft but no libkrun process | Create TAP, attach to bridge, start libkrun VM |
-| libkrun VM running but VM not in Raft | Stop libkrun VM, cleanup TAP |
+| VM in Raft but no cloud-hypervisor process | Create TAP, attach to bridge, spawn cloud-hypervisor process |
+| cloud-hypervisor VM running but VM not in Raft | Stop cloud-hypervisor VM via REST API, cleanup TAP |
 | VPC in Raft but no bridge on this node | Create VXLAN interface + bridge |
 | Bridge exists but VPC removed from Raft | Delete bridge + VXLAN interface |
 | Security group rules changed in Raft | Recompute and atomically replace nftables rules |
 | FDB entries stale (VM moved to another node) | Remove old FDB, add new |
-| Volume attached in Raft but not mounted | Connect ZeroFS NBD, attach to libkrun VM |
+| Volume attached in Raft but not mounted | Connect ZeroFS NBD, attach to cloud-hypervisor VM |
 | DNS record in Raft but not in zone file | Regenerate zone file, reload CoreDNS |
 
 **Step 4 — Report actual state**
 
 After reconciliation, the forge gossips the actual state of each resource:
-- VM `web-1` is `Running` (or `Error` if the libkrun VM crashed)
+- VM `web-1` is `Running` (or `Error` if the cloud-hypervisor process crashed)
 - Node has 24 vCPU free, 48 GB RAM free
 - Health: `Up`
 
@@ -229,10 +229,10 @@ Every resource type follows a phase model. Phases are linear — a resource move
 |---|---|---|
 | **Pending** | Raft (on create) | VM definition exists. Waiting for scheduler. |
 | **Scheduled** | Raft (scheduler) | Scheduler picked a node. Waiting for forge to act. |
-| **Provisioning** | Forge (gossip) | Forge is creating TAP, bridge, volume, starting libkrun VM. |
-| **Running** | Forge (gossip) | libkrun VM process is alive. VM is operational. |
+| **Provisioning** | Forge (gossip) | Forge is creating TAP, bridge, volume, spawning cloud-hypervisor process. |
+| **Running** | Forge (gossip) | cloud-hypervisor process is alive. VM is operational. |
 | **Stopping** | Raft (on stop request) | User requested stop. Forge sending shutdown signal. |
-| **Stopped** | Forge (gossip) | libkrun VM process exited cleanly. Resources still allocated. |
+| **Stopped** | Forge (gossip) | cloud-hypervisor process exited cleanly. Resources still allocated. |
 | **Deleting** | Raft (on delete request) | User requested deletion. Forge cleaning up. |
 | **Deleted** | Raft (after cleanup confirmed) | All resources released. VM record can be garbage collected. |
 | **Failed** | Forge (gossip) | Something went wrong. Error message attached. |
@@ -251,8 +251,8 @@ Every resource type follows a phase model. Phases are linear — a resource move
 |---|---|---|
 | **Pending** | Raft (on create) | Volume definition exists. ZeroFS file not yet created. |
 | **Available** | Forge (gossip) | ZeroFS NBD file created on S3. Not attached to any VM. |
-| **Attaching** | Raft (on attach request) | Volume being connected to a VM's libkrun process. |
-| **Attached** | Forge (gossip) | NBD device connected to libkrun VM. VM can read/write. |
+| **Attaching** | Raft (on attach request) | Volume being connected to a VM's cloud-hypervisor process. |
+| **Attached** | Forge (gossip) | NBD device connected to cloud-hypervisor VM. VM can read/write. |
 | **Detaching** | Raft (on detach request) | Volume being disconnected. ZeroFS flushing cache. |
 | **Deleting** | Raft (on delete request) | Volume being removed from S3. |
 | **Deleted** | Raft (after cleanup) | S3 data removed. Record can be garbage collected. |
@@ -342,14 +342,14 @@ The phases are the **language** the reconciliation loop speaks. The loop's job i
 
     Forge on Node B sees:
       vm-web-1: phase = Scheduled (just assigned to this node)
-      No local libkrun VM process exists.
+      No local cloud-hypervisor process exists.
 
     Reconciliation:
       1. Phase is Scheduled → target is Running
-      2. No libkrun VM process → need to provision
+      2. No cloud-hypervisor process → need to provision
       3. Create TAP, bridge (if needed), volume
-      4. Start libkrun VM → set phase to Provisioning (gossip)
-      5. libkrun VM boots → set phase to Running (gossip)
+      4. Spawn cloud-hypervisor process → set phase to Provisioning (gossip)
+      5. cloud-hypervisor VM boots → set phase to Running (gossip)
       6. Done. Next loop iteration: Running == Running, no action.
 ```
 

--- a/handbook/testing.md
+++ b/handbook/testing.md
@@ -313,7 +313,7 @@ The `just e2e-local` command uses `dev/e2e.sh`, which volume-mounts a locally-co
 | **core** | Types, validation, crypto, addressing | Serialization roundtrips | -- |
 | **fabric** | Key generation, address derivation | WireGuard interface (root), peering protocol, state persistence | Multi-node mesh, connectivity, rejoin, secret rotation, stress tests |
 | **state** | -- | -- | `syfrah state list/get/drop` |
-| **compute** (planned) | VM spec validation | libkrun VM lifecycle (root) | VM create/start/stop/delete |
+| **compute** (planned) | VM spec validation | Cloud Hypervisor VM lifecycle (root) | VM create/start/stop/delete |
 | **storage** (planned) | Volume spec validation | ZeroFS NBD management (root) | Volume attach, detach, migrate |
 | **overlay** (planned) | IPAM allocation, MAC derivation | Bridge/VXLAN creation (root), nftables rules (root) | VPC isolation, cross-node connectivity |
 | **controlplane** (planned) | Scheduler scoring, state machine | Raft consensus (multi-instance) | Leader election, failover |

--- a/layers/compute/README.md
+++ b/layers/compute/README.md
@@ -2,9 +2,9 @@
 
 ## What is the compute layer?
 
-The compute layer runs tenant workloads. Every VM, every managed database, every load balancer ultimately runs as a **KVM-based microVM via [libkrun](https://github.com/containers/libkrun/)** on a node in the fabric.
+The compute layer runs tenant workloads. Every VM, every managed database, every load balancer ultimately runs as a **KVM-based microVM via [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)** on a node in the fabric.
 
-libkrun is an open-source library (maintained by the containers community, with Red Hat backing) that allows running workloads inside lightweight microVMs using KVM. Unlike standalone VMMs, libkrun embeds directly into the host process — no separate daemon, no API socket, no jailer. It provides hardware-level isolation via KVM with minimal overhead.
+Cloud Hypervisor is an open-source Rust-based VMM (maintained by Intel and the community) that runs as a **separate process per VM**. Each VM is a `cloud-hypervisor` child process managed by the forge via a REST API. This architecture means VMs survive forge restarts — critical for zero-downtime updates. Cloud Hypervisor provides hardware-level isolation via KVM with minimal overhead.
 
 ```
     ┌──────────────────────────────────────────────────────┐
@@ -16,9 +16,9 @@ libkrun is an open-source library (maintained by the containers community, with 
     │  │ 4 GB   │  │ 1 GB   │  │ 8 GB   │  │ 512 MB │     │
     │  └───┬────┘  └───┬────┘  └───┬────┘  └───┬────┘     │
     │      │           │           │           │           │
-    │  Each VM is a separate libkrun microVM instance.       │
+    │  Each VM is a separate cloud-hypervisor process.      │
     │  Hardware isolation via KVM.                          │
-    │  ~5 MB overhead per VM.                               │
+    │  ~13 MB overhead per VM.                              │
     │                                                       │
     │  ┌────────────────────────────────────────────────┐   │
     │  │  Linux kernel + KVM                            │   │
@@ -27,34 +27,46 @@ libkrun is an open-source library (maintained by the containers community, with 
     └──────────────────────────────────────────────────────┘
 ```
 
-## Why libkrun
+## Why Cloud Hypervisor
 
-| | **libkrun** | **QEMU** | **Cloud Hypervisor** | **Firecracker** |
+| | **Cloud Hypervisor** | **QEMU** | **Firecracker** | **libkrun** |
 |---|---|---|---|---|
-| **Architecture** | Library (embeds in host) | Standalone process | Standalone process | Standalone process + jailer |
-| **Overhead per VM** | ~5 MB | ~130 MB | ~13 MB | ~5 MB |
-| **Boot time** | <125 ms | Seconds | ~200 ms | <125 ms |
-| **Device model** | Minimal (virtio only) | Hundreds (full PC) | Moderate | 5 devices |
-| **Attack surface** | Minimal | Large | Moderate | Minimal |
-| **Language** | Rust + C | C | Rust | Rust |
-| **virtio-fs** | Yes | Yes | Yes | No |
-| **GPU passthrough** | No | Yes | Yes | No |
-| **Live migration** | No | Yes | Yes | No |
+| **Architecture** | Separate process per VM with REST API | Standalone process | Standalone process + jailer | Library (embeds in host) |
+| **Overhead per VM** | ~13 MB | ~130 MB | ~5 MB | ~5 MB |
+| **Boot time** | ~200 ms | Seconds | <125 ms | <125 ms |
+| **Device model** | Moderate (virtio-focused) | Hundreds (full PC) | 5 devices | Minimal (virtio only) |
+| **Attack surface** | Moderate | Large | Minimal | Minimal |
+| **Language** | Rust | C | Rust | Rust + C |
+| **virtio-fs** | Yes | Yes | No | Yes |
+| **GPU passthrough** | Yes (VFIO) | Yes | No | No |
+| **Live migration** | Yes | Yes | No | No |
+| **VMs survive host process restart** | Yes | Yes | No | No |
 | **License** | Apache 2.0 | GPL 2.0 | Apache 2.0 | Apache 2.0 |
 
-libkrun's trade-off is clear: **maximum density, security, and integration simplicity at the cost of flexibility**. No GPU, no live migration, no Windows guests. For a cloud platform running Linux VMs, databases, and load balancers on dedicated servers, these trade-offs are acceptable.
+Cloud Hypervisor's trade-off is clear: **separate process per VM with REST API management, GPU support via VFIO passthrough, and VM survival across forge restarts — at slightly higher memory overhead than Firecracker**. The REST API enables clean lifecycle management without embedding VMM code into the forge. VMs are independent processes that persist even when the forge restarts, enabling zero-downtime updates.
 
-Key advantages over standalone VMMs: libkrun embeds directly into the forge process — no separate daemon to manage, no API socket to configure, no jailer to set up. The forge calls libkrun as a library to create and manage VMs. This simplifies the compute stack and reduces the operational surface area.
+Key advantages over embedded VMMs: Cloud Hypervisor runs as a separate process per VM, managed by the forge via REST API. VMs survive forge restarts — critical for zero-downtime platform updates. No jailer needed (unlike Firecracker), with process isolation via cgroups v2 + namespaces.
+
+Key advantages over QEMU: written in Rust with a much smaller attack surface, purpose-built for cloud workloads, and significantly lower memory overhead per VM.
+
+### GPU support
+
+Cloud Hypervisor supports two GPU modes:
+
+- **virtio-gpu** — shared GPU for lightweight rendering workloads
+- **VFIO passthrough** — dedicated GPU with full hardware access, supporting NVIDIA CUDA, multi-GPU configurations, and GPUDirect P2P for ML training and inference workloads
+
+VFIO passthrough gives the guest VM direct access to the GPU hardware, achieving near-native performance for CUDA and ML workloads.
 
 ## Architecture of a microVM
 
-Each libkrun microVM runs as threads within the forge process:
+Each Cloud Hypervisor microVM runs as a separate `cloud-hypervisor` child process managed by the forge:
 
 ```
-    Forge process (hosts all VMs on this node)
+    Forge process (manages all VMs on this node via REST API)
     ┌──────────────────────────────────────────────┐
     │                                              │
-    │  libkrun VM instance (one per VM)            │
+    │  cloud-hypervisor process (one per VM)        │
     │  ┌────────────────────────────────────────┐  │
     │  │                                        │  │
     │  │  VMM thread        ← device emulation  │  │
@@ -66,10 +78,14 @@ Each libkrun microVM runs as threads within the forge process:
     │  │  vCPU thread(s)    ← one per vCPU,     │  │
     │  │  (KVM_RUN loop)      runs guest code   │  │
     │  │                                        │  │
+    │  │  REST API           ← per-VM HTTP API  │  │
+    │  │  (Unix socket)       for lifecycle mgmt│  │
+    │  │                                        │  │
     │  └────────────────────────────────────────┘  │
     │                                              │
-    │  Configuration is done via libkrun's C API   │
-    │  directly — no socket, no REST, no IPC.      │
+    │  Forge manages VMs via Cloud Hypervisor's    │
+    │  REST API — each VM is an independent        │
+    │  process that survives forge restarts.        │
     │                                              │
     └──────────────────────────────────────────────┘
 ```
@@ -93,21 +109,23 @@ When the forge creates a VM, this is what happens:
          │
     2. Create/attach NBD volume (storage, via ZeroFS)
          │
-    3. Configure libkrun VM via library API:
-         ├── krun_set_vm_config()    → vCPU count, memory
-         ├── krun_set_root()         → root filesystem
-         ├── krun_set_mapped_volumes() → data volume (ZeroFS NBD)
-         ├── krun_set_port_map()     → network configuration
-         └── krun_start_enter()      → start the VM
+    3. Spawn cloud-hypervisor process with VM config:
+         ├── --kernel           → vmlinux path
+         ├── --disk             → root filesystem + data volume (ZeroFS NBD)
+         ├── --net              → TAP device configuration
+         ├── --cpus             → vCPU count
+         ├── --memory           → memory size
+         ├── --api-socket       → Unix socket for REST API
+         └── (process starts, VM boots)
          │
-    4. VM boots in <125 ms
+    4. VM boots in ~200 ms
          │
     5. Guest init runs (cloud-init, agent, or application)
 
-    Total time from API call to running VM: ~200-500 ms
+    Total time from API call to running VM: ~300-600 ms
 ```
 
-No jailer, no Unix socket, no separate process. The forge calls libkrun's C API directly to configure and start VMs. This eliminates the complexity of managing external VMM processes.
+Each VM is a separate `cloud-hypervisor` process. The forge manages VM lifecycle via the per-VM REST API on a Unix socket. VMs survive forge restarts — the forge reconnects to existing cloud-hypervisor processes on startup.
 
 ## Networking
 
@@ -162,17 +180,17 @@ A read-only (or copy-on-write) ext4 image containing the base OS. The platform p
 | `alpine-3.20` | Alpine Linux | ~50 MB |
 | `debian-12` | Debian 12 minimal | ~300 MB |
 
-Kernels are shared across all VMs. A single `vmlinux` binary on disk is referenced by every libkrun instance — read-only, no duplication.
+Kernels are shared across all VMs. A single `vmlinux` binary on disk is referenced by every Cloud Hypervisor instance — read-only, no duplication.
 
 ### Data volumes (via ZeroFS)
 
 Persistent storage backed by S3. See [storage.md](storage.md) for the full storage design.
 
-libkrun's `virtio-block` connects directly to ZeroFS's NBD devices — standard Linux block device semantics, no custom integration:
+Cloud Hypervisor's `virtio-block` connects directly to ZeroFS's NBD devices — standard Linux block device semantics, no custom integration:
 
 ```
-    Guest                 libkrun                  Host                  Durable
-    ─────                 ───────                  ────                  ───────
+    Guest                 Cloud Hypervisor         Host                  Durable
+    ─────                 ────────────────         ────                  ───────
 
     /dev/vda ──────► virtio-block ──────► rootfs.ext4            Local image file
     (root fs)             drive:rootfs    (read-only or CoW)
@@ -187,7 +205,7 @@ The write path through the full stack:
 
 ```
     1. VM writes to /dev/vdb
-    2. libkrun virtio-block passes write to /dev/nbd0
+    2. Cloud Hypervisor virtio-block passes write to /dev/nbd0
     3. ZeroFS buffers in memory (microseconds)
     4. On fsync: ZeroFS WAL flush to S3 (~10-50ms)
     5. Background: ZeroFS compacts and flushes SST chunks to S3
@@ -197,7 +215,7 @@ The read path:
 
 ```
     1. VM reads from /dev/vdb
-    2. libkrun virtio-block reads from /dev/nbd0
+    2. Cloud Hypervisor virtio-block reads from /dev/nbd0
     3. ZeroFS checks memory cache → hit? return (microseconds)
     4. ZeroFS checks SSD cache    → hit? return (~100μs)
     5. ZeroFS fetches from S3     → miss? fetch, cache, return (~10-100ms)
@@ -212,13 +230,13 @@ For most workloads, the cache absorbs >95% of I/O. The S3 latency only matters f
 | Web server, app server | Mostly reads, fits in cache | Near-native SSD speed |
 | PostgreSQL (typical OLTP) | fsync on commit → WAL flush | ~53K TPS with warm cache |
 | Large sequential reads (analytics) | Cold data from S3 | Limited by S3 throughput |
-| Boot + init | Rootfs is local, no S3 | <125ms boot, instant rootfs reads |
+| Boot + init | Rootfs is local, no S3 | ~200ms boot, instant rootfs reads |
 
 Per-drive rate limiting (bandwidth + IOPS via cgroups v2) is applied **before** the NBD device, so it caps the VM's I/O regardless of whether the data comes from cache or S3.
 
 ## Security
 
-libkrun's security model is layered:
+Cloud Hypervisor's security model is layered:
 
 ### Layer 1 — Hardware isolation (KVM)
 
@@ -230,45 +248,57 @@ The forge configures OS-level isolation for each VM:
 
 - **cgroups v2**: CPU, memory, and I/O limits per VM
 - **namespaces**: mount, PID, network isolation where applicable
-- **seccomp**: syscall filtering to restrict what the host process can do
+- **seccomp**: syscall filtering to restrict what the cloud-hypervisor process can do
 
-Since libkrun embeds into the forge process, there is no separate jailer binary. Instead, the forge itself manages the isolation boundaries using standard Linux primitives.
+Each VM runs as a separate `cloud-hypervisor` process with its own cgroup and namespace configuration. Process isolation is enforced by the OS, not by a jailer binary.
 
 ### Layer 3 — Seccomp (syscall filtering)
 
-A strict allowlist of system calls is enforced. Any syscall not on the list kills the process immediately. This limits what can happen even after a KVM escape.
+A strict allowlist of system calls is enforced on each cloud-hypervisor process. Any syscall not on the list kills the process immediately. This limits what can happen even after a KVM escape.
 
 ### Layer 4 — Minimal attack surface
 
-libkrun emulates only virtio devices. No PCI bus, no USB, no ACPI, no legacy hardware. Every device that doesn't exist is attack surface that doesn't exist.
+Cloud Hypervisor emulates only virtio devices. No legacy PCI devices, no USB, no full ACPI emulation. Every device that doesn't exist is attack surface that doesn't exist.
 
 ## VM lifecycle
 
 | Operation | How | Time |
 |---|---|---|
-| **Create** | Forge calls libkrun API to configure VM | ~50 ms |
-| **Start** | `krun_start_enter()` | <125 ms |
-| **Stop** | Graceful shutdown signal or force stop | Instant |
-| **Reboot** | Stop + Start | <250 ms |
+| **Create** | Forge spawns cloud-hypervisor process via REST API | ~100 ms |
+| **Start** | Cloud Hypervisor REST API `PUT /vm.boot` | ~200 ms |
+| **Stop** | Graceful shutdown signal via REST API or force stop | Instant |
+| **Reboot** | Stop + Start via REST API | ~400 ms |
 | **Delete** | Stop VM, cleanup TAP device, release NBD volume | Instant |
+
+### Zero-downtime forge updates
+
+Because each VM is a separate `cloud-hypervisor` process, VMs survive forge restarts. When the forge is updated:
+
+1. Forge stops gracefully
+2. New forge binary starts
+3. Forge discovers existing cloud-hypervisor processes
+4. Forge reconnects to each VM's REST API (Unix socket)
+5. Full management restored — no VM downtime
+
+This is critical for platform updates: the forge can be restarted, upgraded, or recovered without affecting running VMs.
 
 ### VM migration between nodes
 
-libkrun does not support live migration. Syfrah compensates with the storage design: since data volumes are backed by S3 (via ZeroFS), migration is a stop-move-start sequence with no data copy.
+Cloud Hypervisor supports live migration, but Syfrah's initial implementation uses a simpler stop-move-start approach that leverages the storage design: since data volumes are backed by S3 (via ZeroFS), migration requires no data copy.
 
 ```
     Node A                                  Node B
     ──────                                  ──────
 
     1. Stop VM
-       ├── libkrun VM stopped
+       ├── cloud-hypervisor process stopped
        └── ZeroFS flushes cache to S3
                                             2. Attach volume
                                                └── ZeroFS connects NBD
                                                    to same S3 data
 
                                             3. Start VM
-                                               ├── libkrun boots (<125ms)
+                                               ├── cloud-hypervisor boots (~200ms)
                                                └── Cache warms up gradually
                                                    (first reads hit S3,
                                                     then cached locally)
@@ -278,21 +308,23 @@ libkrun does not support live migration. Syfrah compensates with the storage des
 ```
 
 This is possible because **compute state and storage state are separated**:
-- libkrun manages compute (CPU, memory, devices) — ephemeral, recreated on boot
+- Cloud Hypervisor manages compute (CPU, memory, devices) — ephemeral, recreated on boot
 - ZeroFS manages storage (volumes) — durable in S3, accessible from any node
 
 The only cost of migration is **cache warmup** on the new node. Active working set data loads progressively from S3 into the local SSD cache over the first minutes of operation.
 
+Live migration via Cloud Hypervisor's built-in support is a future enhancement that will reduce migration downtime to near-zero.
+
 ## Guest-host communication (vsock)
 
-libkrun provides `virtio-vsock` for communication between the VM and the host without using the network:
+Cloud Hypervisor provides `virtio-vsock` for communication between the VM and the host without using the network:
 
 ```
     Host                              Guest
-    ┌──────────────┐                  ┌──────────────┐
-    │ Unix socket  │ ◄── vsock ────► │ AF_VSOCK     │
-    │ /tmp/v.sock  │                  │ port 5000    │
-    └──────────────┘                  └──────────────┘
+    ┌──────────────────┐              ┌──────────────┐
+    │ Unix socket      │ ◄── vsock ──►│ AF_VSOCK     │
+    │ /tmp/v.sock      │              │ port 5000    │
+    └──────────────────┘              └──────────────┘
 ```
 
 Use cases:
@@ -306,14 +338,11 @@ Vsock avoids the complexity of setting up a metadata HTTP endpoint on a link-loc
 
 | Limitation | Impact on Syfrah | Mitigation |
 |---|---|---|
-| **No GPU** | Cannot offer GPU instances | Out of scope for initial product |
-| **No live migration** | Cannot move running VMs between nodes | Stop → move volume → start on new node (see storage.md) |
-| **No Windows guests** | Linux-only VMs | Target audience runs Linux workloads |
-| **Max 32 vCPUs** | Largest VM is 32 vCPU | Sufficient for dedicated server sizes |
-| **No memory/CPU hotplug** | Cannot resize a running VM | Stop → reconfigure → start |
+| **No Windows guests (v1)** | Linux-only VMs initially | Target audience runs Linux workloads; UEFI support planned |
+| **Higher per-VM overhead than Firecracker** | ~13 MB vs ~5 MB per VM | Acceptable trade-off for REST API, GPU support, and VM survival |
 | **No nested virtualization** | Cannot run VMs inside VMs | Not needed for target use cases |
 
-The most impactful limitation is **no live migration**. Syfrah mitigates this through the storage design: since volumes are backed by S3 (via ZeroFS), moving a VM between nodes only requires stopping the VM, detaching the volume, reattaching on the new node, and starting. The data does not need to be copied — just the cache needs to warm up.
+Cloud Hypervisor's feature set covers the primary needs: GPU passthrough (VFIO), virtio-fs, virtio-vsock, live migration support, and VMs that survive forge restarts. The limitations are minor compared to the operational benefits.
 
 ## Relationship to other concepts
 
@@ -326,7 +355,7 @@ The most impactful limitation is **no live migration**. Syfrah mitigates this th
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Compute         ◄── this document                  │
-    │   libkrun microVMs on each node                      │
+    │   Cloud Hypervisor microVMs on each node             │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │
@@ -336,7 +365,7 @@ The most impactful limitation is **no live migration**. Syfrah mitigates this th
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Forge           ◄── forge.md         │
-    │   Manages libkrun VM lifecycle on each node           │
+    │   Manages Cloud Hypervisor VM lifecycle on each node │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │

--- a/layers/forge/README.md
+++ b/layers/forge/README.md
@@ -16,7 +16,7 @@ The forge is the bridge between the control plane and the local compute stack. I
     │          http://[fd12:3456:...:node]:7100/               │
     ├─────────────────────────────────────────────────────────┤
     │                  Internal Compute Stack                   │
-    │       libkrun      │  Networking  │  Storage             │
+    │  Cloud Hypervisor│  Networking  │  Storage             │
     │       (microVMs)   │  (bridges,   │  (volumes,           │
     │                    │   VXLAN)     │   snapshots)         │
     ├─────────────────────────────────────────────────────────┤
@@ -86,9 +86,9 @@ Each node runs three layers, from bottom to top:
     │  ┌────────────┐ ┌───────────┐ ┌──────────────┐  │
     │  │ Compute    │ │ Network   │ │ Storage      │  │
     │  │            │ │           │ │              │  │
-    │  │ libkrun    │ │ bridges   │ │ local disks  │  │
-    │  │ microVMs   │ │ tap devs  │ │ volumes      │  │
-    │  │ lifecycle  │ │ VXLAN     │ │ snapshots    │  │
+    │  │ Cloud      │ │ bridges   │ │ local disks  │  │
+    │  │ Hypervisor │ │ tap devs  │ │ volumes      │  │
+    │  │ microVMs   │ │ VXLAN     │ │ snapshots    │  │
     │  └────────────┘ └───────────┘ └──────────────┘  │
     ├────────────────────────────────────────────────┤
     │                   Fabric                         │
@@ -98,7 +98,7 @@ Each node runs three layers, from bottom to top:
 
 **Forge API** — The REST layer. Receives requests from the control plane (or from operators via curl). Translates API calls into operations on the internal compute stack.
 
-**Internal Compute Stack** — The actual machinery: libkrun for VMs, Linux bridges and tap devices for networking, local disks for storage. This layer is never exposed directly — it's only accessible through the forge.
+**Internal Compute Stack** — The actual machinery: Cloud Hypervisor for VMs (one process per VM, managed via REST API), Linux bridges and tap devices for networking, local disks for storage. This layer is never exposed directly — it's only accessible through the forge.
 
 **Fabric** — The transport. Provides encrypted, authenticated connectivity between nodes.
 
@@ -201,7 +201,7 @@ The forge is **stateless in terms of intent** — it doesn't persist "desired st
       "id": "vm-a1b2c3",                       Allocate resources
       "vcpu": 2,                                Create rootfs volume
       "memory_mb": 2048,                        Create tap interface
-      "rootfs_image": "ubuntu-24.04",           Configure libkrun VM
+      "rootfs_image": "ubuntu-24.04",           Spawn cloud-hypervisor
       "network": {                              Start microVM
         "vpc_id": "vpc-xyz",
         "subnet_id": "subnet-1",            ◄── 201 Created
@@ -227,12 +227,14 @@ The forge is **stateless in terms of intent** — it doesn't persist "desired st
 
 The forge delegates to the internal compute stack. This stack is not exposed via API — it's a set of local subsystems managed by the agent:
 
-### Compute subsystem (libkrun)
+### Compute subsystem (Cloud Hypervisor)
 
-- Manages libkrun microVM instances (embedded in the forge process)
+- Manages Cloud Hypervisor child processes (one per VM, managed via REST API)
 - Handles VM lifecycle: create, start, stop, delete
+- VMs survive forge restarts (separate processes, reconnected on startup)
 - Manages kernel images and root filesystem images
 - Configures vCPU count, memory, and boot parameters
+- Supports GPU passthrough via VFIO for CUDA/ML workloads
 
 ### Network subsystem
 
@@ -292,7 +294,7 @@ Future: the control plane will be the only caller of forge APIs. Access control 
 
 ### Blast radius
 
-The forge has root-level access to the local machine (it manages WireGuard, libkrun VMs, bridges, volumes). A compromised agent means a compromised node. This is inherent to the hypervisor agent model — same as AWS Nitro, GCP Borglet, or any host agent.
+The forge has root-level access to the local machine (it manages WireGuard, Cloud Hypervisor VMs, bridges, volumes). A compromised agent means a compromised node. This is inherent to the hypervisor agent model — same as AWS Nitro, GCP Borglet, or any host agent.
 
 Mitigations:
 - Agent bound to fabric only (no internet exposure)
@@ -337,4 +339,4 @@ This makes the forge immediately useful even before the control plane exists. An
 | Protocol | Custom binary | Protobuf/gRPC | REST/HTTP + JSON |
 | Encryption | Hardware-level | Internal network | WireGuard (ChaCha20) |
 | Reachability | Internal only | Internal only | Fabric only (syfrah0) |
-| Manages | EC2 instances | Borg tasks/containers | libkrun microVMs |
+| Manages | EC2 instances | Borg tasks/containers | Cloud Hypervisor microVMs |

--- a/layers/overlay/README.md
+++ b/layers/overlay/README.md
@@ -441,7 +441,7 @@ The bottleneck is WireGuard encryption (ChaCha20-Poly1305), not VXLAN encapsulat
     ├──────────────────────────────────────────────────────┤
     │                                                      │
     │   Compute          ◄── compute.md      │
-    │   libkrun VMs connect via TAP → bridge                │
+    │   Cloud Hypervisor VMs connect via TAP → bridge        │
     │                                                      │
     ├──────────────────────────────────────────────────────┤
     │                                                      │

--- a/layers/storage/README.md
+++ b/layers/storage/README.md
@@ -36,7 +36,7 @@ Instead of building a distributed block storage system, Syfrah uses the provider
     │              │   ZeroFS   │                               │
     │              │            │                               │
     │              │  NBD block │  ← exposes /dev/nbd* devices  │
-    │              │  devices   │     to VMs via libkrun        │
+    │              │  devices   │     to VMs via Cloud Hypervisor│
     │              │            │                               │
     │              ├────────────┤                               │
     │              │   Cache    │                               │
@@ -103,7 +103,7 @@ When a tenant creates a volume (via the forge API), ZeroFS creates a sparse file
       "size_gb": 100
     }                                    → /dev/nbd0 ready
 
-    POST /compute/vms                    libkrun:
+    POST /compute/vms                    Cloud Hypervisor:
     {                                      attach /dev/nbd0 as /dev/vda
       "id": "vm-xyz",
       "volumes": ["vol-abc123"]
@@ -112,12 +112,12 @@ When a tenant creates a volume (via the forge API), ZeroFS creates a sparse file
 
 Inside the VM, the tenant sees a normal block device (`/dev/vda`) and formats it with ext4, XFS, or whatever they want. They don't know about ZeroFS, S3, or caching.
 
-### How it connects to libkrun
+### How it connects to Cloud Hypervisor
 
-libkrun uses `virtio-block` to expose block devices to VMs. It accepts any block device or file on the host. ZeroFS exposes NBD devices (`/dev/nbd*`). The two connect directly — no custom integration, standard Linux block device semantics:
+Cloud Hypervisor uses `virtio-block` to expose block devices to VMs. It accepts any block device or file on the host. ZeroFS exposes NBD devices (`/dev/nbd*`). The two connect directly — no custom integration, standard Linux block device semantics:
 
 ```
-    libkrun                      ZeroFS                       S3
+    Cloud Hypervisor             ZeroFS                       S3
     (virtio-block)               (NBD + cache + LSM)          (durable backend)
 
     block device config          /dev/nbd0                    s3://bucket/vol-abc
@@ -140,7 +140,7 @@ Per-drive rate limiting (bandwidth + IOPS via token bucket) is applied at the `v
     VM writes to /dev/vdb
          │
          ▼
-    libkrun virtio-block → rate limit check
+    Cloud Hypervisor virtio-block → rate limit check
          │
          ▼
     ZeroFS NBD receives write
@@ -157,7 +157,7 @@ Per-drive rate limiting (bandwidth + IOPS via token bucket) is applied at the `v
     VM reads from /dev/vdb
          │
          ▼
-    libkrun virtio-block → rate limit check
+    Cloud Hypervisor virtio-block → rate limit check
          │
          ▼
     ZeroFS NBD checks:
@@ -182,19 +182,19 @@ Restoring a snapshot means pointing a new volume at the recorded SST files.
 
 ### Moving volumes between nodes
 
-Because the durable data is in S3 (not on local disk), a volume can be detached from one node and attached to another. This compensates for libkrun's lack of live migration — see [compute.md](compute.md) for the full migration flow.
+Because the durable data is in S3 (not on local disk), a volume can be detached from one node and attached to another — see [compute.md](compute.md) for the full migration flow.
 
 ```
     Node A                                 Node B
     ──────                                 ──────
 
-    1. Stop VM (libkrun process stopped)
+    1. Stop VM (cloud-hypervisor process stopped)
     2. ZeroFS flushes cache to S3
     3. Disconnect NBD on Node A
                                            4. ZeroFS connects NBD
                                               to same S3 data
-                                           5. Start VM (libkrun
-                                              boots in <125ms)
+                                           5. Start VM (cloud-hypervisor
+                                              boots in ~200ms)
 
     Data copied: zero
     Downtime: ~5-30 seconds
@@ -203,7 +203,7 @@ Because the durable data is in S3 (not on local disk), a volume can be detached 
 
 The volume data is the same — only the cache is different. First reads on Node B will hit S3 (~10-100ms), then cache locally for subsequent access. Within minutes, the active working set is cached and performance returns to near-native.
 
-This design makes **compute and storage independent**: a libkrun VM can be stopped and restarted on any node, and ZeroFS reconnects to the same data in S3. No shared filesystem, no distributed block device, no data replication between nodes.
+This design makes **compute and storage independent**: a Cloud Hypervisor VM can be stopped and restarted on any node, and ZeroFS reconnects to the same data in S3. No shared filesystem, no distributed block device, no data replication between nodes.
 
 ## Operator setup
 


### PR DESCRIPTION
## Summary

- Replace all references to libkrun with Cloud Hypervisor across 10 documentation files
- Update architectural descriptions to reflect Cloud Hypervisor's separate-process-per-VM model with REST API management
- Add GPU support documentation (virtio-gpu shared + VFIO passthrough for CUDA/ML)
- Highlight zero-downtime forge updates (VMs survive forge restarts)
- Keep cgroups v2 + namespaces for process isolation (no jailer needed)

## Files changed

- `README.md` — roadmap entry
- `layers/compute/README.md` — full rewrite of compute layer doc
- `layers/forge/README.md` — compute subsystem and references
- `layers/overlay/README.md` — relationship diagram
- `layers/storage/README.md` — storage-compute integration paths
- `handbook/ARCHITECTURE.md` — stack diagram, tech choices, non-goals, failure model
- `handbook/cli.md` — forge CLI descriptions
- `handbook/repository.md` — layer descriptions
- `handbook/state-and-reconciliation.md` — VM process state, reconciliation loop, phase models
- `handbook/testing.md` — compute test descriptions

## Test plan

- [x] Verify no remaining `libkrun` references (except comparison table in compute/README.md)
- [x] Verify Firecracker references are only in comparison contexts
- [x] All changes are documentation-only — no code changes, no CI impact

Closes #448