### PR TITLE
docs: fix fabric and mesh documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ The long-term vision is to grow Syfrah into a full control plane that orchestrat
 | Layer | Crate | Status |
 |---|---|---|
 | **Core** | `syfrah-core` | Stable — types, crypto, IPv6 addressing |
-| **State** | `syfrah-state` | Stable — embedded persistence (redb) |
+| **State** (library) | `syfrah-state` | Stable — embedded persistence (redb), cross-cutting library used by all layers |
 | **Fabric** | `syfrah-fabric` | Stable — WireGuard mesh, peering, daemon, CLI |
 | Forge | — | Design phase |
 | Compute | — | Design phase |
 | Storage | — | Design phase |
 | Overlay | — | Design phase |
-| Control Plane | — | Design phase |
+| control plane | — | Design phase |
 | Org | — | Design phase |
 | IAM | — | Design phase |
 | Products | — | Design phase |
@@ -112,9 +112,9 @@ This creates an encrypted WireGuard mesh between the two servers. Each additiona
               └─────────────┘  └─────────────────┘
 ```
 
-**Core** provides pure types with no I/O: node identities, WireGuard keypairs, mesh secrets, and deterministic IPv6 address derivation (ULA /48 per mesh, /128 per node, derived from SHA-256 of the mesh secret and public key).
+**Core** provides pure types with no I/O: node identities, WireGuard keypairs, mesh secrets, and deterministic IPv6 address derivation (ULA /48 prefix per mesh derived from the mesh secret, /128 address per node derived from SHA-256 of the WireGuard public key).
 
-**State** wraps redb for crash-safe embedded persistence. Mesh state is stored in `~/.syfrah/fabric.redb` with a JSON backup at `~/.syfrah/state.json`.
+**State** wraps redb for crash-safe embedded persistence. Mesh state is stored in `~/.syfrah/fabric.redb`. A backward-compatible JSON export is maintained at `~/.syfrah/state.json` (debounced, best-effort).
 
 **Fabric** is the main layer. It manages:
 - A WireGuard interface (`syfrah0`) with a full-mesh topology

--- a/handbook/ARCHITECTURE.md
+++ b/handbook/ARCHITECTURE.md
@@ -239,6 +239,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 - An AZ = an isolated group within a region (eu-west-1, eu-west-ovh)
 
 **Concept doc:** [`handbook/zones-and-regions.md`](zones-and-regions.md)
+**Fabric implementation:** [`layers/fabric/README.md` — Zones and Regions](../layers/fabric/README.md#zones-and-regions)
 
 ## How it all connects
 
@@ -420,15 +421,16 @@ The architecture assumes a hostile operational environment. Nodes are rented mac
 | Layer | Status | Notes |
 |---|---|---|
 | **Core** (`layers/core/`) | Implemented | Types, crypto, addressing, identity |
+| **State** (`layers/state/`) | Implemented | Cross-cutting library: embedded persistence (redb), state inspection CLI |
+| **API** (`layers/api/`) | Implemented | Cross-cutting library: error types, structured responses |
 | **Fabric** (`layers/fabric/`) | Implemented | WireGuard mesh, TCP peering, daemon, full CLI |
-| **State** (`layers/state/`) | Implemented | State inspection CLI (`syfrah state list/get/drop`) |
 | **Forge** (`layers/forge/`) | Planned | README only, no code |
 | **Compute** (`layers/compute/`) | Planned | README only, no code |
 | **Storage** (`layers/storage/`) | Planned | README only, no code |
 | **Overlay** (`layers/overlay/`) | Planned | README only, no code |
-| **Control Plane** (`layers/controlplane/`) | Planned | README only, no code |
-| **Organization** (`layers/org/`) | Planned | README only, no code |
+| **control plane** (`layers/controlplane/`) | Planned | README only, no code |
 | **IAM** (`layers/iam/`) | Planned | README only, no code |
+| **Organization** (`layers/org/`) | Planned | README only, no code |
 | **Products** (`layers/products/`) | Planned | README only, no code |
 
 Sections above describing Raft, gossip, forge reconciliation, compute, storage, overlay, org model, IAM, and cloud products reflect the **architectural plan**, not current functionality.

--- a/handbook/api-architecture.md
+++ b/handbook/api-architecture.md
@@ -250,6 +250,8 @@ Both binaries share the same command grammar wherever semantics overlap; differe
 
 ### API Keys
 
+> **Prefix convention:** `syf_sk_` = mesh secret (local to the node, never leaves it — used for WireGuard key derivation). `syf_key_` = API key (for external gateway access by laptop CLI, Terraform, SDKs). These are distinct credentials with different trust boundaries; do not confuse them.
+
 **Format:** `syf_key_{project_short_id}_{random_256bit_base58}`
 
 **Properties:**

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -23,7 +23,9 @@ Controls the daemon's background loop timers.
 | `health_check_interval` | integer (seconds) | `60` | How often the daemon checks peer health via WireGuard handshake timestamps. |
 | `reconcile_interval` | integer (seconds) | `30` | How often the daemon reconciles WireGuard interface state with the peer list. |
 | `persist_interval` | integer (seconds) | `30` | How often the daemon writes in-memory state to `~/.syfrah/state.json`. |
-| `unreachable_timeout` | integer (seconds) | `300` | After this many seconds without a WireGuard handshake, a peer is marked unreachable. |
+| `unreachable_timeout` | integer (seconds) | `300` | After this many seconds without a WireGuard handshake, a peer is marked unreachable. Must be greater than `health_check_interval` (see note below). |
+
+> **Note:** `health_check_interval` must be less than `unreachable_timeout`. The health check runs periodically and compares each peer's last WireGuard handshake against the unreachable timeout. If `health_check_interval` were equal to or greater than `unreachable_timeout`, the daemon could miss the detection window entirely or detect unreachable peers with excessive delay. The defaults (60s check interval, 300s timeout) provide up to five health check opportunities before a peer is marked unreachable, giving a worst-case detection time of approximately 6 minutes (300s timeout + up to 60s until the next check).
 
 ### `[wireguard]`
 
@@ -43,6 +45,19 @@ Controls the TCP peering protocol used for join requests and peer announcements.
 | `exchange_timeout` | integer (seconds) | `30` | Timeout for individual peering protocol message exchanges. |
 | `max_concurrent_connections` | integer | `100` | Maximum number of simultaneous TCP peering connections the daemon accepts. |
 | `max_pending_joins` | integer | `100` | Maximum number of pending join requests the daemon holds before rejecting new ones. |
+
+> **Note:** The peering port (`peering_port`) is not set in `config.toml`. It is specified at mesh creation or join time via the `--peering-port` CLI flag (default: WireGuard port + 1) and persisted in the node's state database.
+
+### `[gateway]`
+
+Controls the dedicated gateway node role. When enabled, the node exposes the external REST/gRPC API with TLS. See [external-api.md](external-api.md) for full gateway documentation.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Whether this node acts as a gateway. |
+| `bind_address` | string (ip:port) | `0.0.0.0:8443` | Socket address to bind the external API to. |
+| `tls_cert_path` | string (file path) | *(none)* | Path to a PEM-encoded TLS certificate. If omitted, a self-signed certificate is generated at startup. |
+| `tls_key_path` | string (file path) | *(none)* | Path to a PEM-encoded TLS private key. Required when `tls_cert_path` is set. |
 
 ### `[events]`
 
@@ -98,6 +113,12 @@ max_pending_joins = 100
 
 [events]
 max_events = 100
+
+[gateway]
+enabled = false
+bind_address = "0.0.0.0:8443"
+# tls_cert_path = "/etc/syfrah/tls/cert.pem"
+# tls_key_path  = "/etc/syfrah/tls/key.pem"
 
 [limits]
 max_peers = 1000

--- a/layers/fabric/README.md
+++ b/layers/fabric/README.md
@@ -3,6 +3,8 @@ tags: [networking, wireguard, security, mesh]
 ---
 # Fabric
 
+The fabric layer manages the WireGuard mesh network. In Syfrah, "fabric" refers to the layer/module, "mesh" refers to the network it creates.
+
 ## What is the fabric?
 
 The **fabric** is Syfrah's infrastructure network. It connects all hypervisors (nodes) into a single encrypted mesh, regardless of where they are hosted — OVH, Hetzner, Scaleway, or any other provider.
@@ -74,6 +76,8 @@ Each node gets a deterministic IPv6 address derived from the mesh prefix and the
 ### TCP peering protocol
 
 Nodes discover each other through a manual peering process. A new node sends a join request to an existing node; the operator approves (manually or via a PIN), and the joining node receives the mesh secret, the peer list, and the mesh prefix. The new node is then announced to all existing members via encrypted peer announcements.
+
+Peer announcements are sent over TCP connections to each target node's peering port (default 51821), optionally upgraded to TLS when the mesh secret-derived TLS configuration is available. The announcement payload is a `PeerAnnounce` message containing the new peer's record encrypted with AES-256-GCM. Announcements use gossip-based dissemination: each node forwards to `max(3, ceil(log2(n)))` randomly chosen peers rather than broadcasting to all peers, achieving convergence in O(log n) rounds. A replay guard (timestamp + ciphertext deduplication) prevents infinite forwarding loops. For topology-aware meshes, announcements are sent in three waves: same-zone peers first, then same-region, then cross-region, with configurable concurrency and delays per wave.
 
 ### Mesh secret
 
@@ -233,6 +237,8 @@ The PIN mechanism allows unattended node enrollment. The operator starts peering
 
 The PIN is a 4-digit code (1000-9999) transmitted in the JoinRequest. It is designed for convenience during initial cluster bootstrap, not as a long-term security mechanism. Best practice: use PIN mode only during initial setup, then switch to manual approval.
 
+> **Security note:** A 4-digit PIN provides approximately 13 bits of entropy (~9000 possible values). This is intentionally low — the PIN is a convenience mechanism, not a strong authentication factor. It is protected by two mitigations: (1) the peering listener enforces rate limiting on PIN attempts to prevent brute-force attacks, and (2) each PIN is single-use (the peering session is consumed once a node joins successfully). For high-security environments, prefer manual approval (`syfrah peering` without `--pin`).
+
 ### Secret rotation
 
 If the mesh secret is compromised, the operator can rotate it:
@@ -243,7 +249,7 @@ syfrah rotate        # generate new secret, clear peer list
 syfrah start         # restart with new secret
 ```
 
-Rotation generates a new secret, recomputes the mesh prefix and node IPv6 address, and **clears all peers**. Every other node must rejoin with the new secret. This is a disruptive operation by design — it ensures a clean break from the compromised state.
+Rotation generates a new secret, recomputes the mesh prefix and node IPv6 address, and **broadcasts the new secret to all active peers**. Each peer applies the new secret automatically (re-derives encryption keys, prefix, and IPv6 address). The response includes `peers_notified` and `peers_failed` counts. Peers that were unreachable during the broadcast must be re-joined manually.
 
 ### Threat model summary
 
@@ -381,7 +387,7 @@ Future work could address these limits with parallel announcements, database-bac
 
 ### Metrics
 
-The daemon tracks four counters, persisted every 30 seconds to `~/.syfrah/state.json`:
+The daemon tracks four counters, persisted to `~/.syfrah/fabric.redb` (with a best-effort JSON export to `~/.syfrah/state.json`):
 
 | Metric | Description |
 |---|---|
@@ -396,6 +402,14 @@ The daemon tracks four counters, persisted every 30 seconds to `~/.syfrah/state.
 - **Last handshake** — time since last successful cryptographic handshake
 - **RX/TX bytes** — traffic counters per peer
 - **Endpoint** — current resolved endpoint address
+
+### Event log
+
+The daemon maintains a persistent event log stored in the redb database (`~/.syfrah/fabric.redb`) in an `events` table. Events are written with auto-incrementing keys and include a timestamp, event type, and optional peer name, endpoint, and details.
+
+The event log uses a **ring buffer retention policy**: when the number of stored events exceeds a configurable maximum (default 100, set via `[events] max_events` in `config.toml`), the oldest entries are pruned automatically. Event recording is best-effort — failures are logged as warnings but never crash the daemon.
+
+Tracked event types include: daemon lifecycle, join requests (received, accepted, rejected, timed out), peer state changes (active, unreachable, recovered, removed, updated), reconciliation and health check runs, announcement status, configuration reloads, zone health transitions, and secret rotations.
 
 ### Logging
 
@@ -464,3 +478,18 @@ Region and zone are displayed in CLI output:
 ### Design notes
 
 The fabric remains a flat full-mesh WireGuard network connecting all nodes regardless of region or zone. Region and zone are purely logical labels stored in the node state and propagated to peers. They do not affect routing or tunnel topology at the fabric layer — it is the overlay and control plane that consume this metadata for topology-aware decisions.
+
+For the full zones and regions design (including placement rules, failure domains, and topology-aware overlay routing), see [handbook/zones-and-regions.md](../../handbook/zones-and-regions.md).
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **fabric** | The layer/module (`layers/fabric/`). Use "fabric" when referring to the crate, CLI subcommand, or layer. |
+| **mesh** | The WireGuard network that the fabric creates. Use "mesh" when referring to the network itself (e.g., "join the mesh", "mesh secret"). |
+| **node** | Any server running syfrah. A machine becomes a node when syfrah is installed and running, even before it connects to other nodes. |
+| **peer** | A node that has joined a mesh. Once a node completes the join ceremony, it becomes a peer of every other node in the mesh. |
+| **peering** | The subsystem that handles join requests and peer announcements (e.g., "start the peering listener", "stop peering"). |
+| **joining** | The act of a node joining the mesh (e.g., "the node is joining", "the join ceremony"). |


### PR DESCRIPTION
## Summary

- Fix secret rotation docs: rotation broadcasts to peers (not "clears all peers") per `daemon.rs` implementation
- Fix IPv6 derivation: /48 prefix from mesh secret, /128 from SHA-256 of WG public key (not "mesh secret and public key") per `addressing.rs`
- Document event log storage and retention (redb `events` table, ring buffer, max 100) per `events.rs`
- Add PIN security note: ~13 bits entropy, rate-limited, single-use tradeoff
- Document peer announcement transport: TCP peering port, optional TLS, gossip dissemination with replay guard per `peering.rs`
- Add `health_check_interval` < `unreachable_timeout` guidance in configuration.md
- Add zones/regions cross-references between fabric/README.md, ARCHITECTURE.md, and handbook/zones-and-regions.md

## Test plan

- [ ] Verify all links resolve correctly
- [ ] Confirm source code references match implementation
- [ ] Read through each changed section for accuracy

Part of #449