### PR TITLE
fix: implement --beta flag in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,14 @@ set -eu
 REPO="sifrah/syfrah"
 BIN="syfrah"
 INSTALL_DIR="/usr/local/bin"
+CHANNEL="stable"
+
+# Parse arguments
+for arg in "$@"; do
+  case "$arg" in
+    --beta) CHANNEL="beta" ;;
+  esac
+done
 
 # --- UX helpers -----------------------------------------------------------
 
@@ -95,18 +103,30 @@ esac
 
 TARGET="${ARCH}-${OS}"
 
-# --- Fetch latest release tag ----------------------------------------------
+# --- Fetch release tag -----------------------------------------------------
 
-start_spinner "Fetching latest release version..."
-VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')" || true
-
-if [ -z "$VERSION" ]; then
-  stop_spinner "Could not determine latest release version" fail
-  exit 1
+if [ "$CHANNEL" = "beta" ]; then
+  start_spinner "Fetching latest beta release version..."
+  # Beta releases are pre-releases — /releases/latest ignores them.
+  # List all releases and pick the first pre-release (most recent).
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" \
+    | grep -A 2 '"prerelease": true' | grep '"tag_name"' | head -1 \
+    | sed 's/.*"tag_name": *"//;s/".*//')" || true
+  if [ -z "$VERSION" ]; then
+    stop_spinner "No beta release found" fail
+    exit 1
+  fi
+  stop_spinner "Latest beta: ${VERSION}"
+else
+  start_spinner "Fetching latest stable release version..."
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')" || true
+  if [ -z "$VERSION" ]; then
+    stop_spinner "Could not determine latest release version" fail
+    exit 1
+  fi
+  stop_spinner "Latest version: ${VERSION}"
 fi
-
-stop_spinner "Latest version: ${VERSION}"
 
 # --- Download archive -------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`curl ... install.sh | sh -s -- --beta` was supposed to install the latest beta but downloaded the stable release instead. The `--beta` flag was documented but never implemented.

`/releases/latest` on GitHub always returns the latest non-prerelease. Beta releases (marked `prerelease: true`) are ignored.

## Fix

- Parse `--beta` from args
- Stable (default): use `/releases/latest` (existing behavior)
- Beta: query `/releases?per_page=20`, find the first with `prerelease: true`, use its tag

## Test

```bash
# Stable
curl -fsSL .../install.sh | sh

# Beta  
curl -fsSL .../install.sh | sh -s -- --beta
```