### PR TITLE
docs: fix proto and API doc inconsistencies

### DIFF
--- a/handbook/api-architecture.md
+++ b/handbook/api-architecture.md
@@ -127,15 +127,17 @@ HTTP/JSON over the fabric. Same serde types as local IPC. Same version, same bin
 
 ### Location
 
+Per-layer protos live alongside their layer crate; shared types live in `api/proto/`:
+
 ```
-api/proto/syfrah/v1/
-  fabric.proto         # Fabric service (peers, topology, peering)
-  compute.proto        # Compute service (VMs, images)
-  overlay.proto        # Overlay service (VPCs, subnets, security groups)
-  storage.proto        # Storage service (volumes, snapshots)
-  org.proto            # Organization service (orgs, projects, envs)
-  iam.proto            # IAM service (users, roles, API keys)
-  common.proto         # Shared types (pagination, errors, health)
+layers/fabric/proto/fabric.proto     # Fabric service (peers, topology, peering)
+layers/forge/proto/forge.proto       # Forge service (per-node ops)
+layers/compute/proto/compute.proto   # Compute service (VMs, images)
+layers/overlay/proto/overlay.proto   # Overlay service (VPCs, subnets, security groups)
+layers/storage/proto/storage.proto   # Storage service (volumes, snapshots)
+layers/org/proto/org.proto           # Organization service (orgs, projects, envs)
+
+api/proto/syfrah/v1/common.proto     # Shared types (pagination, errors, health)
 
 buf.yaml              # buf lint + breaking config
 buf.gen.yaml          # code generation config
@@ -324,19 +326,7 @@ Implementation: in-memory token bucket per gateway instance. No external depende
 
 ### Error codes per layer
 
-Each layer defines its error codes. Examples:
-
-```
-FABRIC_PEER_NOT_FOUND
-FABRIC_MESH_NOT_INITIALIZED
-FABRIC_DAEMON_NOT_RUNNING
-COMPUTE_VM_NOT_FOUND
-COMPUTE_INSUFFICIENT_RESOURCES
-IAM_KEY_EXPIRED
-IAM_UNAUTHORIZED
-```
-
-The gRPC status codes map to these: `NOT_FOUND`, `UNAUTHENTICATED`, `PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, etc.
+Each layer prefixes its error codes with the layer name (e.g. `FABRIC_PEER_NOT_FOUND`, `COMPUTE_VM_NOT_FOUND`). See [external-api.md](external-api.md#error-codes) for the canonical error code table with HTTP status mappings.
 
 ---
 
@@ -463,7 +453,7 @@ Replace `Error { message }` with `Error { code, message, trace_id }`. Add `SO_PE
 
 ### Phase 3: Proto definitions (2 days)
 
-Create `api/proto/syfrah/v1/fabric.proto` mirroring current `FabricRequest`/`FabricResponse`. Add `buf.yaml`, CI lint/breaking checks.
+Create `layers/fabric/proto/fabric.proto` mirroring current `FabricRequest`/`FabricResponse`. Add `buf.yaml`, CI lint/breaking checks.
 
 ### Phase 4: gRPC server (3 days)
 

--- a/handbook/cli.md
+++ b/handbook/cli.md
@@ -11,7 +11,7 @@ tags: [cli, tooling, operations]
 syfrah <namespace> <command> [flags]
 ```
 
-The CLI communicates with the local daemon via a Unix domain socket (`~/.syfrah/control.sock`) for runtime operations, or directly reads/writes state for offline operations.
+The CLI communicates with the local daemon via a Unix domain socket (`~/.syfrah/control.sock`) for runtime operations, or directly reads/writes state for offline operations. The socket uses length-prefixed JSON frames (max 64 KB, 5 s read timeout); see [api-architecture.md](api-architecture.md#1-local-server-cli--daemon) for details.
 
 > **Implementation status:** Only `syfrah fabric`, `syfrah state`, and `syfrah update` are implemented. All other namespaces (`forge`, `org`, `vm`, `vpc`, etc.) are planned. See the command tree below for details.
 

--- a/handbook/external-api.md
+++ b/handbook/external-api.md
@@ -3,6 +3,7 @@
 This document covers exposing the syfrah control plane API to external clients (laptop CLI, Terraform provider, SDKs) via a dedicated gateway node. It includes gateway setup, API key management, authentication, rate limiting, a full endpoint reference, and troubleshooting.
 
 For internal architecture details, see [api-architecture.md](api-architecture.md).
+For the Terraform provider, multi-language SDKs, and SDK generation pipeline, see [api-architecture.md](api-architecture.md#sdk-generation).
 
 ---
 
@@ -580,9 +581,15 @@ All errors follow a consistent JSON structure:
 | `AUTH_FORBIDDEN` | 403 | Valid key but insufficient role, or source IP not in CIDR allowlist. |
 | `RESOURCE_EXHAUSTED` | 429 | Rate limit exceeded. |
 | `FABRIC_PEER_NOT_FOUND` | 400 | The specified peer does not exist. |
-| `FABRIC_DAEMON_NOT_RUNNING` | 503 | The daemon is not running or unreachable. |
 | `FABRIC_MESH_NOT_INITIALIZED` | 400 | The mesh has not been initialized yet. |
+| `FABRIC_DAEMON_NOT_RUNNING` | 503 | The daemon is not running or unreachable. |
+| `COMPUTE_VM_NOT_FOUND` | 404 | The specified VM does not exist. |
+| `COMPUTE_INSUFFICIENT_RESOURCES` | 409 | Not enough resources to fulfill the request. |
+| `IAM_KEY_EXPIRED` | 401 | The API key has exceeded its TTL. |
+| `IAM_UNAUTHORIZED` | 403 | IAM policy denies the requested action. |
 | `INTERNAL_ERROR` | 500 | Unexpected server error. |
+
+Each layer prefixes its codes with the layer name (e.g. `FABRIC_`, `COMPUTE_`, `IAM_`). The gRPC status codes map accordingly: `NOT_FOUND`, `UNAUTHENTICATED`, `PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, etc.
 
 ---
 

--- a/handbook/proto-strategy.md
+++ b/handbook/proto-strategy.md
@@ -38,11 +38,15 @@ api/proto/syfrah/v1/common.proto     # Shared types (pagination, errors, health)
 
 ## 2. Package Conventions
 
-Every proto file declares its package as:
+Every per-layer proto file declares its package as `syfrah.{layer}.v1`:
 
 ```protobuf
-package syfrah.v1;
+package syfrah.fabric.v1;   // layers/fabric/proto/fabric.proto
+package syfrah.compute.v1;   // layers/compute/proto/compute.proto
+package syfrah.overlay.v1;   // layers/overlay/proto/overlay.proto
 ```
+
+Shared types in `api/proto/syfrah/v1/common.proto` use `package syfrah.v1`.
 
 The version number in the package name (`v1`) corresponds to the API version.
 
@@ -230,7 +234,7 @@ These changes are all non-breaking and require no version bump.
 
 When a breaking change is unavoidable:
 
-1. Create a new package: `syfrah.v2` (reflected in the proto file and URL paths).
+1. Create a new package: `syfrah.{layer}.v2` (reflected in the proto file and URL paths).
 2. Serve both `v1` and `v2` simultaneously for at least one release cycle.
 3. Announce deprecation of the old version.
 4. After two minor releases, remove the old version.
@@ -324,7 +328,7 @@ Create `layers/{name}/proto/{name}.proto`:
 ```protobuf
 syntax = "proto3";
 
-package syfrah.v1;
+package syfrah.{name}.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 


### PR DESCRIPTION
## Summary
- Fix proto file path references in `api-architecture.md` to reflect actual layout (`layers/{layer}/proto/` instead of `api/proto/syfrah/v1/`)
- Fix package naming in `proto-strategy.md` to use `syfrah.{layer}.v1` instead of `syfrah.v1`
- Add Terraform/SDK cross-reference in `external-api.md`
- Add IPC frame format reference (length-prefixed JSON, 64 KB, 5 s timeout) in `cli.md` where the control socket is mentioned
- Consolidate error code tables: canonical list now in `external-api.md`, referenced from `api-architecture.md`

## Test plan
- [ ] Verify proto file paths match reality (`layers/*/proto/*.proto`, `api/proto/syfrah/v1/common.proto`)
- [ ] Verify package names match reality (`syfrah.{layer}.v1`)
- [ ] Check all cross-doc links resolve correctly

Part of #449