### PR TITLE
feat(compute): define compute.proto with 9 RPCs and HTTP annotations

### DIFF
--- a/layers/compute/proto/compute.proto
+++ b/layers/compute/proto/compute.proto
@@ -4,14 +4,218 @@ package syfrah.compute.v1;
 
 option go_package = "github.com/sacha-ops/syfrah/gen/go/syfrah/v1;syfrahv1";
 
-// ComputeService exposes VM and container orchestration operations.
+import "syfrah/v1/common.proto";
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+
+// ComputeService exposes the syfrah compute layer for VM lifecycle management.
 service ComputeService {
+  // --- VM lifecycle ---
+
+  // CreateVm creates a new virtual machine from the given specification.
+  rpc CreateVm(CreateVmRequest) returns (Vm) {
+    option (google.api.http) = { post: "/compute/vms" body: "*" };
+  }
+
+  // GetVm returns the details of a single virtual machine by ID.
+  rpc GetVm(GetVmRequest) returns (Vm) {
+    option (google.api.http) = { get: "/compute/vms/{id}" };
+  }
+
+  // ListVms returns all virtual machines on this node.
+  rpc ListVms(ListVmsRequest) returns (ListVmsResponse) {
+    option (google.api.http) = { get: "/compute/vms" };
+  }
+
+  // DeleteVm deletes a virtual machine and cleans up all runtime artifacts.
+  rpc DeleteVm(DeleteVmRequest) returns (DeleteVmResponse) {
+    option (google.api.http) = { delete: "/compute/vms/{id}" };
+  }
+
+  // StartVm boots a stopped virtual machine.
+  rpc StartVm(StartVmRequest) returns (Vm) {
+    option (google.api.http) = { post: "/compute/vms/{id}/start" body: "*" };
+  }
+
+  // StopVm shuts down a running virtual machine.
+  rpc StopVm(StopVmRequest) returns (Vm) {
+    option (google.api.http) = { post: "/compute/vms/{id}/stop" body: "*" };
+  }
+
+  // RebootVm reboots a running virtual machine.
+  rpc RebootVm(RebootVmRequest) returns (Vm) {
+    option (google.api.http) = { post: "/compute/vms/{id}/reboot" body: "*" };
+  }
+
+  // ResizeVm hot-resizes the CPU and memory of a running virtual machine.
+  rpc ResizeVm(ResizeVmRequest) returns (Vm) {
+    option (google.api.http) = { post: "/compute/vms/{id}/resize" body: "*" };
+  }
+
+  // --- Status ---
+
   // GetStatus returns the health and summary of the compute layer.
-  rpc GetStatus(ComputeGetStatusRequest) returns (ComputeGetStatusResponse);
+  rpc GetStatus(GetStatusRequest) returns (GetStatusResponse) {
+    option (google.api.http) = { get: "/compute/status" };
+  }
 }
 
-message ComputeGetStatusRequest {}
+// ---- VM resource messages ----
 
-message ComputeGetStatusResponse {
+// Vm represents a virtual machine and its current state.
+message Vm {
+  // Unique identifier for this VM.
+  string id = 1;
+  // Number of virtual CPUs allocated.
+  uint32 vcpus = 2;
+  // Memory allocated in megabytes.
+  uint32 memory_mb = 3;
+  // Rootfs image name (e.g. "ubuntu-24.04").
+  string image = 4;
+  // Current lifecycle phase (Pending, Provisioning, Starting, Running, Stopping, Stopped, Deleting, Deleted, Failed).
+  string phase = 5;
+  // ISO 8601 timestamp of when the VM was created.
+  string created_at = 6;
+  // Uptime in seconds, present only when the VM is running.
+  optional uint64 uptime_secs = 7;
+  // GPU configuration for this VM.
+  GpuMode gpu = 8;
+  // Attached volumes.
+  repeated VolumeAttachment volumes = 9;
+  // Network configuration.
+  optional NetworkConfig network = 10;
+}
+
+// GpuMode describes the GPU configuration for a VM.
+message GpuMode {
+  // Set to true for no GPU.
+  bool none = 1;
+  // VFIO passthrough configuration, mutually exclusive with none.
+  GpuPassthrough passthrough = 2;
+}
+
+// GpuPassthrough describes a VFIO GPU passthrough device.
+message GpuPassthrough {
+  // PCI bus-device-function address (e.g. "0000:01:00.0").
+  string bdf = 1;
+}
+
+// VolumeAttachment describes a block device attached to a VM.
+message VolumeAttachment {
+  // Path to the block device or image file.
+  string path = 1;
+  // Whether the volume is mounted read-only.
+  bool read_only = 2;
+}
+
+// NetworkConfig describes the network interface configuration for a VM.
+message NetworkConfig {
+  // Name of the TAP device (created by the overlay layer).
+  string tap_name = 1;
+  // Optional MAC address override.
+  optional string mac = 2;
+}
+
+// ---- Request messages ----
+
+// CreateVmRequest contains the specification for a new virtual machine.
+message CreateVmRequest {
+  // Human-readable name for the VM.
+  string name = 1;
+  // Number of virtual CPUs to allocate.
+  uint32 vcpus = 2;
+  // Memory to allocate in megabytes.
+  uint32 memory_mb = 3;
+  // Rootfs image name (e.g. "ubuntu-24.04").
+  string image = 4;
+  // Optional path to a custom kernel (defaults to shared vmlinux).
+  optional string kernel = 5;
+  // GPU configuration.
+  GpuMode gpu = 6;
+  // Volumes to attach.
+  repeated VolumeAttachment volumes = 7;
+  // Network configuration.
+  optional NetworkConfig network = 8;
+}
+
+// GetVmRequest identifies a VM to retrieve.
+message GetVmRequest {
+  // VM identifier.
+  string id = 1;
+}
+
+// ListVmsRequest lists all VMs, with optional pagination.
+message ListVmsRequest {
+  PaginationRequest pagination = 1;
+}
+
+// DeleteVmRequest identifies a VM to delete.
+message DeleteVmRequest {
+  // VM identifier.
+  string id = 1;
+}
+
+// StartVmRequest identifies a VM to boot.
+message StartVmRequest {
+  // VM identifier.
+  string id = 1;
+}
+
+// StopVmRequest identifies a VM to shut down.
+message StopVmRequest {
+  // VM identifier.
+  string id = 1;
+  // If true, use force shutdown (power button) instead of graceful ACPI shutdown.
+  optional bool force = 2;
+}
+
+// RebootVmRequest identifies a VM to reboot.
+message RebootVmRequest {
+  // VM identifier.
+  string id = 1;
+}
+
+// ResizeVmRequest specifies new CPU and memory values for a running VM.
+message ResizeVmRequest {
+  // VM identifier.
+  string id = 1;
+  // New number of virtual CPUs (omit to keep current).
+  optional uint32 vcpus = 2;
+  // New memory in megabytes (omit to keep current).
+  optional uint32 memory_mb = 3;
+}
+
+// GetStatusRequest is empty — no parameters needed.
+message GetStatusRequest {}
+
+// ---- Response messages ----
+
+// ListVmsResponse contains the list of virtual machines.
+message ListVmsResponse {
+  // List of VMs.
+  repeated Vm vms = 1;
+  // Pagination metadata.
+  PaginationResponse pagination = 2;
+}
+
+// DeleteVmResponse confirms deletion of a VM.
+message DeleteVmResponse {
+  // ID of the deleted VM.
+  string id = 1;
+  // Deletion status (e.g. "deleted").
+  string status = 2;
+}
+
+// GetStatusResponse returns the health and resource summary of the compute layer.
+message GetStatusResponse {
+  // Overall health status of the compute layer.
   string status = 1;
+  // Total number of VMs on this node.
+  uint32 total_vms = 2;
+  // Number of VMs currently in Running phase.
+  uint32 running_vms = 3;
+  // Available virtual CPUs on this node.
+  uint32 available_vcpus = 4;
+  // Available memory in megabytes on this node.
+  uint32 available_memory_mb = 5;
 }

--- a/layers/compute/proto/google/api/annotations.proto
+++ b/layers/compute/proto/google/api/annotations.proto
@@ -1,0 +1,31 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "AnnotationsProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See `HttpRule`.
+  HttpRule http = 72295728;
+}

--- a/layers/compute/proto/google/api/http.proto
+++ b/layers/compute/proto/google/api/http.proto
@@ -1,0 +1,370 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "HttpProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Defines the HTTP configuration for an API service. It contains a list of
+// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+message Http {
+  // A list of HTTP configuration rules that apply to individual API methods.
+  //
+  // **NOTE:** All service configuration rules follow "last one wins" order.
+  repeated HttpRule rules = 1;
+
+  // When set to true, URL path parameters will be fully URI-decoded except in
+  // cases of single segment matches in reserved expansion, where "%2F" will be
+  // left encoded.
+  //
+  // The default behavior is to not decode RFC 6570 reserved characters in multi
+  // segment matches.
+  bool fully_decode_reserved_expansion = 2;
+}
+
+// gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and one or
+// more HTTP REST endpoints. It allows developers to build a single API service
+// that supports both gRPC APIs and REST APIs. Many systems, including [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+// how different portions of the gRPC request message are mapped to the URL
+// path, URL query parameters, and HTTP request body. It also controls how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule` is
+// typically specified as an `google.api.http` annotation on the gRPC method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The path
+// template may refer to one or more fields in the gRPC request message, as long
+// as each field is a non-repeated field with a primitive (non-message) type.
+// The path template controls how fields of the request message are mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(name: "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path template
+// automatically become HTTP query parameters if there is no HTTP request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// - HTTP: `GET /v1/messages/123456?revision=2&sub.subfield=foo`
+// - gRPC: `GetMessage(message_id: "123456" revision: 2 sub:
+// SubMessage(subfield: "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have a
+// primitive type or a repeated primitive type or a non-repeated message type.
+// In the case of a repeated type, the parameter can be repeated in the URL
+// as `...?param=A&param=B`. In the case of a message type, each field of the
+// message is mapped to a separate parameter, such as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body` field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where the
+// representation of the JSON in the request body is determined by
+// protos JSON encoding:
+//
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define that
+// every field not bound by the path template should be mapped to the
+// request body.  This enables the following alternative definition of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// - HTTP: `PATCH /v1/messages/123456 { "text": "Hi!" }`
+// - gRPC: `UpdateMessage(message_id: "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice when
+// defining REST APIs. The common usage of `*` is in custom methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC mappings:
+//
+// - HTTP: `GET /v1/messages/123456`
+// - gRPC: `GetMessage(message_id: "123456")`
+//
+// - HTTP: `GET /v1/users/me/messages/123456`
+// - gRPC: `GetMessage(user_id: "me" message_id: "123456")`
+//
+// Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the URL path.
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They
+//    are passed via the HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and the
+//      parameter name is the field path in the request message. A repeated
+//      field can be represented as multiple query parameters under the same
+//      name.
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL
+//  query parameter, all fields
+//     are passed via URL path and HTTP request body.
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP
+//  request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**` matches
+// zero or more URL path segments, which must be the last part of the URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by its
+// template. A variable template must not contain other variables. If a variable
+// matches a single path segment, its template may be omitted, e.g. `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+// contains any reserved character, such characters should be percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as `"{var}"` or
+// `"{var=*}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
+//
+// If a variable contains multiple path segments, such as `"{var=foo/*}"`
+// or `"{var=**}"`, when such a variable is expanded into a URL path on the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
+//
+// Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration language
+// for configuring a gRPC service to become a user-facing product. The
+// service config is simply the YAML representation of the `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure gRPC
+// transcoding in your service config YAML files. You do this by specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+// effect as the proto annotation. This can be particularly useful if you
+// have a proto that is reused in multiple services. Note that any transcoding
+// specified in the service config will override any matching transcoding
+// configuration in the proto.
+//
+// The following example selects a gRPC method and applies an `HttpRule` to it:
+//
+//     http:
+//       rules:
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+// proto to JSON conversion must follow the [proto3
+// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// Expansion, the multi segment variable **does not** follow RFC 6570 Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+// does not expand special characters like `?` and `#`, which would lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped field,
+// because client libraries are not capable of handling such variable expansion.
+//
+// The path variables **must not** capture the leading "/" character. The reason
+// is that the most common use case "{var}" does not capture the leading "/"
+// character. For consistency, all path variables must share the same behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters, because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it can map
+// the request or response body to a repeated field. However, some gRPC
+// Transcoding implementations may not support this feature.
+message HttpRule {
+  // Selects a method to which this rule applies.
+  //
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax
+  // details.
+  string selector = 1;
+
+  // Determines the URL pattern is matched by this rules. This pattern can be
+  // used with any of the {get|put|post|delete|patch} methods. A custom method
+  // can be defined using the 'custom' field.
+  oneof pattern {
+    // Maps to HTTP GET. Used for listing and getting information about
+    // resources.
+    string get = 2;
+
+    // Maps to HTTP PUT. Used for replacing a resource.
+    string put = 3;
+
+    // Maps to HTTP POST. Used for creating a resource or performing an action.
+    string post = 4;
+
+    // Maps to HTTP DELETE. Used for deleting a resource.
+    string delete = 5;
+
+    // Maps to HTTP PATCH. Used for updating a resource.
+    string patch = 6;
+
+    // The custom pattern is used for specifying an HTTP method that is not
+    // included in the `pattern` field, such as HEAD, or "*" to leave the
+    // HTTP method unspecified for this rule. The wild-card rule is useful
+    // for services that provide content to Web (HTML) clients.
+    CustomHttpPattern custom = 8;
+  }
+
+  // The name of the request field whose value is mapped to the HTTP request
+  // body, or `*` for mapping all request fields not captured by the path
+  // pattern to the HTTP body, or omitted for not having any HTTP request body.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  string body = 7;
+
+  // Optional. The name of the response field whose value is mapped to the HTTP
+  // response body. When omitted, the entire response message will be used
+  // as the HTTP response body.
+  //
+  // NOTE: The referred field must be present at the top-level of the response
+  // message type.
+  string response_body = 12;
+
+  // Additional HTTP bindings for the selector. Nested bindings must
+  // not contain an `additional_bindings` field themselves (that is,
+  // the nesting may only be one level deep).
+  repeated HttpRule additional_bindings = 11;
+}
+
+// A custom pattern is used for defining custom HTTP verb.
+message CustomHttpPattern {
+  // The name of this custom HTTP verb.
+  string kind = 1;
+
+  // The path matched by this custom verb.
+  string path = 2;
+}

--- a/scripts/gen-openapi.py
+++ b/scripts/gen-openapi.py
@@ -53,7 +53,7 @@ def parse_proto(proto_path: str) -> dict:
     rpc_pattern = re.compile(
         r"((?://[^\n]*\n\s*)*)"  # leading comments
         r"rpc\s+(\w+)\s*\(\s*(\w+)\s*\)\s*returns\s*\(\s*(\w+)\s*\)\s*"
-        r"(?:\{[^}]*option\s*\(google\.api\.http\)\s*=\s*\{([^}]*)\}[^}]*\})?",
+        r"(?:\{[^}]*option\s*\(google\.api\.http\)\s*=\s*\{((?:[^}]|\}(?!\s*;))*)\}\s*;[^}]*\})?",
         re.MULTILINE,
     )
     for m in rpc_pattern.finditer(content):
@@ -415,7 +415,7 @@ def _humanize(name: str) -> str:
 
 
 # Stub layers: those whose only RPC is GetStatus
-STUB_LAYERS = {"compute", "forge", "overlay", "storage", "org"}
+STUB_LAYERS = {"forge", "overlay", "storage", "org"}
 
 
 def main():


### PR DESCRIPTION
## Summary

- Rewrites `layers/compute/proto/compute.proto` from a stub (1 RPC) to a full VM lifecycle API (9 RPCs)
- All RPCs have `google.api.http` annotations for REST mapping: CreateVm, GetVm, ListVms, DeleteVm, StartVm, StopVm, RebootVm, ResizeVm, GetStatus
- Defines VM resource model messages: `Vm`, `GpuMode`, `GpuPassthrough`, `VolumeAttachment`, `NetworkConfig`
- Fixes `gen-openapi.py` regex to handle `{id}` path templates in HTTP annotations
- Removes compute from `STUB_LAYERS` so full OpenAPI spec is generated

## Test plan

- [x] `python3 scripts/gen-openapi.py` generates `layers/compute/openapi.yaml` with all 9 endpoints
- [x] `bash scripts/gen-openapi.sh` merges compute into `api/openapi.yaml` (26 total paths)
- [x] `cargo fmt && cargo clippy` pass clean
- [x] Fabric layer OpenAPI still generates correctly (15 operations, no regression)
- [ ] CI passes

Closes #491