### PR TITLE
feat(compute): image types, InstanceId, ImageError, VmSpec extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2694,6 +2695,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",

--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -19,6 +19,7 @@ syfrah-api = { path = "../api" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/layers/compute/proto/compute.proto
+++ b/layers/compute/proto/compute.proto
@@ -136,6 +136,10 @@ message CreateVmRequest {
   repeated VolumeAttachment volumes = 7;
   // Network configuration.
   optional NetworkConfig network = 8;
+  // SSH public key to inject into the VM via cloud-init.
+  optional string ssh_key = 9;
+  // Root disk size in megabytes. Omit to use the image default.
+  optional uint32 disk_size_mb = 10;
 }
 
 // GetVmRequest identifies a VM to retrieve.

--- a/layers/compute/src/config.rs
+++ b/layers/compute/src/config.rs
@@ -23,6 +23,8 @@ pub struct ValidatedSpec {
     pub network: Option<NetworkConfig>,
     pub volumes: Vec<ValidatedVolume>,
     pub gpu: GpuMode,
+    pub ssh_key: Option<String>,
+    pub disk_size_mb: Option<u32>,
 }
 
 /// Volume attachment that has passed validation (path is non-empty).
@@ -78,6 +80,24 @@ pub fn validate(spec: &VmSpec) -> Result<ValidatedSpec, Vec<ConfigError>> {
         }
     }
 
+    // ssh_key: if provided, must not be empty after trim
+    if let Some(ref key) = spec.ssh_key {
+        if key.trim().is_empty() {
+            errors.push(ConfigError::ConflictingSettings {
+                detail: "ssh_key must not be empty or whitespace-only".to_string(),
+            });
+        }
+    }
+
+    // disk_size_mb: if provided, must be >= 128 (minimum bootable disk)
+    if let Some(size) = spec.disk_size_mb {
+        if size < 128 {
+            errors.push(ConfigError::ConflictingSettings {
+                detail: format!("disk_size_mb must be >= 128, got {size}"),
+            });
+        }
+    }
+
     // network: tap_name must not be empty
     if let Some(ref net) = spec.network {
         if net.tap_name.is_empty() {
@@ -102,6 +122,8 @@ pub fn validate(spec: &VmSpec) -> Result<ValidatedSpec, Vec<ConfigError>> {
                 })
                 .collect(),
             gpu: spec.gpu.clone(),
+            ssh_key: spec.ssh_key.clone(),
+            disk_size_mb: spec.disk_size_mb,
         })
     } else {
         Err(errors)
@@ -294,6 +316,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         }
     }
 
@@ -321,6 +345,8 @@ mod tests {
             gpu: GpuMode::Passthrough {
                 bdf: "0000:01:00.0".to_string(),
             },
+            ssh_key: None,
+            disk_size_mb: None,
         }
     }
 
@@ -470,6 +496,8 @@ mod tests {
             gpu: GpuMode::Passthrough {
                 bdf: "bad".to_string(),
             },
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let errors = validate(&spec).unwrap_err();
         // Should have at least 5 errors: vcpus, memory, image, bdf, volume, tap
@@ -635,6 +663,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         assert!(validate(&spec).is_ok());
     }
@@ -650,6 +680,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         assert!(validate(&spec).is_ok());
     }
@@ -701,6 +733,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let errors = validate(&spec).unwrap_err();
         assert!(
@@ -737,6 +771,8 @@ mod tests {
                 read_only: false,
             }],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let validated = validate(&spec).unwrap();
         let resolved = resolve(
@@ -933,6 +969,8 @@ mod tests {
             gpu: GpuMode::Passthrough {
                 bdf: "0000:03:00.0".to_string(),
             },
+            ssh_key: None,
+            disk_size_mb: None,
         };
 
         // Step 1: validate
@@ -967,5 +1005,58 @@ mod tests {
         assert_eq!(json["net"].as_array().unwrap()[0]["tap"], "tap-e2e");
         assert_eq!(json["devices"].as_array().unwrap().len(), 1);
         assert_eq!(json["rng"]["src"], "/dev/urandom");
+    }
+
+    // -- ssh_key and disk_size_mb validation (#538) ---------------------------
+
+    #[test]
+    fn validate_ssh_key_empty_rejected() {
+        let mut spec = minimal_spec();
+        spec.ssh_key = Some("".to_string());
+        let errors = validate(&spec).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::ConflictingSettings { .. })));
+    }
+
+    #[test]
+    fn validate_ssh_key_whitespace_only_rejected() {
+        let mut spec = minimal_spec();
+        spec.ssh_key = Some("  \n".to_string());
+        let errors = validate(&spec).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::ConflictingSettings { .. })));
+    }
+
+    #[test]
+    fn validate_ssh_key_valid_passes() {
+        let mut spec = minimal_spec();
+        spec.ssh_key = Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 user@host".to_string());
+        assert!(validate(&spec).is_ok());
+    }
+
+    #[test]
+    fn validate_disk_size_mb_too_small_rejected() {
+        let mut spec = minimal_spec();
+        spec.disk_size_mb = Some(50);
+        let errors = validate(&spec).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::ConflictingSettings { .. })));
+    }
+
+    #[test]
+    fn validate_disk_size_mb_128_passes() {
+        let mut spec = minimal_spec();
+        spec.disk_size_mb = Some(128);
+        assert!(validate(&spec).is_ok());
+    }
+
+    #[test]
+    fn validate_disk_size_mb_none_passes() {
+        let spec = minimal_spec();
+        assert!(validate(&spec).is_ok());
+        assert!(spec.disk_size_mb.is_none());
     }
 }

--- a/layers/compute/src/control.rs
+++ b/layers/compute/src/control.rs
@@ -138,6 +138,8 @@ async fn handle_compute_request(mgr: &VmManager, req: ComputeRequest) -> Compute
                 network,
                 volumes: vec![],
                 gpu,
+                ssh_key: None,
+                disk_size_mb: None,
             };
             match mgr.create_vm(spec).await {
                 Ok(status) => ComputeResponse::Vm(vm_status_to_json(&status)),

--- a/layers/compute/src/error.rs
+++ b/layers/compute/src/error.rs
@@ -26,6 +26,9 @@ pub enum ComputeError {
 
     #[error("concurrency error: {0}")]
     Concurrency(#[from] ConcurrencyError),
+
+    #[error("image error: {0}")]
+    Image(#[from] crate::image::error::ImageError),
 }
 
 /// Precondition not met before spawning a VM.

--- a/layers/compute/src/handler.rs
+++ b/layers/compute/src/handler.rs
@@ -162,6 +162,7 @@ fn error_to_status(err: &ComputeError) -> StatusCode {
             }
         }
         ComputeError::Client(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        ComputeError::Image(_) => StatusCode::UNPROCESSABLE_ENTITY,
     }
 }
 
@@ -231,6 +232,8 @@ async fn create_vm(
             })
             .collect(),
         gpu: parse_gpu_mode(body.gpu),
+        ssh_key: None,
+        disk_size_mb: None,
     };
 
     match mgr.create_vm(spec).await {

--- a/layers/compute/src/image/error.rs
+++ b/layers/compute/src/image/error.rs
@@ -1,0 +1,195 @@
+/// Typed errors for image operations.
+///
+/// Each variant maps to a specific failure mode with enough context for the
+/// operator to diagnose and fix the issue.
+#[derive(Debug, thiserror::Error)]
+pub enum ImageError {
+    #[error("image not found: {name}")]
+    ImageNotFound { name: String },
+
+    #[error("image already exists: {name}")]
+    ImageAlreadyExists { name: String },
+
+    #[error("catalog fetch failed for {url}: {reason}")]
+    CatalogFetchFailed { url: String, reason: String },
+
+    #[error("catalog unavailable")]
+    CatalogUnavailable,
+
+    #[error("checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+
+    #[error("invalid image format: {detail}")]
+    InvalidImageFormat { detail: String },
+
+    #[error("image {name} is in use by {vm_count} VM(s)")]
+    ImageInUse { name: String, vm_count: u32 },
+
+    #[error("import failed: {reason}")]
+    ImportFailed { reason: String },
+
+    #[error("disk clone failed: {reason}")]
+    DiskCloneFailed { reason: String },
+
+    #[error("resize failed: {reason}")]
+    ResizeFailed { reason: String },
+
+    #[error("cloud-init generation failed: {reason}")]
+    CloudInitGenerationFailed { reason: String },
+
+    #[error("insufficient disk space: required {required_mb} MB, available {available_mb} MB")]
+    InsufficientDiskSpace { required_mb: u64, available_mb: u64 },
+
+    #[error("architecture mismatch: image is {image_arch}, node is {node_arch}")]
+    ArchMismatch {
+        image_arch: String,
+        node_arch: String,
+    },
+
+    #[error("kernel not found: {path}")]
+    KernelNotFound { path: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ComputeError;
+
+    // -- Display tests for every variant --------------------------------------
+
+    #[test]
+    fn display_image_not_found() {
+        let e = ImageError::ImageNotFound {
+            name: "ubuntu-24.04".to_string(),
+        };
+        assert!(e.to_string().contains("ubuntu-24.04"));
+    }
+
+    #[test]
+    fn display_image_already_exists() {
+        let e = ImageError::ImageAlreadyExists {
+            name: "alpine".to_string(),
+        };
+        assert!(e.to_string().contains("alpine"));
+        assert!(e.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn display_catalog_fetch_failed() {
+        let e = ImageError::CatalogFetchFailed {
+            url: "https://images.syfrah.dev".to_string(),
+            reason: "DNS failure".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("https://images.syfrah.dev"));
+        assert!(msg.contains("DNS failure"));
+    }
+
+    #[test]
+    fn display_catalog_unavailable() {
+        let e = ImageError::CatalogUnavailable;
+        assert!(e.to_string().contains("catalog unavailable"));
+    }
+
+    #[test]
+    fn display_checksum_mismatch() {
+        let e = ImageError::ChecksumMismatch {
+            expected: "abc123".to_string(),
+            actual: "def456".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("abc123"));
+        assert!(msg.contains("def456"));
+    }
+
+    #[test]
+    fn display_invalid_image_format() {
+        let e = ImageError::InvalidImageFormat {
+            detail: "unsupported format vdi".to_string(),
+        };
+        assert!(e.to_string().contains("unsupported format vdi"));
+    }
+
+    #[test]
+    fn display_image_in_use() {
+        let e = ImageError::ImageInUse {
+            name: "debian-12".to_string(),
+            vm_count: 3,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("debian-12"));
+        assert!(msg.contains("3"));
+    }
+
+    #[test]
+    fn display_import_failed() {
+        let e = ImageError::ImportFailed {
+            reason: "corrupted archive".to_string(),
+        };
+        assert!(e.to_string().contains("corrupted archive"));
+    }
+
+    #[test]
+    fn display_disk_clone_failed() {
+        let e = ImageError::DiskCloneFailed {
+            reason: "I/O error".to_string(),
+        };
+        assert!(e.to_string().contains("I/O error"));
+    }
+
+    #[test]
+    fn display_resize_failed() {
+        let e = ImageError::ResizeFailed {
+            reason: "filesystem busy".to_string(),
+        };
+        assert!(e.to_string().contains("filesystem busy"));
+    }
+
+    #[test]
+    fn display_cloud_init_generation_failed() {
+        let e = ImageError::CloudInitGenerationFailed {
+            reason: "template error".to_string(),
+        };
+        assert!(e.to_string().contains("template error"));
+    }
+
+    #[test]
+    fn display_insufficient_disk_space() {
+        let e = ImageError::InsufficientDiskSpace {
+            required_mb: 8192,
+            available_mb: 2048,
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("8192"));
+        assert!(msg.contains("2048"));
+    }
+
+    #[test]
+    fn display_arch_mismatch() {
+        let e = ImageError::ArchMismatch {
+            image_arch: "aarch64".to_string(),
+            node_arch: "x86_64".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("aarch64"));
+        assert!(msg.contains("x86_64"));
+    }
+
+    #[test]
+    fn display_kernel_not_found() {
+        let e = ImageError::KernelNotFound {
+            path: "/opt/syfrah/vmlinux".to_string(),
+        };
+        assert!(e.to_string().contains("/opt/syfrah/vmlinux"));
+    }
+
+    // -- From impl tests ------------------------------------------------------
+
+    #[test]
+    fn compute_error_from_image_error() {
+        let inner = ImageError::CatalogUnavailable;
+        let outer: ComputeError = inner.into();
+        assert!(matches!(outer, ComputeError::Image(_)));
+        assert!(outer.to_string().contains("image"));
+    }
+}

--- a/layers/compute/src/image/mod.rs
+++ b/layers/compute/src/image/mod.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod types;

--- a/layers/compute/src/image/types.rs
+++ b/layers/compute/src/image/types.rs
@@ -1,0 +1,391 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// ImageMeta (#535)
+// ---------------------------------------------------------------------------
+
+/// Full metadata for an image in the catalog.
+///
+/// Every field that the image management system needs is here from day one so
+/// downstream consumers (image service, disk service, CLI, catalog) never need
+/// schema migrations.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ImageMeta {
+    /// Image name / slug (e.g. `"ubuntu-24.04"`).
+    pub name: String,
+    /// CPU architecture (e.g. `"aarch64"`, `"x86_64"`).
+    pub arch: String,
+    /// OS family (e.g. `"linux"`, `"windows"`).
+    pub os_family: String,
+    /// Optional variant tag (e.g. `"minimal"`, `"desktop"`).
+    pub variant: Option<String>,
+    /// Disk image format (e.g. `"raw"`, `"qcow2"`).
+    pub format: String,
+    /// Compression algorithm used on the download artifact (e.g. `"zstd"`, `"gzip"`).
+    pub compression: Option<String>,
+    /// Boot mode (e.g. `"uefi"`, `"bios"`).
+    pub boot_mode: String,
+    /// SHA-256 checksum of the uncompressed image.
+    pub sha256: String,
+    /// Image size in megabytes.
+    pub size_mb: u64,
+    /// Minimum disk size in megabytes required to boot the image.
+    pub min_disk_mb: u64,
+    /// Whether the image ships with cloud-init support.
+    pub cloud_init: bool,
+    /// Default login username baked into the image.
+    pub default_username: Option<String>,
+    /// Root filesystem type (e.g. `"ext4"`, `"btrfs"`).
+    pub rootfs_fs: Option<String>,
+    /// How the image was sourced (e.g. `"catalog"`, `"import"`, `"build"`).
+    pub source_kind: String,
+    /// Filename of the image artifact in the catalog.
+    pub file: String,
+    /// Local-only: timestamp of when the image was imported. `None` for
+    /// catalog-only entries that have not been pulled yet.
+    pub imported_at: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// ImageCatalog (#535)
+// ---------------------------------------------------------------------------
+
+/// A versioned collection of images served by a catalog endpoint.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ImageCatalog {
+    /// Schema version of the catalog format.
+    pub version: u32,
+    /// Base URL where image artifacts can be downloaded.
+    pub base_url: String,
+    /// List of available images.
+    pub images: Vec<ImageMeta>,
+}
+
+// ---------------------------------------------------------------------------
+// PullPolicy (#535)
+// ---------------------------------------------------------------------------
+
+/// Controls when the image service should fetch an image from the catalog.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub enum PullPolicy {
+    /// Only pull if the image is not already present locally.
+    #[default]
+    IfNotPresent,
+    /// Always pull, even if a local copy exists.
+    Always,
+    /// Never pull — fail if the image is not present locally.
+    Never,
+}
+
+// ---------------------------------------------------------------------------
+// InstanceId (#536)
+// ---------------------------------------------------------------------------
+
+/// Unique identifier for a VM instance directory, backed by a v4 UUID.
+///
+/// Used as filesystem path component and HashMap key.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct InstanceId(Uuid);
+
+impl InstanceId {
+    /// Generate a new random instance ID (UUID v4).
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for InstanceId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for InstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CloudInitConfig (#536)
+// ---------------------------------------------------------------------------
+
+/// Structured cloud-init configuration for VM provisioning.
+///
+/// All optional fields default to `None` / empty so callers can build minimal
+/// configs without specifying every knob.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct CloudInitConfig {
+    /// Hostname to assign to the guest.
+    pub hostname: String,
+    /// SSH public keys to inject into the default user's `authorized_keys`.
+    pub ssh_authorized_keys: Vec<String>,
+    /// Name of the default user account.
+    pub default_user: String,
+    /// Additional user accounts to create.
+    #[serde(default)]
+    pub users: Vec<UserConfig>,
+    /// Raw YAML for network configuration (written to network-config).
+    pub network_config: Option<String>,
+    /// Extra user-data YAML appended to the generated user-data file.
+    pub user_data_extra: Option<String>,
+}
+
+/// A user account to create inside the guest via cloud-init.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct UserConfig {
+    /// Username.
+    pub name: String,
+    /// Groups the user should belong to.
+    #[serde(default)]
+    pub groups: Vec<String>,
+    /// Sudo rule (e.g. `"ALL=(ALL) NOPASSWD:ALL"`).
+    pub sudo: Option<String>,
+    /// Login shell path.
+    pub shell: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    fn sample_image_meta() -> ImageMeta {
+        ImageMeta {
+            name: "ubuntu-24.04".to_string(),
+            arch: "aarch64".to_string(),
+            os_family: "linux".to_string(),
+            variant: Some("minimal".to_string()),
+            format: "raw".to_string(),
+            compression: Some("zstd".to_string()),
+            boot_mode: "uefi".to_string(),
+            sha256: "abc123def456".to_string(),
+            size_mb: 2048,
+            min_disk_mb: 4096,
+            cloud_init: true,
+            default_username: Some("ubuntu".to_string()),
+            rootfs_fs: Some("ext4".to_string()),
+            source_kind: "catalog".to_string(),
+            file: "ubuntu-24.04-aarch64-minimal.raw.zst".to_string(),
+            imported_at: Some("2025-01-15T12:00:00Z".to_string()),
+        }
+    }
+
+    fn minimal_image_meta() -> ImageMeta {
+        ImageMeta {
+            name: "alpine-3.20".to_string(),
+            arch: "x86_64".to_string(),
+            os_family: "linux".to_string(),
+            variant: None,
+            format: "raw".to_string(),
+            compression: None,
+            boot_mode: "bios".to_string(),
+            sha256: "deadbeef".to_string(),
+            size_mb: 256,
+            min_disk_mb: 512,
+            cloud_init: false,
+            default_username: None,
+            rootfs_fs: None,
+            source_kind: "import".to_string(),
+            file: "alpine-3.20-x86_64.raw".to_string(),
+            imported_at: None,
+        }
+    }
+
+    // -- ImageMeta tests (#535) -----------------------------------------------
+
+    #[test]
+    fn image_meta_serde_roundtrip_full() {
+        let meta = sample_image_meta();
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: ImageMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+    }
+
+    #[test]
+    fn image_meta_serde_roundtrip_minimal() {
+        let meta = minimal_image_meta();
+        let json = serde_json::to_string(&meta).unwrap();
+        let back: ImageMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, back);
+        assert!(back.imported_at.is_none());
+        assert!(back.variant.is_none());
+    }
+
+    // -- ImageCatalog tests (#535) --------------------------------------------
+
+    #[test]
+    fn image_catalog_serde_roundtrip() {
+        let catalog = ImageCatalog {
+            version: 1,
+            base_url: "https://images.syfrah.dev/v1".to_string(),
+            images: vec![sample_image_meta(), minimal_image_meta()],
+        };
+        let json = serde_json::to_string(&catalog).unwrap();
+        let back: ImageCatalog = serde_json::from_str(&json).unwrap();
+        assert_eq!(catalog, back);
+        assert_eq!(back.images.len(), 2);
+    }
+
+    #[test]
+    fn image_catalog_parse_from_json_string() {
+        let json = r#"{
+            "version": 1,
+            "base_url": "https://images.syfrah.dev/v1",
+            "images": [
+                {
+                    "name": "ubuntu-24.04",
+                    "arch": "aarch64",
+                    "os_family": "linux",
+                    "variant": null,
+                    "format": "raw",
+                    "compression": "zstd",
+                    "boot_mode": "uefi",
+                    "sha256": "abc123",
+                    "size_mb": 2048,
+                    "min_disk_mb": 4096,
+                    "cloud_init": true,
+                    "default_username": "ubuntu",
+                    "rootfs_fs": "ext4",
+                    "source_kind": "catalog",
+                    "file": "ubuntu-24.04.raw.zst",
+                    "imported_at": null
+                }
+            ]
+        }"#;
+        let catalog: ImageCatalog = serde_json::from_str(json).unwrap();
+        assert_eq!(catalog.version, 1);
+        assert_eq!(catalog.images.len(), 1);
+        assert_eq!(catalog.images[0].name, "ubuntu-24.04");
+    }
+
+    // -- PullPolicy tests (#535) ----------------------------------------------
+
+    #[test]
+    fn pull_policy_default_is_if_not_present() {
+        assert_eq!(PullPolicy::default(), PullPolicy::IfNotPresent);
+    }
+
+    #[test]
+    fn pull_policy_serde_roundtrip() {
+        for policy in [
+            PullPolicy::IfNotPresent,
+            PullPolicy::Always,
+            PullPolicy::Never,
+        ] {
+            let json = serde_json::to_string(&policy).unwrap();
+            let back: PullPolicy = serde_json::from_str(&json).unwrap();
+            assert_eq!(policy, back);
+        }
+    }
+
+    // -- InstanceId tests (#536) ----------------------------------------------
+
+    #[test]
+    fn instance_id_unique_generation() {
+        let ids: Vec<InstanceId> = (0..100).map(|_| InstanceId::new()).collect();
+        let unique: HashSet<_> = ids.iter().collect();
+        assert_eq!(
+            ids.len(),
+            unique.len(),
+            "all 100 InstanceIds must be unique"
+        );
+    }
+
+    #[test]
+    fn instance_id_display() {
+        let id = InstanceId::new();
+        let display = id.to_string();
+        // UUID v4 format: 8-4-4-4-12 hex digits
+        assert_eq!(display.len(), 36);
+        assert_eq!(display.chars().filter(|c| *c == '-').count(), 4);
+    }
+
+    #[test]
+    fn instance_id_serde_roundtrip() {
+        let id = InstanceId::new();
+        let json = serde_json::to_string(&id).unwrap();
+        let back: InstanceId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn instance_id_as_hashmap_key() {
+        let mut map = HashMap::new();
+        let id = InstanceId::new();
+        map.insert(id.clone(), "running");
+        assert_eq!(map.get(&id), Some(&"running"));
+    }
+
+    // -- CloudInitConfig tests (#536) -----------------------------------------
+
+    #[test]
+    fn cloud_init_config_serde_minimal() {
+        let config = CloudInitConfig {
+            hostname: "vm-web-1".to_string(),
+            ssh_authorized_keys: vec!["ssh-ed25519 AAAA...".to_string()],
+            default_user: "ubuntu".to_string(),
+            users: vec![],
+            network_config: None,
+            user_data_extra: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let back: CloudInitConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, back);
+        assert!(back.users.is_empty());
+        assert!(back.network_config.is_none());
+    }
+
+    #[test]
+    fn cloud_init_config_serde_full() {
+        let config = CloudInitConfig {
+            hostname: "vm-db-1".to_string(),
+            ssh_authorized_keys: vec![
+                "ssh-ed25519 AAAA...".to_string(),
+                "ssh-rsa BBBB...".to_string(),
+            ],
+            default_user: "admin".to_string(),
+            users: vec![
+                UserConfig {
+                    name: "deploy".to_string(),
+                    groups: vec!["docker".to_string(), "sudo".to_string()],
+                    sudo: Some("ALL=(ALL) NOPASSWD:ALL".to_string()),
+                    shell: Some("/bin/bash".to_string()),
+                },
+                UserConfig {
+                    name: "monitor".to_string(),
+                    groups: vec![],
+                    sudo: None,
+                    shell: None,
+                },
+            ],
+            network_config: Some("network:\n  version: 2\n".to_string()),
+            user_data_extra: Some("runcmd:\n  - echo hello\n".to_string()),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let back: CloudInitConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, back);
+        assert_eq!(back.users.len(), 2);
+        assert!(back.network_config.is_some());
+    }
+
+    #[test]
+    fn user_config_serde_roundtrip() {
+        let user = UserConfig {
+            name: "testuser".to_string(),
+            groups: vec!["wheel".to_string()],
+            sudo: Some("ALL=(ALL) ALL".to_string()),
+            shell: Some("/bin/zsh".to_string()),
+        };
+        let json = serde_json::to_string(&user).unwrap();
+        let back: UserConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(user, back);
+    }
+}

--- a/layers/compute/src/lib.rs
+++ b/layers/compute/src/lib.rs
@@ -30,6 +30,7 @@ pub mod control;
 pub mod error;
 pub mod events;
 pub mod handler;
+pub mod image;
 pub mod manager;
 pub mod phase;
 pub mod preflight;

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -574,6 +574,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir.write_meta(&meta).unwrap();
 

--- a/layers/compute/src/process.rs
+++ b/layers/compute/src/process.rs
@@ -183,6 +183,12 @@ pub struct VmMeta {
     /// Memory in megabytes (persisted for reconnect).
     #[serde(default)]
     pub memory_mb: u32,
+    /// Image name used to create this VM.
+    #[serde(default)]
+    pub image_name: Option<String>,
+    /// Disk size in megabytes (persisted for reconnect).
+    #[serde(default)]
+    pub disk_size_mb: Option<u32>,
 }
 
 /// Scan a base directory for runtime dirs that contain meta.json.
@@ -442,6 +448,8 @@ async fn spawn_vm_inner(
         spec_hash: compute_spec_hash(spec),
         vcpus: spec.vcpus,
         memory_mb: spec.memory_mb,
+        image_name: Some(spec.image.clone()),
+        disk_size_mb: spec.disk_size_mb,
     };
     runtime_dir.write_meta(&meta)?;
 
@@ -1185,6 +1193,8 @@ mod tests {
             spec_hash: "hash:abc123".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
 
         dir.write_meta(&meta).unwrap();
@@ -1207,6 +1217,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
 
         dir.write_meta(&meta).unwrap();
@@ -1279,6 +1291,8 @@ mod tests {
             spec_hash: "hash:deadbeef".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         let json = serde_json::to_string(&meta).unwrap();
         let back: VmMeta = serde_json::from_str(&json).unwrap();
@@ -1303,6 +1317,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir1.write_meta(&meta).unwrap();
 
@@ -1375,6 +1391,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let h1 = compute_spec_hash(&spec);
         let h2 = compute_spec_hash(&spec);
@@ -1522,6 +1540,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir1.write_meta(&meta).unwrap();
 
@@ -1557,6 +1577,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir.write_meta(&meta).unwrap();
 
@@ -1601,6 +1623,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir.write_meta(&meta).unwrap();
 
@@ -1788,6 +1812,8 @@ mod tests {
             spec_hash: "hash:aaa".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir.write_meta(&meta1).unwrap();
 
@@ -1856,6 +1882,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir.write_meta(&meta).unwrap();
         assert!(dir.meta_path().exists());
@@ -1909,6 +1937,8 @@ mod tests {
             spec_hash: "hash:0".to_string(),
             vcpus: 2,
             memory_mb: 512,
+            image_name: None,
+            disk_size_mb: None,
         };
         dir1.write_meta(&meta1).unwrap();
 

--- a/layers/compute/src/types.rs
+++ b/layers/compute/src/types.rs
@@ -40,6 +40,12 @@ pub struct VmSpec {
     pub volumes: Vec<VolumeAttachment>,
     /// GPU passthrough mode.
     pub gpu: GpuMode,
+    /// SSH public key to inject into the VM via cloud-init.
+    #[serde(default)]
+    pub ssh_key: Option<String>,
+    /// Root disk size in megabytes. `None` uses the image default.
+    #[serde(default)]
+    pub disk_size_mb: Option<u32>,
 }
 
 /// TAP device configuration, provided by overlay via forge.
@@ -179,6 +185,8 @@ mod tests {
             gpu: GpuMode::Passthrough {
                 bdf: "0000:01:00.0".to_string(),
             },
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: VmSpec = serde_json::from_str(&json).unwrap();
@@ -196,6 +204,8 @@ mod tests {
             network: None,
             volumes: vec![],
             gpu: GpuMode::None,
+            ssh_key: None,
+            disk_size_mb: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: VmSpec = serde_json::from_str(&json).unwrap();
@@ -307,5 +317,47 @@ mod tests {
         } else {
             panic!("expected Resized");
         }
+    }
+
+    #[test]
+    fn vm_spec_with_ssh_key_and_disk_size_serde_roundtrip() {
+        let spec = VmSpec {
+            id: VmId("vm-extended".to_string()),
+            vcpus: 2,
+            memory_mb: 1024,
+            image: "ubuntu-24.04".to_string(),
+            kernel: None,
+            network: None,
+            volumes: vec![],
+            gpu: GpuMode::None,
+            ssh_key: Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 user@host".to_string()),
+            disk_size_mb: Some(20480),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: VmSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(spec, back);
+        assert_eq!(
+            back.ssh_key.as_deref(),
+            Some("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 user@host")
+        );
+        assert_eq!(back.disk_size_mb, Some(20480));
+    }
+
+    #[test]
+    fn vm_spec_without_new_fields_deserializes() {
+        // Backward compatibility: JSON without ssh_key/disk_size_mb should deserialize
+        let json = r#"{
+            "id": "vm-old",
+            "vcpus": 1,
+            "memory_mb": 512,
+            "image": "alpine",
+            "kernel": null,
+            "network": null,
+            "volumes": [],
+            "gpu": "None"
+        }"#;
+        let spec: VmSpec = serde_json::from_str(json).unwrap();
+        assert!(spec.ssh_key.is_none());
+        assert!(spec.disk_size_mb.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- **ImageMeta, ImageCatalog, PullPolicy** (#535): Foundation types for the image catalog system with full metadata model (name, arch, os_family, variant, format, compression, boot_mode, sha256, size_mb, min_disk_mb, cloud_init, default_username, rootfs_fs, source_kind, file, imported_at).
- **InstanceId, CloudInitConfig** (#536): UUID-backed InstanceId newtype (Display, Hash, serde, HashMap key) and CloudInitConfig/UserConfig structs for VM provisioning.
- **ImageError** (#537): 14-variant error enum with thiserror, plus `From<ImageError> for ComputeError` integration.
- **VmSpec extensions** (#538): Added `ssh_key: Option<String>` and `disk_size_mb: Option<u32>` to VmSpec, with validation (ssh_key non-empty, disk_size_mb >= 128), proto updates, and VmMeta extensions (image_name, disk_size_mb).

## Test plan

- [x] ImageMeta serde roundtrip (full + minimal)
- [x] ImageCatalog parse from JSON string
- [x] PullPolicy default is IfNotPresent
- [x] InstanceId unique generation (100 IDs, all different)
- [x] InstanceId Display format (UUID v4)
- [x] InstanceId as HashMap key
- [x] CloudInitConfig serde (minimal + full)
- [x] UserConfig serde roundtrip
- [x] ImageError Display for all 14 variants
- [x] ComputeError::from(ImageError) works
- [x] VmSpec with ssh_key/disk_size_mb serde roundtrip
- [x] VmSpec backward-compatible deserialization (missing new fields)
- [x] validate: ssh_key empty string rejected
- [x] validate: ssh_key whitespace-only rejected
- [x] validate: valid ssh_key passes
- [x] validate: disk_size_mb < 128 rejected
- [x] validate: disk_size_mb = 128 passes
- [x] validate: disk_size_mb None passes
- [x] 37 new tests total, 309 tests pass

Closes #535
Closes #536
Closes #537
Closes #538