### PR TITLE
fix: increase stress test convergence timeout (15 nodes)

### DIFF
--- a/tests/e2e/scenarios/16_fabric_stress_max_nodes.sh
+++ b/tests/e2e/scenarios/16_fabric_stress_max_nodes.sh
@@ -29,12 +29,12 @@ done
 info "Waiting for full convergence ($NODE_COUNT nodes, $EXPECTED peers each)..."
 START_TIME=$(date +%s)
 
-if wait_for_convergence "e2e-max-" $NODE_COUNT $EXPECTED 90; then
+if wait_for_convergence "e2e-max-" $NODE_COUNT $EXPECTED 180; then
     ELAPSED=$(($(date +%s) - START_TIME))
     pass "$NODE_COUNT nodes converged in ${ELAPSED}s"
 else
     ELAPSED=$(($(date +%s) - START_TIME))
-    fail "mesh did not fully converge in 90s"
+    fail "mesh did not fully converge in 180s"
     for i in $(seq 1 $NODE_COUNT); do
         count=$(docker exec "e2e-max-$i" syfrah fabric peers 2>&1 | grep -c "active" || echo "0")
         echo "  e2e-max-$i: $count/$EXPECTED peers"


### PR DESCRIPTION
## Summary

`16_fabric_stress_max_nodes` fails intermittently on CI — 15 nodes need more than 90s to converge on a 2-vCPU runner (210 peering connections). Increase timeout from 90s to 180s.

Not a code bug — convergence works, just takes longer on constrained CI hardware.