### PR TITLE
test(compute): mock CH server + client unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -2099,8 +2100,12 @@ dependencies = [
 name = "syfrah-compute"
 version = "0.2.0"
 dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2586,6 +2591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2709,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -12,3 +12,8 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+hyper = { version = "1", features = ["server", "http1"] }
+tempfile = "3"
+tokio = { workspace = true }

--- a/layers/compute/src/client.rs
+++ b/layers/compute/src/client.rs
@@ -369,6 +369,15 @@ fn is_idempotent_ok(status: u16, operation: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::{MockChServer, MockResponse};
+    use tempfile::TempDir;
+
+    /// Helper: create a temp dir and return (dir, socket_path).
+    fn temp_socket() -> (TempDir, PathBuf) {
+        let dir = TempDir::new().expect("failed to create temp dir");
+        let sock = dir.path().join("api.sock");
+        (dir, sock)
+    }
 
     // ── Idempotence truth table ──────────────────────────────────────
 
@@ -409,7 +418,6 @@ mod tests {
 
     #[test]
     fn create_is_not_idempotent() {
-        // 409 on create is an error, not a no-op.
         assert!(!is_idempotent_ok(409, "create"));
     }
 
@@ -445,5 +453,363 @@ mod tests {
         let client = ChClient::new(PathBuf::from("/tmp/nonexistent-ch-test.sock"));
         let result = client.ping().await;
         assert!(matches!(result, Err(ClientError::SocketNotFound { .. })));
+    }
+
+    // ── ping tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn ping_returns_true_on_200() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vmm.ping",
+            MockResponse::ok_json(r#"{"pong":true}"#),
+        );
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let result = client.ping().await.expect("ping should succeed");
+        assert!(result);
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn ping_socket_not_found() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("nonexistent.sock");
+        let client = ChClient::new(sock);
+        let err = client.ping().await.unwrap_err();
+        assert!(matches!(err, ClientError::SocketNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn ping_timeout() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vmm.ping",
+            MockResponse::delayed(Duration::from_secs(5)),
+        );
+        mock.start().await;
+
+        let client = ChClient::with_timeout(sock, Duration::from_secs(1));
+        let err = client.ping().await.unwrap_err();
+        assert!(matches!(err, ClientError::Timeout { .. }));
+        mock.shutdown();
+    }
+
+    // ── info tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn info_returns_parsed_json() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        let vm_json = r#"{"state":"Running","vcpus":4,"memory":1073741824}"#;
+        mock.route("GET", "/vm.info", MockResponse::ok_json(vm_json));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let info = client.info().await.expect("info should succeed");
+        assert_eq!(info["state"], "Running");
+        assert_eq!(info["vcpus"], 4);
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn info_garbage_body_returns_invalid_response() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vm.info",
+            MockResponse::ok_json("this is not json {{{{"),
+        );
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let err = client.info().await.unwrap_err();
+        assert!(matches!(err, ClientError::InvalidResponse { .. }));
+        mock.shutdown();
+    }
+
+    // ── create tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_returns_ok_on_204() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.create", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let config = serde_json::json!({"kernel": "/vmlinux"});
+        client.create(config).await.expect("create should succeed");
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn create_409_is_error_not_idempotent() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.create", MockResponse::error(409));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let config = serde_json::json!({"kernel": "/vmlinux"});
+        let err = client.create(config).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ClientError::UnexpectedStatus { status: 409, .. }
+        ));
+        mock.shutdown();
+    }
+
+    // ── boot tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn boot_returns_ok_on_204() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.boot", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client.boot().await.expect("boot should succeed");
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn boot_404_vm_not_created_is_error() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.boot", MockResponse::error(404));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let err = client.boot().await.unwrap_err();
+        assert!(matches!(
+            err,
+            ClientError::UnexpectedStatus { status: 404, .. }
+        ));
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn boot_409_already_booted_is_idempotent_ok() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.boot", MockResponse::error(409));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .boot()
+            .await
+            .expect("boot 409 should be treated as success");
+        mock.shutdown();
+    }
+
+    // ── shutdown tests ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn shutdown_graceful_returns_ok_on_204() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.shutdown", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .shutdown_graceful()
+            .await
+            .expect("shutdown should succeed");
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn shutdown_graceful_404_already_stopped_is_idempotent_ok() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.shutdown", MockResponse::error(404));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .shutdown_graceful()
+            .await
+            .expect("shutdown 404 should be treated as success");
+        mock.shutdown();
+    }
+
+    // ── delete tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn delete_returns_ok_on_204() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.delete", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client.delete().await.expect("delete should succeed");
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn delete_404_already_deleted_is_idempotent_ok() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.delete", MockResponse::error(404));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .delete()
+            .await
+            .expect("delete 404 should be treated as success");
+        mock.shutdown();
+    }
+
+    // ── resize tests ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resize_returns_ok_on_204() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.resize", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .resize(Some(4), Some(1_073_741_824))
+            .await
+            .expect("resize should succeed");
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn resize_sends_correct_json_body() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route("PUT", "/vm.resize", MockResponse::no_content());
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        client
+            .resize(Some(8), Some(2_147_483_648))
+            .await
+            .expect("resize should succeed");
+
+        let captured = mock
+            .captured_body("PUT", "/vm.resize")
+            .await
+            .expect("request body should be captured");
+        let json: serde_json::Value =
+            serde_json::from_str(&captured).expect("captured body should be valid JSON");
+        assert_eq!(json["desired_vcpus"], 8);
+        assert_eq!(json["desired_ram"], 2_147_483_648_u64);
+        mock.shutdown();
+    }
+
+    // ── counters tests ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn counters_returns_parsed_json() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        let counters_json = r#"{"vcpu":{"cycles":1000}}"#;
+        mock.route("GET", "/vm.counters", MockResponse::ok_json(counters_json));
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let counters = client.counters().await.expect("counters should succeed");
+        assert_eq!(counters["vcpu"]["cycles"], 1000);
+        mock.shutdown();
+    }
+
+    // ── error handling tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn connection_refused_no_server_listening() {
+        let (_dir, sock) = temp_socket();
+        // Create the socket file so SocketNotFound is not triggered, but
+        // nobody is listening. We bind+close to leave a stale socket.
+        let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+        drop(listener);
+        // The socket file still exists but nobody is listening.
+        let client = ChClient::new(sock);
+        let err = client.ping().await.unwrap_err();
+        assert!(
+            matches!(err, ClientError::ConnectionRefused)
+                || matches!(err, ClientError::InvalidResponse { .. })
+        );
+    }
+
+    #[tokio::test]
+    async fn server_returns_500_unexpected_status() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vm.info",
+            MockResponse::error_with_body(500, r#"{"error":"internal"}"#),
+        );
+        mock.start().await;
+
+        let client = ChClient::new(sock);
+        let err = client.info().await.unwrap_err();
+        assert!(matches!(
+            err,
+            ClientError::UnexpectedStatus { status: 500, .. }
+        ));
+        mock.shutdown();
+    }
+
+    #[tokio::test]
+    async fn timeout_on_slow_server() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vm.info",
+            MockResponse::delayed(Duration::from_secs(5)),
+        );
+        mock.start().await;
+
+        let client = ChClient::with_timeout(sock, Duration::from_secs(1));
+        let err = client.info().await.unwrap_err();
+        assert!(matches!(err, ClientError::Timeout { .. }));
+        mock.shutdown();
+    }
+
+    // ── concurrent requests ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn concurrent_clients_both_succeed() {
+        let (_dir, sock) = temp_socket();
+        let mut mock = MockChServer::new(&sock);
+        mock.route(
+            "GET",
+            "/vmm.ping",
+            MockResponse::ok_json(r#"{"pong":true}"#),
+        );
+        mock.start().await;
+
+        let sock_path = sock.clone();
+        let (r1, r2) = tokio::join!(
+            async {
+                let c = ChClient::new(sock_path.clone());
+                c.ping().await
+            },
+            async {
+                let c = ChClient::new(sock.clone());
+                c.ping().await
+            },
+        );
+        assert!(r1.unwrap());
+        assert!(r2.unwrap());
+        mock.shutdown();
     }
 }

--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -4,6 +4,8 @@ pub mod error;
 pub mod phase;
 #[allow(dead_code)]
 mod runtime;
+#[cfg(test)]
+pub mod test_utils;
 pub mod types;
 
 pub use error::{

--- a/layers/compute/src/test_utils.rs
+++ b/layers/compute/src/test_utils.rs
@@ -1,0 +1,241 @@
+//! Test utilities for the compute layer.
+//!
+//! `MockChServer` is a lightweight HTTP/1.1 server on a Unix socket that
+//! simulates the Cloud Hypervisor REST API. It is designed to be reusable
+//! across client tests and future process-manager tests.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::UnixListener;
+use tokio::sync::Notify;
+
+/// A canned response that the mock will return for a given (method, path).
+#[derive(Clone)]
+pub struct MockResponse {
+    pub status: u16,
+    pub body: Option<String>,
+    /// Optional delay before sending the response (simulates slow CH).
+    pub delay: Option<Duration>,
+    /// If true, drop the connection without sending a response.
+    pub drop_connection: bool,
+}
+
+impl MockResponse {
+    /// 204 No Content — the standard success for mutating CH endpoints.
+    pub fn no_content() -> Self {
+        Self {
+            status: 204,
+            body: None,
+            delay: None,
+            drop_connection: false,
+        }
+    }
+
+    /// 200 OK with a JSON body.
+    pub fn ok_json(json: &str) -> Self {
+        Self {
+            status: 200,
+            body: Some(json.to_string()),
+            delay: None,
+            drop_connection: false,
+        }
+    }
+
+    /// An error response with the given status code.
+    pub fn error(status: u16) -> Self {
+        Self {
+            status,
+            body: None,
+            delay: None,
+            drop_connection: false,
+        }
+    }
+
+    /// An error response with a body.
+    pub fn error_with_body(status: u16, body: &str) -> Self {
+        Self {
+            status,
+            body: Some(body.to_string()),
+            delay: None,
+            drop_connection: false,
+        }
+    }
+
+    /// Response that is delayed (to trigger client-side timeout).
+    pub fn delayed(delay: Duration) -> Self {
+        Self {
+            status: 200,
+            body: Some("{}".to_string()),
+            delay: Some(delay),
+            drop_connection: false,
+        }
+    }
+
+    /// Drop the connection without responding (simulates crash).
+    pub fn drop_conn() -> Self {
+        Self {
+            status: 0,
+            body: None,
+            delay: None,
+            drop_connection: true,
+        }
+    }
+}
+
+type RouteKey = (String, String); // (METHOD, path)
+type RouteMap = HashMap<RouteKey, MockResponse>;
+
+/// A lightweight mock HTTP server on a Unix socket.
+///
+/// # Usage
+///
+/// ```ignore
+/// let mut mock = MockChServer::new(&socket_path);
+/// mock.route("GET", "/vmm.ping", MockResponse::ok_json(r#"{"pong":true}"#));
+/// mock.start().await;
+/// // ... use ChClient pointing at socket_path ...
+/// mock.shutdown();
+/// ```
+pub struct MockChServer {
+    socket_path: PathBuf,
+    routes: RouteMap,
+    /// Captured request bodies, keyed by (method, path).
+    captured_bodies: Arc<tokio::sync::Mutex<HashMap<RouteKey, String>>>,
+    shutdown: Arc<Notify>,
+}
+
+impl MockChServer {
+    /// Create a new mock server bound to the given socket path.
+    pub fn new(socket_path: &Path) -> Self {
+        Self {
+            socket_path: socket_path.to_path_buf(),
+            routes: HashMap::new(),
+            captured_bodies: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            shutdown: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Register a canned response for a (method, path) pair.
+    pub fn route(&mut self, method: &str, path: &str, response: MockResponse) {
+        self.routes
+            .insert((method.to_string(), path.to_string()), response);
+    }
+
+    /// Start accepting connections in the background.
+    pub async fn start(&self) {
+        // Remove stale socket if it exists.
+        let _ = std::fs::remove_file(&self.socket_path);
+
+        let listener =
+            UnixListener::bind(&self.socket_path).expect("failed to bind mock Unix socket");
+
+        let routes = Arc::new(self.routes.clone());
+        let captured = self.captured_bodies.clone();
+        let shutdown = self.shutdown.clone();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    accept = listener.accept() => {
+                        match accept {
+                            Ok((stream, _)) => {
+                                let routes = routes.clone();
+                                let captured = captured.clone();
+                                tokio::spawn(async move {
+                                    let io = TokioIo::new(stream);
+                                    let svc = service_fn(move |req: Request<hyper::body::Incoming>| {
+                                        let routes = routes.clone();
+                                        let captured = captured.clone();
+                                        async move {
+                                            handle_request(req, &routes, &captured).await
+                                        }
+                                    });
+                                    let _ = http1::Builder::new()
+                                        .serve_connection(io, svc)
+                                        .await;
+                                });
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    _ = shutdown.notified() => break,
+                }
+            }
+        });
+
+        // Give the listener a moment to be ready.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    /// Stop the server.
+    pub fn shutdown(&self) {
+        self.shutdown.notify_one();
+    }
+
+    /// Retrieve the captured request body for a given (method, path).
+    pub async fn captured_body(&self, method: &str, path: &str) -> Option<String> {
+        let guard = self.captured_bodies.lock().await;
+        guard.get(&(method.to_string(), path.to_string())).cloned()
+    }
+}
+
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    routes: &RouteMap,
+    captured: &Arc<tokio::sync::Mutex<HashMap<RouteKey, String>>>,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    use http_body_util::BodyExt;
+
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let key = (method.to_string(), path.clone());
+
+    // Capture request body.
+    let body_bytes = req.into_body().collect().await?.to_bytes();
+    if !body_bytes.is_empty() {
+        let body_str = String::from_utf8_lossy(&body_bytes).to_string();
+        captured.lock().await.insert(key.clone(), body_str);
+    }
+
+    let mock_resp = routes.get(&key);
+
+    match mock_resp {
+        Some(resp) if resp.drop_connection => {
+            // Return a normal response but we want to simulate a drop.
+            // The simplest approach: just stall forever, the test timeout handles it.
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+            Ok(Response::builder()
+                .status(500)
+                .body(Full::new(Bytes::new()))
+                .unwrap())
+        }
+        Some(resp) => {
+            if let Some(delay) = resp.delay {
+                tokio::time::sleep(delay).await;
+            }
+            let status = StatusCode::from_u16(resp.status).unwrap_or(StatusCode::OK);
+            let body = resp.body.clone().unwrap_or_default();
+            Ok(Response::builder()
+                .status(status)
+                .header("Content-Type", "application/json")
+                .body(Full::new(Bytes::from(body)))
+                .unwrap())
+        }
+        None => {
+            // Unregistered route: 404.
+            Ok(Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Full::new(Bytes::from("{\"error\":\"not found\"}")))
+                .unwrap())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MockChServer` test helper in `layers/compute/src/test_utils.rs` -- a reusable HTTP/1.1 server on a Unix socket that simulates Cloud Hypervisor API responses
- Add 20+ async client tests covering all `ChClient` endpoints: ping, info, create, boot, shutdown, delete, resize, counters
- Tests cover success paths, idempotence (409/404 handling), timeouts, invalid JSON, connection refused, HTTP 500, and concurrent requests

## Test plan
- [x] `cargo test -p syfrah-compute` -- 116 tests pass (including 20+ new mock-server tests)
- [x] `cargo clippy -p syfrah-compute --tests` -- clean
- [x] `cargo fmt` -- clean

Closes #473