### PR TITLE
docs(compute): clean public API surface with rustdoc for forge integration

### DIFF
--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -1,3 +1,27 @@
+//! # syfrah-compute
+//!
+//! Cloud Hypervisor driver for the Syfrah control plane.
+//!
+//! This crate owns the full lifecycle of a VM on a single node: create, boot,
+//! monitor, shutdown, delete, and reconnect after daemon restarts. It is the
+//! specialist that interfaces with [Cloud Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)
+//! and manages VM processes.
+//!
+//! ## Public API for forge
+//!
+//! Forge interacts with compute through [`VmManager`], which provides:
+//! - [`VmManager::create_vm`] — spawn and boot a VM from a [`VmSpec`]
+//! - [`VmManager::shutdown_vm`] — graceful shutdown via the 4-level kill chain
+//! - [`VmManager::delete_vm`] — stop + clean up all artifacts
+//! - [`VmManager::info`] / [`VmManager::list`] — query VM status
+//! - [`VmManager::subscribe`] — receive lifecycle [`VmEvent`]s via broadcast
+//! - [`VmManager::reconnect`] — recover VMs after daemon restart
+//!
+//! ## Event model
+//!
+//! See the [`events`] module for the two-level event model (internal tracing
+//! vs external broadcast channel).
+
 pub mod binary;
 pub mod client;
 pub mod config;
@@ -15,6 +39,9 @@ mod runtime;
 pub mod test_utils;
 pub mod types;
 
+// -- Public re-exports for forge consumption ----------------------------------
+
+pub use binary::VersionReport;
 pub use error::{
     ClientError, ComputeError, ConcurrencyError, ConfigError, PreflightError, ProcessError,
     TransitionError,

--- a/layers/compute/src/phase.rs
+++ b/layers/compute/src/phase.rs
@@ -6,21 +6,32 @@ use serde::{Deserialize, Serialize};
 /// Invalid transitions are rejected at runtime with a `TransitionError`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VmPhase {
+    /// Forge has requested creation; not yet started.
     Pending,
+    /// Process spawned, cgroup configured, runtime directory created.
     Provisioning,
+    /// Cloud Hypervisor process is running; waiting for API readiness.
     Starting,
+    /// VMM API is responding — the VM is operational.
     Running,
+    /// Shutdown in progress (kill chain active).
     Stopping,
+    /// Process terminated cleanly; runtime artifacts may still exist.
     Stopped,
+    /// Cleanup in progress (removing socket, pid, cgroup, runtime dir).
     Deleting,
+    /// Fully cleaned up — terminal state.
     Deleted,
+    /// An error occurred; VM may need manual intervention or deletion.
     Failed,
 }
 
 /// Error returned when an invalid state transition is attempted.
 #[derive(Debug, Clone)]
 pub struct TransitionError {
+    /// The phase the VM was in when the transition was attempted.
     pub from: VmPhase,
+    /// The phase the caller tried to transition to.
     pub to: VmPhase,
 }
 

--- a/layers/compute/src/types.rs
+++ b/layers/compute/src/types.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use crate::phase::VmPhase;
 
 /// Unique identifier for a VM.
+///
+/// A thin wrapper around `String`, used as a key in maps and event payloads.
+/// The inner value is typically a human-readable slug like `"vm-web-1"`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct VmId(pub String);
 
@@ -14,30 +17,52 @@ impl fmt::Display for VmId {
     }
 }
 
-/// Desired state of a VM.
+/// Desired state of a VM, provided by forge when requesting creation.
+///
+/// This is the "what" — the declarative specification. Compute translates it
+/// into Cloud Hypervisor configuration, resolves paths, and validates constraints.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct VmSpec {
+    /// Unique identifier for this VM.
     pub id: VmId,
+    /// Number of virtual CPUs (must be > 0).
     pub vcpus: u32,
+    /// Memory allocation in megabytes (must be >= 128, power of 2).
     pub memory_mb: u32,
+    /// Root filesystem image name (e.g., `"ubuntu-24.04"`). Resolved to a path
+    /// by the config pipeline.
     pub image: String,
+    /// Path to the kernel. `None` uses the shared default vmlinux.
     pub kernel: Option<String>,
+    /// Network configuration (TAP device), provided by overlay via forge.
     pub network: Option<NetworkConfig>,
+    /// Block device volumes to attach (e.g., ZeroFS NBD devices).
     pub volumes: Vec<VolumeAttachment>,
+    /// GPU passthrough mode.
     pub gpu: GpuMode,
 }
 
 /// TAP device configuration, provided by overlay via forge.
+///
+/// Compute does not create or manage TAP devices — it receives this
+/// configuration and passes it to Cloud Hypervisor's `--net` argument.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct NetworkConfig {
+    /// Name of the TAP device (e.g., `"tap-vm-web-1"`).
     pub tap_name: String,
+    /// Optional MAC address override. `None` lets Cloud Hypervisor assign one.
     pub mac: Option<String>,
 }
 
-/// Block device attachment.
+/// Block device attachment for a VM.
+///
+/// Volumes are provided by the storage layer (e.g., ZeroFS NBD devices)
+/// and attached as additional `--disk` entries in Cloud Hypervisor.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct VolumeAttachment {
+    /// Path to the block device (e.g., `"/dev/nbd0"`).
     pub path: String,
+    /// Whether the volume should be attached as read-only.
     pub read_only: bool,
 }
 
@@ -60,9 +85,13 @@ pub enum GpuMode {
 /// Internal details (PID, socket path, cgroup) are deliberately omitted.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct VmStatus {
+    /// Unique identifier of the VM.
     pub vm_id: VmId,
+    /// Current lifecycle phase.
     pub phase: VmPhase,
+    /// Number of virtual CPUs allocated.
     pub vcpus: u32,
+    /// Memory allocation in megabytes.
     pub memory_mb: u32,
     /// Unix timestamp of when the VM was created.
     pub created_at: Option<u64>,
@@ -76,46 +105,32 @@ pub struct VmStatus {
 /// always `info()` / `status()`, never the event stream alone.
 #[derive(Clone, Debug)]
 pub enum VmEvent {
-    Created {
-        vm_id: VmId,
-    },
-    Booted {
-        vm_id: VmId,
-    },
-    Stopped {
-        vm_id: VmId,
-    },
-    Crashed {
-        vm_id: VmId,
-        error: String,
-    },
-    Deleted {
-        vm_id: VmId,
-    },
-    ReconnectSucceeded {
-        vm_id: VmId,
-    },
-    ReconnectFailed {
-        vm_id: VmId,
-        error: String,
-    },
-    VmOrphanCleaned {
-        vm_id: VmId,
-        reason: String,
-    },
+    /// VM definition created and cloud-hypervisor process spawned.
+    Created { vm_id: VmId },
+    /// VM booted successfully — CH API is responding and `vm.boot` completed.
+    Booted { vm_id: VmId },
+    /// VM stopped cleanly via the kill chain (graceful or forced shutdown).
+    Stopped { vm_id: VmId },
+    /// VM crashed — process exited unexpectedly or API became unresponsive.
+    Crashed { vm_id: VmId, error: String },
+    /// VM deleted — all runtime artifacts cleaned up.
+    Deleted { vm_id: VmId },
+    /// VM successfully recovered after a daemon restart.
+    ReconnectSucceeded { vm_id: VmId },
+    /// VM failed to reconnect after a daemon restart.
+    ReconnectFailed { vm_id: VmId, error: String },
+    /// Orphaned runtime directory cleaned up during reconnect.
+    VmOrphanCleaned { vm_id: VmId, reason: String },
+    /// VM CPU/memory resized via hot-resize.
     Resized {
         vm_id: VmId,
         new_vcpus: u32,
         new_memory_mb: u32,
     },
-    DeviceAttached {
-        vm_id: VmId,
-        device: String,
-    },
-    DeviceDetached {
-        vm_id: VmId,
-        device: String,
-    },
+    /// Device hot-attached to the VM (disk, network, or VFIO).
+    DeviceAttached { vm_id: VmId, device: String },
+    /// Device hot-detached from the VM.
+    DeviceDetached { vm_id: VmId, device: String },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add crate-level rustdoc explaining the public API for forge consumption
- Re-export `VersionReport` from `lib.rs` alongside all other public types
- Add rustdoc comments on all public items: struct fields, enum variants, methods
- Verify `cargo doc -p syfrah-compute --no-deps` produces clean docs

## Test plan
- [x] All 202 tests pass
- [x] `cargo doc` builds without warnings
- [x] `cargo clippy` clean

Closes #487