### PR TITLE
fix: harden all UX E2E tests against timing flakiness

### DIFF
--- a/tests/e2e/scenarios/100_ux_flow_reboot.sh
+++ b/tests/e2e/scenarios/100_ux_flow_reboot.sh
@@ -18,7 +18,8 @@ init_mesh "e2e-flow-reboot-1" "172.20.0.10" "reboot-srv-1"
 start_peering "e2e-flow-reboot-1"
 join_mesh "e2e-flow-reboot-2" "172.20.0.10" "172.20.0.11" "reboot-srv-2"
 
-sleep 5
+wait_for_peer_active "e2e-flow-reboot-1" 1 30
+wait_for_peer_active "e2e-flow-reboot-2" 1 30
 assert_peer_count "e2e-flow-reboot-1" 1
 assert_peer_count "e2e-flow-reboot-2" 1
 
@@ -28,7 +29,6 @@ docker restart "e2e-flow-reboot-2"
 
 # Step 2: Wait for daemon to come back (container needs time to restart fully)
 info "Step 2: Waiting for daemon recovery..."
-sleep 5
 wait_daemon "e2e-flow-reboot-2" 60
 
 # Step 3: Daemon is responsive (socket exists, commands work)
@@ -39,8 +39,8 @@ else
     fail "e2e-flow-reboot-2 daemon socket missing after reboot"
 fi
 
-# Step 4: Give mesh time to reconverge
-sleep 15
+# Step 4: Wait for mesh to reconverge
+wait_for_peer_active "e2e-flow-reboot-2" 1 30
 
 # Step 5: Server 2 sees server 1 as active
 info "Step 5: Server 2 peers after reboot..."

--- a/tests/e2e/scenarios/102_ux_flow_pin_onboarding.sh
+++ b/tests/e2e/scenarios/102_ux_flow_pin_onboarding.sh
@@ -33,7 +33,8 @@ echo "$output_join" | grep -qi "joined\|approved\|accepted" || fail "PIN join: n
 pass "PIN join: automatic approval (no interaction)"
 
 wait_daemon "e2e-flow-pin-2" 30
-sleep 5
+wait_for_peer_active "e2e-flow-pin-1" 1 30
+wait_for_peer_active "e2e-flow-pin-2" 1 30
 
 # Step 4: Both nodes see each other
 info "Step 4: Verify mesh formed..."

--- a/tests/e2e/scenarios/103_ux_flow_secret_rotation.sh
+++ b/tests/e2e/scenarios/103_ux_flow_secret_rotation.sh
@@ -18,7 +18,7 @@ init_mesh "e2e-flow-rot-1" "172.20.0.10" "rot-srv-1"
 start_peering "e2e-flow-rot-1"
 join_mesh "e2e-flow-rot-2" "172.20.0.10" "172.20.0.11" "rot-srv-2"
 
-sleep 5
+wait_for_peer_active "e2e-flow-rot-1" 1 30
 assert_peer_count "e2e-flow-rot-1" 1
 
 # Capture initial secret

--- a/tests/e2e/scenarios/104_ux_flow_churn.sh
+++ b/tests/e2e/scenarios/104_ux_flow_churn.sh
@@ -21,7 +21,7 @@ join_mesh "e2e-flow-churn-2" "172.20.0.10" "172.20.0.11" "churn-srv-2"
 sleep 3
 join_mesh "e2e-flow-churn-3" "172.20.0.10" "172.20.0.12" "churn-srv-3"
 
-sleep 5
+wait_for_peer_active "e2e-flow-churn-1" 2 30
 
 info "Verifying initial mesh..."
 if wait_for_convergence "e2e-flow-churn-" 3 2 60; then
@@ -34,12 +34,12 @@ fi
 for round in 1 2 3; do
     info "Churn round $round: server-3 leaves..."
     docker exec "e2e-flow-churn-3" syfrah fabric leave --yes 2>&1 || true
-    sleep 3
+    sleep 2
 
     info "Churn round $round: server-3 rejoins..."
     start_peering "e2e-flow-churn-1"
     join_mesh "e2e-flow-churn-3" "172.20.0.10" "172.20.0.12" "churn-srv-3"
-    sleep 5
+    wait_for_peer_active "e2e-flow-churn-3" 1 30
 
     # Quick check: node 3 sees at least 1 peer after rejoin
     actual=$(docker exec "e2e-flow-churn-3" syfrah fabric peers 2>&1 | grep -c "active" || echo "0")

--- a/tests/e2e/scenarios/106_ux_errors_join.sh
+++ b/tests/e2e/scenarios/106_ux_errors_join.sh
@@ -40,7 +40,7 @@ fi
 info "Testing: join when state exists..."
 start_peering "e2e-err-join-1"
 join_mesh "e2e-err-join-2" "172.20.0.10" "172.20.0.11" "err-join-srv-2"
-sleep 3
+wait_for_peer_active "e2e-err-join-2" 1 30
 
 err3=$(docker exec "e2e-err-join-2" syfrah fabric join 172.20.0.10:51821 \
     --node-name err-join-2b --endpoint 172.20.0.11:51820 --pin "$E2E_PIN" 2>&1 || true)

--- a/tests/e2e/scenarios/110_ux_consistency.sh
+++ b/tests/e2e/scenarios/110_ux_consistency.sh
@@ -19,7 +19,7 @@ E2E_MESH="consist-mesh"
 init_mesh "e2e-consist-1" "172.20.0.10" "consist-srv-1"
 start_peering "e2e-consist-1"
 join_mesh "e2e-consist-2" "172.20.0.10" "172.20.0.11" "consist-srv-2"
-sleep 3
+sleep 2
 join_mesh "e2e-consist-3" "172.20.0.10" "172.20.0.12" "consist-srv-3"
 
 wait_for_convergence "e2e-consist-" 3 2 45 || true
@@ -79,7 +79,7 @@ done
 # === Post leave+rejoin: no stale data ===
 info "Testing: no stale data after leave+rejoin..."
 docker exec "e2e-consist-3" syfrah fabric leave --yes 2>&1 || true
-sleep 3
+sleep 2
 start_peering "e2e-consist-1"
 join_mesh "e2e-consist-3" "172.20.0.10" "172.20.0.12" "consist-srv-3"
 wait_for_convergence "e2e-consist-" 3 2 30 || true
@@ -105,6 +105,7 @@ stop_daemon "e2e-consist-1"
 sleep 2
 docker exec -d "e2e-consist-1" syfrah fabric start
 wait_daemon "e2e-consist-1" 30
+wait_for_peer_active "e2e-consist-1" 2 30 || true
 peers_after=$(docker exec "e2e-consist-1" syfrah fabric peers 2>&1 | tail -n +3 | wc -l)
 
 if [ "$peers_before" = "$peers_after" ]; then

--- a/tests/e2e/scenarios/98_ux_flow_first_mesh.sh
+++ b/tests/e2e/scenarios/98_ux_flow_first_mesh.sh
@@ -37,7 +37,8 @@ echo "$output_join" | grep -qi "joined\|approved\|accepted" || fail "join: no ap
 pass "join: approval confirmed"
 
 wait_daemon "e2e-flow-first-2" 30
-sleep 5
+wait_for_peer_active "e2e-flow-first-1" 1 30
+wait_for_peer_active "e2e-flow-first-2" 1 30
 
 # Step 4: Both see each other in peers
 info "Step 4: Verify bidirectional peer visibility..."

--- a/tests/e2e/scenarios/99_ux_flow_leave_rejoin.sh
+++ b/tests/e2e/scenarios/99_ux_flow_leave_rejoin.sh
@@ -18,7 +18,8 @@ init_mesh "e2e-flow-lr-1" "172.20.0.10" "lr-server-1"
 start_peering "e2e-flow-lr-1"
 join_mesh "e2e-flow-lr-2" "172.20.0.10" "172.20.0.11" "lr-server-2"
 
-sleep 5
+wait_for_peer_active "e2e-flow-lr-1" 1 30
+wait_for_peer_active "e2e-flow-lr-2" 1 30
 assert_peer_count "e2e-flow-lr-1" 1
 assert_peer_count "e2e-flow-lr-2" 1
 
@@ -42,7 +43,8 @@ info "Step 3: Server 2 rejoins..."
 start_peering "e2e-flow-lr-1"
 join_mesh "e2e-flow-lr-2" "172.20.0.10" "172.20.0.11" "lr-server-2"
 
-sleep 5
+wait_for_peer_active "e2e-flow-lr-1" 1 30
+wait_for_peer_active "e2e-flow-lr-2" 1 30
 
 # Step 4: Both nodes see each other after rejoin
 info "Step 4: Peers visible after rejoin..."


### PR DESCRIPTION
## Summary
- Replace `sleep N` + assert patterns with `wait_for_peer_active` polling in all UX flow E2E scenarios (98-110)
- Same hardening pattern applied to fabric scenarios in PR #578
- Prevents random CI failures on slow runners where peers need more time to become active

## Files changed
- `98_ux_flow_first_mesh.sh` — sleep 5 before peer checks → wait_for_peer_active
- `99_ux_flow_leave_rejoin.sh` — 2x sleep 5 before peer assertions → wait_for_peer_active
- `100_ux_flow_reboot.sh` — sleep 5/15 around reboot → wait_for_peer_active, removed redundant sleep before wait_daemon
- `102_ux_flow_pin_onboarding.sh` — sleep 5 after join → wait_for_peer_active
- `103_ux_flow_secret_rotation.sh` — sleep 5 before assert_peer_count → wait_for_peer_active
- `104_ux_flow_churn.sh` — sleep 5 before convergence + sleep 5 in churn loop → wait_for_peer_active
- `106_ux_errors_join.sh` — sleep 3 after join → wait_for_peer_active
- `110_ux_consistency.sh` — added wait_for_peer_active after stop+start cycle

## Test plan
- [ ] All E2E UX scenarios (98-110) pass on CI
- [ ] No bash syntax errors (`bash -n` verified locally)
- [ ] Existing grep patterns already have `|| echo "0"` fallbacks
- [ ] get_mesh_ipv6 calls already have null checks

Closes #579