### PR TITLE
docs: fix architecture and layer documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ The long-term vision is to grow Syfrah into a full control plane that orchestrat
 |---|---|---|
 | **Core** | `syfrah-core` | Stable — types, crypto, IPv6 addressing |
 | **State** (library) | `syfrah-state` | Stable — embedded persistence (redb), cross-cutting library used by all layers |
+| **API** (library) | `syfrah-api` | Stable — error types, structured responses, cross-cutting library |
 | **Fabric** | `syfrah-fabric` | Stable — WireGuard mesh, peering, daemon, CLI |
 | Forge | — | Design phase |
 | Compute | — | Design phase |
 | Storage | — | Design phase |
 | Overlay | — | Design phase |
-| control plane | — | Design phase |
-| Org | — | Design phase |
+| Control Plane | — | Design phase |
 | IAM | — | Design phase |
+| Org | — | Design phase |
 | Products | — | Design phase |
 
 ## Install
@@ -150,9 +151,9 @@ The layers below are architecturally designed with concept documentation but hav
 - **Compute** — KVM-based microVMs via Cloud Hypervisor
 - **Storage** — S3-backed block devices (ZeroFS)
 - **Overlay** — VXLAN, VPCs, security groups, private DNS
-- **control plane** — Raft consensus + SWIM gossip, embedded on every node
-- **Org** — multi-tenant organization/project/environment model
+- **Control Plane** — Raft consensus + SWIM gossip, embedded on every node
 - **IAM** — role-based access control and API keys
+- **Org** — multi-tenant organization/project/environment model
 - **Products** — managed databases, load balancers, composed from forge primitives
 
 See [handbook/ARCHITECTURE.md](handbook/ARCHITECTURE.md) for the full design.
@@ -167,6 +168,8 @@ cargo test            # run tests
 cargo clippy          # lint
 cargo run -- --help   # run the CLI
 ```
+
+> **Note:** These are development commands for building from source, not the `syfrah` CLI. For CLI usage, see [Quick Start](#quick-start) above.
 
 ## Security
 

--- a/handbook/ARCHITECTURE.md
+++ b/handbook/ARCHITECTURE.md
@@ -39,17 +39,17 @@ These are deliberate choices, not missing features:
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
-    │   IAM                           Organization Model          │
-    │   4 roles (owner, admin,        Org → Project → Env         │
-    │   developer, viewer)            Custom env names, TTL,      │
-    │   Per-org/project scoping       deletion protection         │
-    │   API keys per project                                      │
+    │   Products                                                  │
+    │   VMs, Load Balancers, Managed PostgreSQL, ...              │
+    │   Each product = forge primitives + product-specific config  │
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
-    │   Cloud Products                                            │
-    │   VMs, Load Balancers, Managed PostgreSQL, ...              │
-    │   Each product = forge primitives + product-specific config  │
+    │   Org                             IAM                       │
+    │   Org → Project → Env             4 roles (owner, admin,    │
+    │   Custom env names, TTL,          developer, viewer)        │
+    │   deletion protection             Per-org/project scoping   │
+    │                                   API keys per project      │
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
@@ -81,13 +81,24 @@ These are deliberate choices, not missing features:
     │                                                             │
     ├─────────────────────────────────────────────────────────────┤
     │                                                             │
+    │   Core                                                      │
+    │   Pure types, crypto, IPv6 addressing (no I/O)              │
+    │                                                             │
+    ├─────────────────────────────────────────────────────────────┤
+    │                                                             │
     │   Dedicated Servers        +        S3 Buckets              │
     │   (OVH, Hetzner, Scaleway)          (same providers)        │
     │                                                             │
     └─────────────────────────────────────────────────────────────┘
+
+    Cross-cutting libraries (not vertical layers — any layer may depend on these):
+    ┌─────────────────────────────────────────────────────────────┐
+    │  State (syfrah-state): redb wrapper, ACID persistence       │
+    │  API (syfrah-api): error types, structured responses        │
+    └─────────────────────────────────────────────────────────────┘
 ```
 
-**State** is a **cross-cutting library**, not a vertical stack layer. It provides embedded persistence (redb) and is used by all layers that need to store data locally. It does not appear in the stack diagram because it sits alongside every layer rather than above or below them.
+The vertical layer order (bottom to top) is: **Core, Fabric, Forge, Compute/Storage/Overlay, Control Plane, IAM/Org, Products**. **State** and **API** are cross-cutting libraries that sit alongside the stack rather than within it -- they provide embedded persistence and shared transport types respectively, and are used by all layers that need them.
 
 ## Layer by layer
 
@@ -352,7 +363,7 @@ Regions and availability zones are logical labels on nodes. They represent where
 | Storage engine | ZeroFS | S3-backed block devices, Rust, local cache |
 | Overlay encap | VXLAN | Standard, kernel-native, 16M VNIs |
 | Firewall | nftables | Per-VM security groups, stateful, conntrack |
-| DNS | CoreDNS | Lightweight, per-VPC zones |
+| DNS | CoreDNS (planned) | Lightweight, per-VPC zones -- not yet implemented, part of the overlay layer |
 | Serialization | serde + JSON | All public types are Serialize/Deserialize |
 | Errors | thiserror (lib), anyhow (bin) | Project convention |
 
@@ -430,7 +441,7 @@ The architecture assumes a hostile operational environment. Nodes are rented mac
 | **Compute** (`layers/compute/`) | Planned | README only, no code |
 | **Storage** (`layers/storage/`) | Planned | README only, no code |
 | **Overlay** (`layers/overlay/`) | Planned | README only, no code |
-| **control plane** (`layers/controlplane/`) | Planned | README only, no code |
+| **Control Plane** (`layers/controlplane/`) | Planned | README only, no code |
 | **IAM** (`layers/iam/`) | Planned | README only, no code |
 | **Organization** (`layers/org/`) | Planned | README only, no code |
 | **Products** (`layers/products/`) | Planned | README only, no code |

--- a/handbook/local-dev.md
+++ b/handbook/local-dev.md
@@ -107,7 +107,7 @@ Ensure Docker daemon has IPv6 enabled. Check `/etc/docker/daemon.json`:
 
 ## Running E2E Tests Locally
 
-The CI E2E suite (`tests/e2e/run.sh`) rebuilds a full Docker image on every run (~3 min), which makes local iteration slow. `dev/e2e.sh` solves this by volume-mounting a locally-compiled binary into lightweight containers.
+There are two different E2E setups. **CI mode** (`tests/e2e/run.sh`) builds a full Docker image via `tests/e2e/Dockerfile` that compiles syfrah with musl -- the binary is baked into the image. This takes ~3 min per run, which makes local iteration slow. **Local dev mode** (`dev/e2e.sh`) solves this by building a lightweight base image (no Rust compilation) and volume-mounting a locally-compiled binary into each container.
 
 ### Quick start
 

--- a/handbook/repository.md
+++ b/handbook/repository.md
@@ -11,15 +11,16 @@ The repository is organized by architectural layer. Each layer is a self-contain
     ────────                              ────────────────              ──────
 
     layers/core/                          Foundation types (no I/O)     Implemented
+    layers/state/                         State library (cross-cutting) Implemented
+    layers/api/                           API library (cross-cutting)   Implemented
     layers/fabric/                        Fabric layer                  Implemented
-    layers/state/                         State inspection              Implemented
     layers/forge/                         Forge layer                   Planned (README only)
     layers/compute/                       Compute layer (Cloud Hypervisor) Planned (README only)
     layers/storage/                       Storage layer                 Planned (README only)
     layers/overlay/                       Overlay layer                 Planned (README only)
     layers/controlplane/                  Control plane layer           Planned (README only)
-    layers/org/                           Organization model            Planned (README only)
     layers/iam/                           IAM layer                     Planned (README only)
+    layers/org/                           Organization model            Planned (README only)
     layers/products/                      Products layer                Planned (README only)
 
     One folder = one layer.
@@ -347,8 +348,9 @@ Lower layers never depend on higher layers. `core` is the foundation.
 
 ```
     syfrah-core             ← depends on nothing (foundation)
-    syfrah-fabric           ← depends on core
-    syfrah-state            ← depends on nothing (standalone state inspection)
+    syfrah-state            ← depends on nothing (cross-cutting persistence library)
+    syfrah-api              ← depends on nothing (cross-cutting transport library)
+    syfrah-fabric           ← depends on core, state, api
     bin/syfrah              ← depends on fabric, state
 ```
 
@@ -356,8 +358,9 @@ Lower layers never depend on higher layers. `core` is the foundation.
 
 ```
     syfrah-core             ← depends on nothing (foundation)
-    syfrah-fabric           ← depends on core
-    syfrah-state            ← depends on nothing
+    syfrah-state            ← depends on nothing (cross-cutting)
+    syfrah-api              ← depends on nothing (cross-cutting)
+    syfrah-fabric           ← depends on core, state, api
     syfrah-org              ← depends on core
     syfrah-iam              ← depends on core, org
     syfrah-compute          ← depends on core, fabric

--- a/handbook/testing.md
+++ b/handbook/testing.md
@@ -302,7 +302,14 @@ just e2e-local 01_fabric    # single scenario
 just ci && just e2e
 ```
 
-The `just e2e-local` command uses `dev/e2e.sh`, which volume-mounts a locally-compiled static binary into lightweight containers. This avoids the ~3 min Docker image rebuild, making the edit-build-test cycle much faster. See `handbook/local-dev.md` for details.
+There are **two different E2E setups** depending on the context:
+
+| Setup | Command | How it works |
+|---|---|---|
+| **CI mode** | `just e2e` / `./tests/e2e/run.sh` | Builds a Docker image via `tests/e2e/Dockerfile` that compiles syfrah with musl for static linking. The binary is baked into the image. This is what CI uses. |
+| **Local dev mode** | `just e2e-local` / `./dev/e2e.sh` | Builds a lightweight base image (debian + wireguard-tools, no Rust compilation), then volume-mounts a locally-compiled static binary into each container. Much faster iteration (~10s vs ~3 min). |
+
+Both setups run the same scenarios from `tests/e2e/scenarios/` via the same `run.sh` orchestrator and `lib.sh` helpers. The only difference is how the syfrah binary gets into the containers. See `handbook/local-dev.md` for local dev details.
 
 ## What we test at each layer
 


### PR DESCRIPTION
## Summary

- Align layer order across README.md, handbook/ARCHITECTURE.md, and handbook/repository.md to one canonical order: Core, State (library), API (library), Fabric, Forge, Compute, Storage, Overlay, Control Plane, IAM, Org, Products
- Add State and API as cross-cutting libraries in the ARCHITECTURE.md stack diagram
- Add Core layer to the stack diagram (was missing)
- Fix dependency graph: fabric depends on core, state, and api (verified against `layers/fabric/Cargo.toml`)
- Mark CoreDNS as `(planned)` in the technology table
- Clarify two different E2E setups (CI vs local dev) in testing.md and local-dev.md
- Add note clarifying cargo commands are dev commands, not the syfrah CLI

## Test plan

- [ ] Verify all three files (README, ARCHITECTURE, repository) list layers in the same canonical order
- [ ] Verify dependency graph matches actual Cargo.toml declarations
- [ ] Verify CoreDNS is marked as planned
- [ ] Verify E2E documentation distinguishes CI mode from local dev mode

Closes #449