### PR TITLE
feat(compute): add CLI commands for VM lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1144,9 +1144,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2003,9 +2003,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -2087,6 +2087,7 @@ dependencies = [
  "libc",
  "serde",
  "sha2",
+ "syfrah-compute",
  "syfrah-core",
  "syfrah-fabric",
  "syfrah-state",
@@ -2100,7 +2101,9 @@ dependencies = [
 name = "syfrah-compute"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "axum",
+ "clap",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2683,9 +2686,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "js-sys",
  "serde_core",
@@ -2749,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2762,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2772,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2785,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -2828,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/bin/syfrah/Cargo.toml
+++ b/bin/syfrah/Cargo.toml
@@ -13,6 +13,7 @@ name = "syfrah"
 path = "src/main.rs"
 
 [dependencies]
+syfrah-compute = { path = "../../layers/compute" }
 syfrah-core = { path = "../../layers/core" }
 syfrah-fabric = { path = "../../layers/fabric" }
 syfrah-state = { path = "../../layers/state" }

--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -29,6 +29,11 @@ enum Commands {
         #[command(subcommand)]
         command: FabricCommand,
     },
+    /// Manage virtual machines and compute resources
+    Compute {
+        #[command(subcommand)]
+        command: syfrah_compute::cli::ComputeCommand,
+    },
     /// Inspect and manage layer state databases
     State {
         #[command(subcommand)]
@@ -874,6 +879,7 @@ async fn run() -> Result<()> {
                 }
             }
         },
+        Commands::Compute { command } => syfrah_compute::cli::run(command).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             generate(shell, &mut cmd, "syfrah", &mut std::io::stdout());

--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 axum = "0.8"
+clap = { version = "4", features = ["derive"] }
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }

--- a/layers/compute/src/cli/mod.rs
+++ b/layers/compute/src/cli/mod.rs
@@ -1,0 +1,51 @@
+//! CLI commands for `syfrah compute ...`.
+//!
+//! Provides subcommands for VM lifecycle management and compute layer
+//! status queries. Each handler communicates with the daemon via the
+//! control socket (stubbed for now — prints a placeholder message until
+//! the daemon integration is complete).
+
+pub mod vm;
+
+use clap::Subcommand;
+
+/// Top-level compute CLI command.
+#[derive(Debug, Subcommand)]
+pub enum ComputeCommand {
+    /// Manage virtual machines
+    Vm {
+        #[command(subcommand)]
+        command: vm::VmCommand,
+    },
+    /// Show compute layer status
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Execute a compute CLI command.
+pub async fn run(cmd: ComputeCommand) -> anyhow::Result<()> {
+    match cmd {
+        ComputeCommand::Vm { command } => vm::run(command).await,
+        ComputeCommand::Status { json } => run_status(json).await,
+    }
+}
+
+async fn run_status(json: bool) -> anyhow::Result<()> {
+    if json {
+        let status = serde_json::json!({
+            "status": "not yet connected to daemon",
+            "total_vms": 0,
+            "running_vms": 0,
+        });
+        println!("{}", serde_json::to_string_pretty(&status)?);
+    } else {
+        println!("Compute Status");
+        println!("  Status:      not yet connected to daemon");
+        println!("  Total VMs:   0");
+        println!("  Running VMs: 0");
+    }
+    Ok(())
+}

--- a/layers/compute/src/cli/vm.rs
+++ b/layers/compute/src/cli/vm.rs
@@ -1,0 +1,427 @@
+//! VM lifecycle CLI commands.
+//!
+//! Subcommands: create, list, get, start, stop, delete, reboot, resize.
+//! Each handler currently prints a stub message until daemon control
+//! socket integration is complete.
+
+use clap::Subcommand;
+
+/// VM management subcommands.
+#[derive(Debug, Subcommand)]
+pub enum VmCommand {
+    /// Create a new virtual machine
+    Create {
+        /// Human-readable name for the VM
+        #[arg(long)]
+        name: String,
+        /// Number of virtual CPUs
+        #[arg(long, default_value = "2")]
+        vcpus: u32,
+        /// Memory in megabytes
+        #[arg(long, default_value = "2048")]
+        memory: u32,
+        /// Root filesystem image name (e.g. "ubuntu-24.04")
+        #[arg(long)]
+        image: String,
+        /// Optional GPU PCI BDF address for VFIO passthrough
+        #[arg(long)]
+        gpu: Option<String>,
+        /// TAP device name for networking
+        #[arg(long)]
+        tap: Option<String>,
+    },
+    /// List all virtual machines
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Get details of a virtual machine
+    Get {
+        /// VM identifier
+        id: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Start (boot) a stopped virtual machine
+    Start {
+        /// VM identifier
+        id: String,
+    },
+    /// Stop a running virtual machine
+    Stop {
+        /// VM identifier
+        id: String,
+        /// Force shutdown (kill) instead of graceful ACPI
+        #[arg(long, short)]
+        force: bool,
+    },
+    /// Delete a virtual machine and clean up all artifacts
+    Delete {
+        /// VM identifier
+        id: String,
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
+    /// Reboot a running virtual machine
+    Reboot {
+        /// VM identifier
+        id: String,
+    },
+    /// Hot-resize CPU and memory of a running virtual machine
+    Resize {
+        /// VM identifier
+        id: String,
+        /// New number of virtual CPUs
+        #[arg(long)]
+        vcpus: Option<u32>,
+        /// New memory in megabytes
+        #[arg(long)]
+        memory: Option<u32>,
+    },
+}
+
+/// Execute a VM subcommand.
+pub async fn run(cmd: VmCommand) -> anyhow::Result<()> {
+    match cmd {
+        VmCommand::Create {
+            name,
+            vcpus,
+            memory,
+            image,
+            gpu,
+            tap,
+        } => run_create(name, vcpus, memory, image, gpu, tap).await,
+        VmCommand::List { json } => run_list(json).await,
+        VmCommand::Get { id, json } => run_get(id, json).await,
+        VmCommand::Start { id } => run_start(id).await,
+        VmCommand::Stop { id, force } => run_stop(id, force).await,
+        VmCommand::Delete { id, yes } => run_delete(id, yes).await,
+        VmCommand::Reboot { id } => run_reboot(id).await,
+        VmCommand::Resize { id, vcpus, memory } => run_resize(id, vcpus, memory).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers (stubs until daemon control socket integration)
+// ---------------------------------------------------------------------------
+
+async fn run_create(
+    name: String,
+    vcpus: u32,
+    memory: u32,
+    image: String,
+    gpu: Option<String>,
+    tap: Option<String>,
+) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    println!("Would create VM:");
+    println!("  Name:   {name}");
+    println!("  vCPUs:  {vcpus}");
+    println!("  Memory: {memory} MB");
+    println!("  Image:  {image}");
+    if let Some(ref g) = gpu {
+        println!("  GPU:    {g}");
+    }
+    if let Some(ref t) = tap {
+        println!("  TAP:    {t}");
+    }
+    Ok(())
+}
+
+async fn run_list(json: bool) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    if json {
+        println!("{}", serde_json::json!({"vms": []}));
+    } else {
+        println!(
+            "{:<20} {:<12} {:<6} {:<10} {:<20} {:<10}",
+            "ID", "PHASE", "vCPUs", "MEMORY", "IMAGE", "UPTIME"
+        );
+        println!("{}", "-".repeat(78));
+        println!("(no VMs)");
+    }
+    Ok(())
+}
+
+async fn run_get(id: String, json: bool) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    if json {
+        let vm = serde_json::json!({
+            "id": id,
+            "phase": "Unknown",
+            "vcpus": 0,
+            "memory_mb": 0,
+        });
+        println!("{}", serde_json::to_string_pretty(&vm)?);
+    } else {
+        println!("VM Details");
+        println!("  ID:        {id}");
+        println!("  Phase:     Unknown");
+        println!("  vCPUs:     -");
+        println!("  Memory:    -");
+        println!("  Image:     -");
+        println!("  Created:   -");
+        println!("  Uptime:    -");
+    }
+    Ok(())
+}
+
+async fn run_start(id: String) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    println!("Would start VM: {id}");
+    Ok(())
+}
+
+async fn run_stop(id: String, force: bool) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    if force {
+        println!("Would force-stop VM: {id}");
+    } else {
+        println!("Would gracefully stop VM: {id}");
+    }
+    Ok(())
+}
+
+async fn run_delete(id: String, yes: bool) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    if !yes {
+        println!("Would prompt for confirmation before deleting VM: {id}");
+    }
+    println!("Would delete VM: {id}");
+    Ok(())
+}
+
+async fn run_reboot(id: String) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    println!("Would reboot VM: {id}");
+    Ok(())
+}
+
+async fn run_resize(id: String, vcpus: Option<u32>, memory: Option<u32>) -> anyhow::Result<()> {
+    eprintln!("not yet connected to daemon");
+    println!("Would resize VM: {id}");
+    if let Some(v) = vcpus {
+        println!("  New vCPUs:  {v}");
+    }
+    if let Some(m) = memory {
+        println!("  New Memory: {m} MB");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    /// Helper to parse VM commands from an arg list.
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        cmd: VmCommand,
+    }
+
+    fn parse(args: &[&str]) -> VmCommand {
+        let full_args = std::iter::once("test").chain(args.iter().copied());
+        TestCli::parse_from(full_args).cmd
+    }
+
+    #[test]
+    fn parse_create_minimal() {
+        let cmd = parse(&["create", "--name", "test-vm", "--image", "ubuntu-24.04"]);
+        match cmd {
+            VmCommand::Create {
+                name,
+                vcpus,
+                memory,
+                image,
+                gpu,
+                tap,
+            } => {
+                assert_eq!(name, "test-vm");
+                assert_eq!(vcpus, 2); // default
+                assert_eq!(memory, 2048); // default
+                assert_eq!(image, "ubuntu-24.04");
+                assert!(gpu.is_none());
+                assert!(tap.is_none());
+            }
+            other => panic!("expected Create, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_create_full() {
+        let cmd = parse(&[
+            "create",
+            "--name",
+            "gpu-vm",
+            "--vcpus",
+            "8",
+            "--memory",
+            "16384",
+            "--image",
+            "ubuntu-24.04",
+            "--gpu",
+            "0000:01:00.0",
+            "--tap",
+            "tap0",
+        ]);
+        match cmd {
+            VmCommand::Create {
+                name,
+                vcpus,
+                memory,
+                image,
+                gpu,
+                tap,
+            } => {
+                assert_eq!(name, "gpu-vm");
+                assert_eq!(vcpus, 8);
+                assert_eq!(memory, 16384);
+                assert_eq!(image, "ubuntu-24.04");
+                assert_eq!(gpu.as_deref(), Some("0000:01:00.0"));
+                assert_eq!(tap.as_deref(), Some("tap0"));
+            }
+            other => panic!("expected Create, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_list() {
+        let cmd = parse(&["list"]);
+        assert!(matches!(cmd, VmCommand::List { json: false }));
+    }
+
+    #[test]
+    fn parse_list_json() {
+        let cmd = parse(&["list", "--json"]);
+        assert!(matches!(cmd, VmCommand::List { json: true }));
+    }
+
+    #[test]
+    fn parse_get() {
+        let cmd = parse(&["get", "vm-123"]);
+        match cmd {
+            VmCommand::Get { id, json } => {
+                assert_eq!(id, "vm-123");
+                assert!(!json);
+            }
+            other => panic!("expected Get, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_get_json() {
+        let cmd = parse(&["get", "vm-456", "--json"]);
+        match cmd {
+            VmCommand::Get { id, json } => {
+                assert_eq!(id, "vm-456");
+                assert!(json);
+            }
+            other => panic!("expected Get, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_start() {
+        let cmd = parse(&["start", "vm-789"]);
+        assert!(matches!(cmd, VmCommand::Start { id } if id == "vm-789"));
+    }
+
+    #[test]
+    fn parse_stop() {
+        let cmd = parse(&["stop", "vm-abc"]);
+        match cmd {
+            VmCommand::Stop { id, force } => {
+                assert_eq!(id, "vm-abc");
+                assert!(!force);
+            }
+            other => panic!("expected Stop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_stop_force() {
+        let cmd = parse(&["stop", "--force", "vm-abc"]);
+        match cmd {
+            VmCommand::Stop { id, force } => {
+                assert_eq!(id, "vm-abc");
+                assert!(force);
+            }
+            other => panic!("expected Stop, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_delete() {
+        let cmd = parse(&["delete", "vm-del"]);
+        match cmd {
+            VmCommand::Delete { id, yes } => {
+                assert_eq!(id, "vm-del");
+                assert!(!yes);
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_delete_yes() {
+        let cmd = parse(&["delete", "--yes", "vm-del"]);
+        match cmd {
+            VmCommand::Delete { id, yes } => {
+                assert_eq!(id, "vm-del");
+                assert!(yes);
+            }
+            other => panic!("expected Delete, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_reboot() {
+        let cmd = parse(&["reboot", "vm-reboot"]);
+        assert!(matches!(cmd, VmCommand::Reboot { id } if id == "vm-reboot"));
+    }
+
+    #[test]
+    fn parse_resize_vcpus_only() {
+        let cmd = parse(&["resize", "vm-resize", "--vcpus", "4"]);
+        match cmd {
+            VmCommand::Resize { id, vcpus, memory } => {
+                assert_eq!(id, "vm-resize");
+                assert_eq!(vcpus, Some(4));
+                assert!(memory.is_none());
+            }
+            other => panic!("expected Resize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_resize_memory_only() {
+        let cmd = parse(&["resize", "vm-resize", "--memory", "8192"]);
+        match cmd {
+            VmCommand::Resize { id, vcpus, memory } => {
+                assert_eq!(id, "vm-resize");
+                assert!(vcpus.is_none());
+                assert_eq!(memory, Some(8192));
+            }
+            other => panic!("expected Resize, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_resize_both() {
+        let cmd = parse(&["resize", "vm-resize", "--vcpus", "8", "--memory", "16384"]);
+        match cmd {
+            VmCommand::Resize { id, vcpus, memory } => {
+                assert_eq!(id, "vm-resize");
+                assert_eq!(vcpus, Some(8));
+                assert_eq!(memory, Some(16384));
+            }
+            other => panic!("expected Resize, got {other:?}"),
+        }
+    }
+}

--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -23,6 +23,7 @@
 //! vs external broadcast channel).
 
 pub mod binary;
+pub mod cli;
 pub mod client;
 pub mod config;
 pub mod error;


### PR DESCRIPTION
## Summary
- Add `syfrah compute vm {create,list,get,start,stop,delete,reboot,resize}` subcommands with clap derive macros
- Add `syfrah compute status` for compute layer health
- Human-readable output (table for list, key-value for get) with `--json` flag
- Register in `bin/syfrah/src/main.rs` as a top-level `Compute` command
- 15 unit tests covering CLI argument parsing for all subcommands

## Test plan
- [x] All 15 CLI parsing tests pass
- [x] Full syfrah-compute test suite passes (211 tests)
- [x] cargo clippy clean on both syfrah-compute and syfrah-bin
- [x] cargo fmt applied

Closes #493