### PR TITLE
fix: add version files to e2e Dockerfile build context

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:latest AS builder
 WORKDIR /app
 RUN rustup target add x86_64-unknown-linux-musl && \
     apt-get update && apt-get install -y musl-tools
-COPY Cargo.toml Cargo.lock CLOUD_HYPERVISOR_VERSION ./
+COPY Cargo.toml Cargo.lock CLOUD_HYPERVISOR_VERSION CRUN_VERSION RUNSC_VERSION ./
 COPY layers layers
 COPY bin bin
 RUN cargo build --release --bin syfrah --target x86_64-unknown-linux-musl


### PR DESCRIPTION
build.rs reads CRUN_VERSION and RUNSC_VERSION via include_str\! but the Dockerfile didn't COPY them.