### PR TITLE
fix: add VmNotFound error variant instead of abusing SpawnFailed

### DIFF
--- a/layers/compute/src/error.rs
+++ b/layers/compute/src/error.rs
@@ -27,6 +27,9 @@ pub enum ComputeError {
     #[error("concurrency error: {0}")]
     Concurrency(#[from] ConcurrencyError),
 
+    #[error("VM {id} not found")]
+    VmNotFound { id: String },
+
     #[error("image error: {0}")]
     Image(#[from] crate::image::error::ImageError),
 }

--- a/layers/compute/src/handler.rs
+++ b/layers/compute/src/handler.rs
@@ -153,14 +153,8 @@ fn error_to_status(err: &ComputeError) -> StatusCode {
         ComputeError::Preflight(_) => StatusCode::BAD_REQUEST,
         ComputeError::Transition(_) => StatusCode::CONFLICT,
         ComputeError::Concurrency(_) => StatusCode::CONFLICT,
-        ComputeError::Process(ref pe) => {
-            let msg = pe.to_string();
-            if msg.contains("not found") {
-                StatusCode::NOT_FOUND
-            } else {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
-        }
+        ComputeError::VmNotFound { .. } => StatusCode::NOT_FOUND,
+        ComputeError::Process(_) => StatusCode::INTERNAL_SERVER_ERROR,
         ComputeError::Client(_) => StatusCode::INTERNAL_SERVER_ERROR,
         ComputeError::Image(_) => StatusCode::UNPROCESSABLE_ENTITY,
     }
@@ -593,15 +587,15 @@ mod tests {
     }
 
     #[test]
-    fn error_to_status_process_not_found() {
-        let err = ComputeError::Process(crate::error::ProcessError::SpawnFailed {
-            reason: "VM vm-123 not found".to_string(),
-        });
+    fn error_to_status_vm_not_found() {
+        let err = ComputeError::VmNotFound {
+            id: "vm-123".to_string(),
+        };
         assert_eq!(error_to_status(&err), StatusCode::NOT_FOUND);
     }
 
     #[test]
-    fn error_to_status_process_other_is_500() {
+    fn error_to_status_process_is_500() {
         let err = ComputeError::Process(crate::error::ProcessError::SpawnFailed {
             reason: "permission denied".to_string(),
         });

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -572,15 +572,12 @@ impl VmManager {
 
     /// Look up a VM by ID, returning its `Arc<Mutex<VmRuntimeState>>`.
     ///
-    /// Returns `ProcessError::PidNotFound`-style error if the VM is unknown.
+    /// Returns `ComputeError::VmNotFound` if the VM is unknown.
     async fn get_vm(&self, id: &str) -> Result<Arc<Mutex<VmRuntimeState>>, ComputeError> {
         let map = self.vms.read().await;
-        map.get(id).cloned().ok_or_else(|| {
-            ProcessError::SpawnFailed {
-                reason: format!("VM {id} not found"),
-            }
-            .into()
-        })
+        map.get(id)
+            .cloned()
+            .ok_or_else(|| ComputeError::VmNotFound { id: id.to_string() })
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `VmNotFound { id: String }` variant to `ComputeError` in `layers/compute/src/error.rs`
- Replaced `ProcessError::SpawnFailed { reason: "VM X not found" }` with `ComputeError::VmNotFound { id }` in `manager.rs::get_vm()`
- Replaced fragile string matching (`msg.contains("not found")`) in `handler.rs::error_to_status()` with a direct `ComputeError::VmNotFound` match arm returning 404

## Test plan
- [x] All 412 unit tests pass (`cargo test -p syfrah-compute`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Handler tests updated: `error_to_status_vm_not_found` replaces `error_to_status_process_not_found`
- [x] Integration tests (`get_vm_not_found_returns_404`, `delete_vm_not_found_returns_404`, `stop_vm_not_found_returns_404`) still pass

Closes #587