### PR TITLE
fix: correct daemon connection error message

### DIFF
--- a/layers/compute/src/cli/image.rs
+++ b/layers/compute/src/cli/image.rs
@@ -88,7 +88,7 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -139,7 +139,7 @@ async fn run_inspect(name: String) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -164,7 +164,7 @@ async fn run_pull(name: String) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -192,7 +192,7 @@ async fn run_import(path: PathBuf, name: String, arch: String) -> anyhow::Result
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -229,7 +229,7 @@ async fn run_delete(name: String, yes: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -253,7 +253,7 @@ async fn run_catalog(json: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 

--- a/layers/compute/src/cli/mod.rs
+++ b/layers/compute/src/cli/mod.rs
@@ -54,7 +54,7 @@ async fn run_status(json: bool) -> anyhow::Result<()> {
     let req = ComputeRequest::Status;
     let resp = send_compute_request(&control_socket_path(), &req)
         .await
-        .map_err(|e| anyhow::anyhow!("failed to connect to daemon: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"))?;
 
     match resp {
         ComputeResponse::Status(v) => {

--- a/layers/compute/src/cli/vm.rs
+++ b/layers/compute/src/cli/vm.rs
@@ -183,7 +183,7 @@ async fn run_create(
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -224,7 +224,7 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -274,7 +274,7 @@ async fn run_get(id: String, json: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -318,7 +318,7 @@ async fn run_start(id: String) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -346,7 +346,7 @@ async fn run_stop(id: String, force: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -389,7 +389,7 @@ async fn run_delete(id: String, yes: bool) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -413,7 +413,7 @@ async fn run_reboot(id: String) -> anyhow::Result<()> {
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 
@@ -442,7 +442,7 @@ async fn run_resize(id: String, vcpus: Option<u32>, memory: Option<u32>) -> anyh
         .await
         .map_err(|e| {
             anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Try: syfrah start"
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
             )
         })?;
 


### PR DESCRIPTION
Replaced 'Try: syfrah start' with 'Initialize with: syfrah fabric init --name <mesh-name>' — the actual command to start the daemon.