### PR TITLE
docs: fix CLI, workflow, and release documentation inconsistencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,10 @@ Open-source control plane to transform dedicated servers into a programmable clo
 - `wg.rs` — WireGuard interface management
 - `cli/` — CLI commands for `syfrah fabric ...`
 
+## CLI
+Only `syfrah fabric`, `syfrah state`, and `syfrah update` commands are currently implemented.
+All other namespaces (`forge`, `org`, `vm`, `vpc`, etc.) are planned. See `handbook/cli.md` for the full command tree.
+
 ## Conventions
 - serde Serialize/Deserialize on all public types
 - thiserror for library errors, anyhow for binaries

--- a/handbook/ci.md
+++ b/handbook/ci.md
@@ -110,6 +110,10 @@ Some tests require root privileges or WireGuard kernel support. These are marked
 sudo cargo test -- --ignored
 ```
 
+## E2E tests
+
+End-to-end tests (multi-node mesh scenarios) are not yet part of the CI pipeline. They are run manually before cutting a stable release. E2E test coverage and strategy are tracked separately; when a dedicated testing handbook page is created, it will be linked here.
+
 ## Branch protection
 
 The `main` branch is protected by a GitHub ruleset named **main-protection**. The ruleset enforces:

--- a/handbook/cli.md
+++ b/handbook/cli.md
@@ -13,7 +13,7 @@ syfrah <namespace> <command> [flags]
 
 The CLI communicates with the local daemon via a Unix domain socket (`~/.syfrah/control.sock`) for runtime operations, or directly reads/writes state for offline operations. The socket uses length-prefixed JSON frames (max 64 KB, 5 s read timeout); see [api-architecture.md](api-architecture.md#1-local-server-cli--daemon) for details.
 
-> **Implementation status:** Only `syfrah fabric`, `syfrah state`, and `syfrah update` are implemented. All other namespaces (`forge`, `org`, `vm`, `vpc`, etc.) are planned. See the command tree below for details.
+> **Implementation status:** Only `syfrah fabric`, `syfrah state`, `syfrah update`, and `syfrah completions` are implemented. All other namespaces (`forge`, `org`, `vm`, `vpc`, etc.) are planned. See the command tree below for details.
 
 ## Command tree
 
@@ -22,7 +22,9 @@ Commands marked **(planned)** are not yet implemented.
 ```
 syfrah
 │
-├── update                        Update syfrah binary
+├── update                        Update syfrah to the latest release
+│
+├── completions                   Generate shell completions (bash, zsh, fish)
 │
 ├── fabric                        Fabric mesh management
 │   ├── init                      Create a new mesh
@@ -32,101 +34,111 @@ syfrah
 │   ├── leave                     Leave the mesh, clear state
 │   ├── status                    Show mesh and daemon status
 │   ├── events                    Show the event log
+│   ├── audit                     Show the security audit log
 │   ├── peers                     List all mesh peers
+│   │   ├── remove                Remove a peer from the mesh
+│   │   └── update                Update a peer's endpoint
 │   ├── token                     Show the mesh secret
 │   ├── rotate                    Rotate the mesh secret
 │   ├── diagnose                  Run diagnostic checks
+│   ├── reload                    Reload config.toml without restart
+│   ├── topology                  Show mesh topology by region/zone
+│   ├── metrics                   Export Prometheus metrics
+│   ├── hosts                     Print /etc/hosts entries for peers
 │   ├── service                   Manage the systemd service
 │   │   ├── install               Install and enable service
 │   │   ├── uninstall             Disable and remove service
 │   │   └── status                Show service status
-│   └── peering                   Manage join requests
-│       ├── start                 Start accepting joins
-│       ├── stop                  Stop accepting joins
-│       ├── list                  List pending requests
-│       ├── accept                Accept a request
-│       └── reject                Reject a request
+│   ├── peering                   Manage join requests
+│   │   ├── start                 Start accepting joins
+│   │   ├── stop                  Stop accepting joins
+│   │   ├── list                  List pending requests
+│   │   ├── watch                 Watch for requests interactively
+│   │   ├── accept                Accept a request
+│   │   └── reject                Reject a request
+│   └── zone                      Manage zone drain state
+│       ├── drain                 Mark a zone as draining
+│       ├── undrain               Restore a zone to active
+│       └── status                Show zone health and drain status
 │
 ├── state                         Inspect and manage layer state databases
 │   ├── list                      List tables in a layer's state database
 │   ├── get                       Get values from a table
 │   └── drop                      Drop (delete) a layer's state database
 │
-├── update                        Update syfrah to the latest release
-│
 ├── forge                         Per-node debug and ops (planned)
-│   ├── status                    This node's health and resources
-│   ├── vms                       Cloud Hypervisor microVM processes on this node
-│   ├── bridges                   Active bridges, VXLAN, TAP devices
-│   ├── volumes                   Mounted ZeroFS volumes, cache stats
-│   ├── nftables                  Active security group rules
-│   ├── logs                      Tail daemon logs
-│   └── drain                     Prepare node for maintenance
+│   ├── status                    This node's health and resources (planned)
+│   ├── vms                       Cloud Hypervisor microVM processes on this node (planned)
+│   ├── bridges                   Active bridges, VXLAN, TAP devices (planned)
+│   ├── volumes                   Mounted ZeroFS volumes, cache stats (planned)
+│   ├── nftables                  Active security group rules (planned)
+│   ├── logs                      Tail daemon logs (planned)
+│   └── drain                     Prepare node for maintenance (planned)
 │
 ├── org                           Organization management (planned)
-│   ├── create
-│   ├── list
-│   └── delete
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   └── delete                    (planned)
 │
 ├── project                       Project management (planned)
-│   ├── create
-│   ├── list
-│   └── delete
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   └── delete                    (planned)
 │
 ├── env                           Environment management (planned)
-│   ├── create
-│   ├── list
-│   ├── update
-│   └── destroy
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── update                    (planned)
+│   └── destroy                   (planned)
 │
 ├── vm                            Virtual machine management (planned)
-│   ├── create
-│   ├── list
-│   ├── start
-│   ├── stop
-│   ├── reboot
-│   ├── delete
-│   └── ssh
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── start                     (planned)
+│   ├── stop                      (planned)
+│   ├── reboot                    (planned)
+│   ├── delete                    (planned)
+│   └── ssh                       (planned)
 │
 ├── vpc                           VPC management (planned)
-│   ├── create
-│   ├── list
-│   ├── delete
-│   └── peer
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── delete                    (planned)
+│   └── peer                      (planned)
 │
 ├── subnet                        Subnet management (planned)
-│   ├── create
-│   └── list
+│   ├── create                    (planned)
+│   └── list                      (planned)
 │
 ├── sg                            Security group management (planned)
-│   ├── create
-│   ├── list
-│   ├── add-rule
-│   └── remove-rule
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── add-rule                  (planned)
+│   └── remove-rule               (planned)
 │
 ├── volume                        Volume management (planned)
-│   ├── create
-│   ├── list
-│   ├── attach
-│   ├── detach
-│   ├── delete
-│   └── snapshot
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── attach                    (planned)
+│   ├── detach                    (planned)
+│   ├── delete                    (planned)
+│   └── snapshot                  (planned)
 │
 ├── user                          User management (planned)
-│   ├── create
-│   ├── list
-│   └── disable
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   └── disable                   (planned)
 │
 ├── iam                           Role assignment (planned)
-│   ├── assign
-│   ├── list
-│   └── revoke
+│   ├── assign                    (planned)
+│   ├── list                      (planned)
+│   └── revoke                    (planned)
 │
 ├── apikey                        API key management (planned)
-│   ├── create
-│   ├── list
-│   ├── rotate
-│   └── delete
+│   ├── create                    (planned)
+│   ├── list                      (planned)
+│   ├── rotate                    (planned)
+│   └── delete                    (planned)
 │
 ├── login                         Authenticate (planned)
 └── logout                        Clear session (planned)
@@ -141,6 +153,7 @@ Each CLI namespace maps to an architectural layer, a source of truth, and a dire
 | `fabric` | Fabric | Local state (redb) | `layers/fabric/src/cli/` | Implemented |
 | `state` | State | Local state databases | `layers/state/src/cli/` | Implemented |
 | `update` | — | GitHub releases | `bin/syfrah/src/update.rs` | Implemented |
+| `completions` | — | — | `bin/syfrah/src/main.rs` | Implemented |
 | `forge` | Forge (per-node) | Local reality (observed) | — | Planned |
 | `org`, `project`, `env` | Organization | Raft (desired) | — | Planned |
 | `vm` | Compute | Raft (desired) | — | Planned |
@@ -509,12 +522,20 @@ layers/fabric/src/cli/
 ├── leave.rs             syfrah fabric leave
 ├── status.rs            syfrah fabric status
 ├── events.rs            syfrah fabric events
+├── audit.rs             syfrah fabric audit
 ├── peers.rs             syfrah fabric peers
+├── peers_remove.rs      syfrah fabric peers remove
+├── peers_update.rs      syfrah fabric peers update
 ├── token.rs             syfrah fabric token
 ├── rotate.rs            syfrah fabric rotate
 ├── diagnose.rs          syfrah fabric diagnose
+├── reload.rs            syfrah fabric reload
+├── topology.rs          syfrah fabric topology
+├── metrics.rs           syfrah fabric metrics
+├── hosts.rs             syfrah fabric hosts
 ├── service.rs           syfrah fabric service {install,uninstall,status}
-└── peering.rs           syfrah fabric peering {start,stop,list,accept,reject}
+├── peering.rs           syfrah fabric peering {start,stop,list,watch,accept,reject}
+└── zone.rs              syfrah fabric zone {drain,undrain,status}
 
 layers/state/src/cli/
 ├── mod.rs               StateCommand enum + dispatch

--- a/handbook/configuration.md
+++ b/handbook/configuration.md
@@ -33,6 +33,7 @@ WireGuard interface settings.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
+| `interface_name` | string | `"syfrah0"` | WireGuard interface name. The default `syfrah0` is hardcoded in `layers/fabric/src/wg.rs` as `DEFAULT_INTERFACE_NAME`. Override this if you need a different interface name (e.g., to avoid conflicts with existing WireGuard interfaces). Must not be empty. |
 | `keepalive_interval` | integer (seconds) | `25` | WireGuard persistent keepalive interval. Keeps NAT mappings alive. |
 
 ### `[peering]`

--- a/handbook/releasing.md
+++ b/handbook/releasing.md
@@ -39,7 +39,7 @@ feature branch → PR → merge to main → beta vX.Y.Z-beta.N (pre-release)
 ### How it works
 
 1. **Trigger** -- the `Release` workflow runs on push to `main` (beta) and push to `release/v*` (stable), plus `workflow_dispatch`.
-2. **Loop prevention** -- if the HEAD commit message starts with `release:`, the workflow exits immediately.
+2. **Loop prevention** -- if the HEAD commit message starts with `release:`, the workflow exits immediately. The workflow itself does not create `release:` commits. This prefix is reserved for manual version-bump commits if needed.
 3. **Version calculation** -- the workflow inspects commit messages since the last git tag and determines the base version:
 
    | Commit message contains | Bump | Example |
@@ -47,6 +47,8 @@ feature branch → PR → merge to main → beta vX.Y.Z-beta.N (pre-release)
    | `BREAKING` or `breaking:` | Major (X.0.0) | `0.2.0 -> 1.0.0` |
    | `[Feature]` or `feat:` | Minor (0.X.0) | `0.2.0 -> 0.3.0` |
    | Anything else | Patch (0.0.X) | `0.2.0 -> 0.2.1` |
+
+   The commit message scanner is **case-insensitive** for all patterns (`grep -iE`). For example, `feat:`, `Feat:`, and `FEAT:` all trigger a minor bump. Similarly, `Fix some bug` and `fix some bug` are both treated as patch bumps.
 
    This convention relies on contributors following [Conventional Commits](https://www.conventionalcommits.org/). If nobody writes `feat:` or `breaking:`, every release is a patch bump. This is intentional — patch is the safe default. For important version bumps, the maintainer cutting the release should verify the computed version makes sense before pushing.
 

--- a/handbook/workflow.md
+++ b/handbook/workflow.md
@@ -49,7 +49,7 @@ Tasks in the Ready column are picked by priority:
 | **P2** | `P2` | Should-have, schedule when ready |
 | **P3** | `P3` | Nice-to-have, backlog |
 
-When multiple tasks share the same priority, prefer the smallest (XS > S > M) to keep throughput high.
+When multiple tasks share the same priority, prefer the smallest first (XS over S over M) to keep throughput high.
 
 ## Contribution workflow
 
@@ -187,4 +187,4 @@ Body:
 | Branch cleanup | Delete after merge |
 | Commit messages | Imperative, <72 chars, reference issue |
 | Max task size | M (1-2 days). Larger = decompose. |
-| Pick order | P0 > P1 > P2 > P3, then smallest first |
+| Pick order | P0 > P1 > P2 > P3, then smallest first (XS over S over M) |


### PR DESCRIPTION
## Summary
- **handbook/cli.md**: Updated command tree to include all implemented commands (audit, topology, metrics, zone, hosts, reload, completions, peering watch, peers remove/update). Added `(planned)` suffix to every subcommand under planned namespaces. Fixed duplicate `update` entry. Updated namespace mapping table and code structure listing.
- **CLAUDE.md**: Added CLI section noting which commands are currently implemented.
- **handbook/workflow.md**: Fixed ambiguous "XS > S > M" notation to "XS over S over M" (item 27).
- **handbook/releasing.md**: Clarified that the commit message scanner is case-insensitive (`grep -iE`). Documented that the `release:` prefix is reserved for manual version-bump commits (item 29).
- **handbook/ci.md**: Added E2E tests section with cross-reference note (item 30).
- **handbook/configuration.md**: Documented `wireguard.interface_name` setting -- defaults to `syfrah0` (hardcoded in `wg.rs`), configurable via config.toml (item 31).

Part of #449

## Test plan
- [ ] Verify command tree in cli.md matches `bin/syfrah/src/main.rs` enum definitions
- [ ] Verify `interface_name` documentation matches `layers/fabric/src/config.rs`
- [ ] Confirm `grep -iE` in release.yml matches case-insensitivity claim

Closes #449