### PR TITLE
docs: standardize naming and terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The layers below are architecturally designed with concept documentation but hav
 - **Compute** — KVM-based microVMs via Cloud Hypervisor
 - **Storage** — S3-backed block devices (ZeroFS)
 - **Overlay** — VXLAN, VPCs, security groups, private DNS
-- **Control Plane** — Raft consensus + SWIM gossip, embedded on every node
+- **control plane** — Raft consensus + SWIM gossip, embedded on every node
 - **Org** — multi-tenant organization/project/environment model
 - **IAM** — role-based access control and API keys
 - **Products** — managed databases, load balancers, composed from forge primitives


### PR DESCRIPTION
## Summary
- Lowercase "control plane" in README.md roadmap section (was title-cased "Control Plane", inconsistent with the rest of the docs where it's already lowercase in prose)
- Items 21-24 (fabric/mesh definitions, peering/joining glossary, node/peer glossary, secret prefix clarification) were already completed in #451 and earlier PRs

## Test plan
- [ ] Verify no remaining title-cased "Control Plane" in prose (diagrams and headings are intentionally title-cased)
- [ ] Confirm glossary in `layers/fabric/README.md` is intact
- [ ] Confirm `syf_sk_` vs `syf_key_` note in `handbook/api-architecture.md` is intact

Part of #449