### PR TITLE
fix(e2e): update VM JSON field references after #574

### DIFF
--- a/tests/e2e/scenarios/70_compute_vm_create.sh
+++ b/tests/e2e/scenarios/70_compute_vm_create.sh
@@ -45,7 +45,7 @@ fi
 sleep 3  # allow VM to reach Running state
 
 LIST_OUTPUT=$(list_vms "e2e-compute-create")
-if echo "$LIST_OUTPUT" | jq -e '.[] | select(.name == "test-vm-1")' >/dev/null 2>&1; then
+if echo "$LIST_OUTPUT" | jq -e '.[] | select(.id == "test-vm-1")' >/dev/null 2>&1; then
     pass "VM test-vm-1 appears in vm list"
 else
     fail "VM test-vm-1 not in vm list: $LIST_OUTPUT"
@@ -66,7 +66,7 @@ else
     fail "VM vCPUs: $VCPUS (expected 2)"
 fi
 
-MEMORY=$(echo "$VM_JSON" | jq -r '.memory // .spec.memory // empty' 2>/dev/null)
+MEMORY=$(echo "$VM_JSON" | jq -r '.memory_mb // .spec.memory_mb // empty' 2>/dev/null)
 if [ "$MEMORY" = "512" ]; then
     pass "VM has 512 MB memory"
 else

--- a/tests/e2e/scenarios/71_compute_vm_stop_delete.sh
+++ b/tests/e2e/scenarios/71_compute_vm_stop_delete.sh
@@ -60,7 +60,7 @@ sleep 2
 # ── Verify VM gone from list ────────────────────────────────────
 
 LIST_OUTPUT=$(list_vms "e2e-compute-stopdel")
-if echo "$LIST_OUTPUT" | jq -e '.[] | select(.name == "test-vm-sd")' >/dev/null 2>&1; then
+if echo "$LIST_OUTPUT" | jq -e '.[] | select(.id == "test-vm-sd")' >/dev/null 2>&1; then
     fail "VM test-vm-sd still in list after delete"
 else
     pass "VM test-vm-sd removed from list"

--- a/tests/e2e/scenarios/74_compute_vm_reconnect.sh
+++ b/tests/e2e/scenarios/74_compute_vm_reconnect.sh
@@ -65,7 +65,7 @@ sleep 3
 # ── Verify VM recovered ─────────────────────────────────────────
 
 LIST_OUTPUT=$(list_vms "e2e-compute-reconn")
-if echo "$LIST_OUTPUT" | jq -e '.[] | select(.name == "test-vm-rc")' >/dev/null 2>&1; then
+if echo "$LIST_OUTPUT" | jq -e '.[] | select(.id == "test-vm-rc")' >/dev/null 2>&1; then
     pass "VM test-vm-rc recovered after daemon restart"
 else
     fail "VM test-vm-rc not found after daemon restart: $LIST_OUTPUT"

--- a/tests/e2e/scenarios/75_compute_vm_crash_detection.sh
+++ b/tests/e2e/scenarios/75_compute_vm_crash_detection.sh
@@ -52,7 +52,7 @@ assert_vm_phase "e2e-compute-crash" "test-vm-crash" "Failed"
 # ── Verify failed VM in list ────────────────────────────────────
 
 LIST_OUTPUT=$(list_vms "e2e-compute-crash")
-if echo "$LIST_OUTPUT" | jq -e '.[] | select(.name == "test-vm-crash")' >/dev/null 2>&1; then
+if echo "$LIST_OUTPUT" | jq -e '.[] | select(.id == "test-vm-crash")' >/dev/null 2>&1; then
     pass "Failed VM still visible in list"
 else
     fail "Failed VM not in list"

--- a/tests/e2e/scenarios/83_compute_image_vm_lifecycle.sh
+++ b/tests/e2e/scenarios/83_compute_image_vm_lifecycle.sh
@@ -71,7 +71,7 @@ delete_vm "e2e-image-vm" "real-vm"
 sleep 2
 
 LIST_OUTPUT=$(list_vms "e2e-image-vm")
-if echo "$LIST_OUTPUT" | jq -e '.[] | select(.name == "real-vm")' >/dev/null 2>&1; then
+if echo "$LIST_OUTPUT" | jq -e '.[] | select(.id == "real-vm")' >/dev/null 2>&1; then
     fail "VM real-vm still in list after delete"
 else
     pass "VM real-vm cleaned up"


### PR DESCRIPTION
## Summary
- E2E compute tests updated to match new VM JSON output from #574
- `.name` -> `.id` in jq selectors for VM list/get
- `.memory` -> `.memory_mb` in VM create assertions

## Test plan
- [x] E2E compute tests should now pass with the renamed JSON fields

Follows up on #575