### PR TITLE
feat(compute): implement VmPhase state machine with strict transitions

### DIFF
--- a/layers/compute/src/error.rs
+++ b/layers/compute/src/error.rs
@@ -123,13 +123,7 @@ pub enum ProcessError {
     SignalFailed { signal: String, pid: u32 },
 }
 
-/// Invalid state machine transition.
-#[derive(Debug, thiserror::Error)]
-#[error("cannot transition from {from} to {to}")]
-pub struct TransitionError {
-    pub from: String,
-    pub to: String,
-}
+pub use crate::phase::TransitionError;
 
 /// Operation blocked by a concurrent operation on the same VM.
 #[derive(Debug, thiserror::Error)]
@@ -248,9 +242,10 @@ mod tests {
 
     #[test]
     fn transition_error_display() {
+        use crate::phase::VmPhase;
         let e = TransitionError {
-            from: "Running".to_string(),
-            to: "Pending".to_string(),
+            from: VmPhase::Running,
+            to: VmPhase::Pending,
         };
         let msg = e.to_string();
         assert!(msg.contains("Running"));
@@ -291,9 +286,10 @@ mod tests {
 
     #[test]
     fn compute_error_from_transition() {
+        use crate::phase::VmPhase;
         let inner = TransitionError {
-            from: "Pending".to_string(),
-            to: "Running".to_string(),
+            from: VmPhase::Pending,
+            to: VmPhase::Running,
         };
         let outer: ComputeError = inner.into();
         assert!(matches!(outer, ComputeError::Transition(_)));

--- a/layers/compute/src/phase.rs
+++ b/layers/compute/src/phase.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::error::TransitionError;
-
 /// Current phase in the VM lifecycle.
 ///
 /// Every VM moves through these phases in a strict order.
@@ -18,6 +16,25 @@ pub enum VmPhase {
     Deleted,
     Failed,
 }
+
+/// Error returned when an invalid state transition is attempted.
+#[derive(Debug, Clone)]
+pub struct TransitionError {
+    pub from: VmPhase,
+    pub to: VmPhase,
+}
+
+impl std::fmt::Display for TransitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid transition from {:?} to {:?}",
+            self.from, self.to
+        )
+    }
+}
+
+impl std::error::Error for TransitionError {}
 
 impl VmPhase {
     /// Returns `true` if the transition from `self` to `target` is allowed.
@@ -48,8 +65,8 @@ impl VmPhase {
             Ok(target)
         } else {
             Err(TransitionError {
-                from: format!("{self:?}"),
-                to: format!("{target:?}"),
+                from: self,
+                to: target,
             })
         }
     }
@@ -127,8 +144,9 @@ mod tests {
                 "{from:?} -> {to:?} should be rejected"
             );
             let err = from.transition(to).unwrap_err();
-            assert_eq!(err.from, format!("{from:?}"));
-            assert_eq!(err.to, format!("{to:?}"));
+            assert_eq!(err.from, from);
+            assert_eq!(err.to, to);
+            assert!(err.to_string().contains("invalid transition"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Implement `VmPhase` enum with 9 phases: Pending, Provisioning, Starting, Running, Stopping, Stopped, Deleting, Deleted, Failed
- Add `can_transition_to` and `transition` methods enforcing the strict transition table from `layers/compute/README.md`
- Add `TransitionError` struct with `from`/`to` fields and `Display`/`Error` impls
- Add helper methods: `is_terminal`, `is_failed`, `is_active`
- Re-export `VmPhase` and `TransitionError` from crate root
- 7 unit tests covering all 14 valid transitions, 8 invalid transitions, helpers, serde roundtrip, and error display

## Test plan

- [x] All 14 valid transitions accepted
- [x] Invalid transitions return `TransitionError` with correct `from`/`to`
- [x] `is_terminal` returns true only for `Deleted`
- [x] `is_failed` returns true only for `Failed`
- [x] `is_active` returns true for Provisioning, Starting, Running, Stopping
- [x] Serde roundtrip for all 9 phases
- [x] `TransitionError` display format matches spec

Closes #459