### PR TITLE
fix: add CLOUD_HYPERVISOR_VERSION to e2e Dockerfile

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:latest AS builder
 WORKDIR /app
 RUN rustup target add x86_64-unknown-linux-musl && \
     apt-get update && apt-get install -y musl-tools
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock CLOUD_HYPERVISOR_VERSION ./
 COPY layers layers
 COPY bin bin
 RUN cargo build --release --bin syfrah --target x86_64-unknown-linux-musl


### PR DESCRIPTION
## Summary

The e2e Dockerfile was missing `CLOUD_HYPERVISOR_VERSION` in the COPY step. The compute crate's `build.rs` reads this file from the repo root at compile time — without it, `cargo build` panics.

One-line fix: add the file to the COPY instruction.

## Test plan

- [ ] E2E Docker image builds successfully