### PR TITLE
fix: cast statvfs fields to u64 for macOS build

### DIFF
--- a/layers/compute/src/disk.rs
+++ b/layers/compute/src/disk.rs
@@ -306,7 +306,11 @@ fn available_disk_space(path: &Path) -> u64 {
     unsafe {
         let mut stat: libc::statvfs = std::mem::zeroed();
         if libc::statvfs(c_path.as_ptr(), &mut stat) == 0 {
-            (stat.f_bavail as u64) * (stat.f_bsize as u64)
+            #[allow(clippy::unnecessary_cast)]
+            let avail = stat.f_bavail as u64;
+            #[allow(clippy::unnecessary_cast)]
+            let bsize = stat.f_bsize as u64;
+            avail * bsize
         } else {
             u64::MAX // cannot check — assume enough
         }


### PR DESCRIPTION
## Problem

Release workflow fails on macOS targets (aarch64-apple-darwin, x86_64-apple-darwin):
```
error[E0308]: mismatched types — expected u32, found u64
error[E0277]: cannot multiply u32 by u64
```

`libc::statvfs` field types differ between platforms:
- Linux: `f_bavail: u64`, `f_bsize: u64`
- macOS: `f_bavail: u32`, `f_bsize: u64` (or both u32)

## Fix

Cast both fields to `u64` explicitly: `(stat.f_bavail as u64) * (stat.f_bsize as u64)`

One-line fix in `layers/compute/src/disk.rs:309`.