### PR TITLE
feat: show image size and spinner during image pull

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "indicatif",
  "libc",
  "reqwest",
  "serde",

--- a/layers/compute/Cargo.toml
+++ b/layers/compute/Cargo.toml
@@ -15,6 +15,7 @@ futures-util = "0.3"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
+indicatif = "0.17"
 libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["stream", "rustls-tls"] }
 serde = { workspace = true }

--- a/layers/compute/src/cli/image.rs
+++ b/layers/compute/src/cli/image.rs
@@ -4,8 +4,10 @@
 //! Each handler communicates with the daemon via the control socket.
 
 use std::path::PathBuf;
+use std::time::Instant;
 
 use clap::Subcommand;
+use indicatif::{ProgressBar, ProgressStyle};
 
 use crate::control::{send_compute_request, ComputeRequest, ComputeResponse};
 
@@ -158,25 +160,63 @@ async fn run_inspect(name: String) -> anyhow::Result<()> {
 }
 
 async fn run_pull(name: String) -> anyhow::Result<()> {
-    println!("Downloading {name}...");
+    let sock = control_socket_path();
+
+    // Fetch catalog to get image size before starting download.
+    let size_mb = match send_compute_request(&sock, &ComputeRequest::ImageCatalog).await {
+        Ok(ComputeResponse::ImageCatalog(v)) => v
+            .get("images")
+            .and_then(|i| i.as_array())
+            .and_then(|imgs| {
+                imgs.iter()
+                    .find(|img| img.get("name").and_then(|n| n.as_str()) == Some(&name))
+            })
+            .and_then(|img| img.get("size_mb").and_then(|s| s.as_u64())),
+        _ => None,
+    };
+
+    let size_label = match size_mb {
+        Some(mb) => format!(" ({mb} MB)"),
+        None => String::new(),
+    };
+
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap_or_else(|_| ProgressStyle::default_spinner()),
+    );
+    spinner.set_message(format!("Downloading {name}{size_label}..."));
+    spinner.enable_steady_tick(std::time::Duration::from_millis(120));
+
+    let start = Instant::now();
+
     let req = ComputeRequest::ImagePull { name: name.clone() };
-    let resp = send_compute_request(&control_socket_path(), &req)
-        .await
-        .map_err(|e| {
-            anyhow::anyhow!(
-                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
-            )
-        })?;
+    let resp = send_compute_request(&sock, &req).await.map_err(|e| {
+        spinner.finish_and_clear();
+        anyhow::anyhow!(
+            "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
+        )
+    })?;
+
+    let elapsed = start.elapsed().as_secs_f64();
 
     match resp {
         ComputeResponse::ImageMeta(_) => {
-            println!("Done.");
+            spinner.finish_and_clear();
+            let time_str = if elapsed < 1.0 {
+                format!("{:.0}ms", elapsed * 1000.0)
+            } else {
+                format!("{elapsed:.1}s")
+            };
+            println!("Downloaded {name}{size_label} in {time_str}. SHA256 verified.");
             Ok(())
         }
         ComputeResponse::Error(msg) => {
+            spinner.finish_and_clear();
             anyhow::bail!("{msg}");
         }
         _ => {
+            spinner.finish_and_clear();
             anyhow::bail!("unexpected response from daemon");
         }
     }


### PR DESCRIPTION
## Summary
- Fetch image catalog before starting pull to display image size (e.g. "Downloading alpine-3.20 (90 MB)...")
- Show an indicatif spinner while waiting for the daemon control socket response
- On completion, display download time and SHA256 verification: "Downloaded alpine-3.20 (90 MB) in 4.2s. SHA256 verified."
- Uses `indicatif` crate (same library used by cargo) with `ProgressBar::new_spinner()` which degrades gracefully on non-interactive terminals (no broken escape codes)

## Test plan
- [ ] Run `syfrah compute image pull alpine-3.20` and verify spinner + size + timing output
- [ ] Pipe output (`| cat`) and verify no broken escape codes
- [ ] Pull an image not in catalog and verify graceful fallback (no size shown)
- [ ] Pull an already-cached image and verify fast completion message
- [ ] Verify daemon not running shows helpful error after clearing spinner

Closes #599