### PR TITLE
fix: wire VmManager through ComputeRuntime trait

### DIFF
--- a/layers/compute/src/control.rs
+++ b/layers/compute/src/control.rs
@@ -251,6 +251,7 @@ async fn handle_compute_request(mgr: &VmManager, req: ComputeRequest) -> Compute
             ComputeResponse::Status(serde_json::json!({
                 "status": status,
                 "warnings": warnings,
+                "runtime": mgr.runtime_name(),
                 "total_vms": total,
                 "running_vms": running,
             }))

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -6,14 +6,13 @@ use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, Mutex, RwLock};
 use tracing::info;
 
-use crate::client::ChClient;
 use crate::error::{ComputeError, ProcessError};
 use crate::events;
 use crate::image::store::ImageStore;
 use crate::image::types::{ImageCatalog, PullPolicy};
-use crate::process::{self, RuntimeDir};
+use crate::process;
 use crate::runtime::VmRuntimeState;
-use crate::runtime_backend::ComputeRuntime;
+use crate::runtime_backend::{ComputeRuntime, RuntimeSpec};
 use crate::runtime_ch;
 use crate::types::{VmEvent, VmId, VmSpec, VmStatus};
 
@@ -304,7 +303,7 @@ impl VmManager {
         self.runtime.name()
     }
 
-    /// Run health checks against KVM, CH binary, and kernel availability.
+    /// Run health checks by delegating to the active runtime backend.
     ///
     /// Returns `("healthy", [])` if everything is OK, or `("degraded", warnings)`
     /// if one or more prerequisites are missing.
@@ -312,11 +311,9 @@ impl VmManager {
     /// Results are cached for [`HEALTH_CHECK_TTL`] (30 s) to avoid repeated stat
     /// syscalls when the status endpoint is polled frequently.
     ///
-    /// NOTE: The path-existence checks here intentionally duplicate the logic in
-    /// `preflight.rs`. Preflight returns typed `PreflightError` variants (collected
-    /// into a `Vec<PreflightError>`) while health_check returns human-readable
-    /// warning strings. Extracting a shared helper would couple two different
-    /// error models for only 3 lines of savings.
+    /// Each runtime checks its own prerequisites:
+    /// - ChRuntime: KVM, CH binary, kernel
+    /// - ContainerRuntime: crun, runsc
     pub fn health_check(&self) -> (&'static str, Vec<String>) {
         // Return cached result if still fresh.
         {
@@ -331,22 +328,8 @@ impl VmManager {
             }
         }
 
-        // Cache miss — perform the stat checks.
-        // Pre-allocate for the 3 possible warnings to avoid a heap allocation
-        // on the happy path (with_capacity(0) is free; grows only if needed).
-        let mut warnings = Vec::with_capacity(3);
-
-        if !Path::new("/dev/kvm").exists() {
-            warnings.push("KVM not available — VMs cannot boot".to_string());
-        }
-
-        if !self.ch_binary.exists() {
-            warnings.push("cloud-hypervisor binary not found".to_string());
-        }
-
-        if !self.config.kernel_path.exists() {
-            warnings.push("kernel not found".to_string());
-        }
+        // Delegate to the active runtime for its specific health warnings.
+        let warnings = self.runtime.health_warnings();
 
         let status = if warnings.is_empty() {
             "healthy"
@@ -371,9 +354,10 @@ impl VmManager {
     /// Create and boot a new VM.
     ///
     /// 1. Checks that no VM with the same ID already exists.
-    /// 2. Calls `process::spawn_vm` (validate, resolve, preflight, spawn, boot).
-    /// 3. Inserts the runtime state into the map with `Arc<Mutex<_>>`.
-    /// 4. Emits `Created` and `Booted` events.
+    /// 2. Performs image management (pull, clone, cloud-init) if enabled.
+    /// 3. Builds a `RuntimeSpec` and delegates to `self.runtime.create()`.
+    /// 4. Inserts the runtime state into the map with `Arc<Mutex<_>>`.
+    /// 5. Emits `Created` and `Booted` events.
     pub async fn create_vm(&self, spec: VmSpec) -> Result<VmStatus, ComputeError> {
         let vm_id_str = spec.id.0.clone();
 
@@ -388,26 +372,179 @@ impl VmManager {
             }
         }
 
-        // Spawn (this is the heavy part — runs outside any lock on the map).
+        // -- Image management (pull, clone, cloud-init) -----------------------
+        // These steps stay in the manager; only the final spawn goes through
+        // the runtime trait.
         let catalog = self.catalog.read().await.clone();
-        let state = process::spawn_vm(
-            &spec,
-            &self.ch_binary,
-            &self.config.base_dir,
-            &self.config.image_dir,
-            &self.config.kernel_path,
-            if self.config.image_management {
-                Some(&self.image_store)
-            } else {
-                None
-            },
-            &catalog,
-            &self.config.pull_policy,
-            &self.config.instance_base,
-        )
-        .await?;
+        let mut instance_dir_path: Option<PathBuf> = None;
+        let mut instance_rootfs: Option<PathBuf> = None;
+        let mut cloud_init_path: Option<PathBuf> = None;
 
+        if self.config.image_management {
+            use crate::disk;
+            use crate::image;
+            use crate::image::error::ImageError;
+            use crate::image::types::{CloudInitConfig, InstanceId};
+
+            let store = &self.image_store;
+
+            // Image check/pull
+            let image_meta = match store.get(&spec.image)? {
+                Some(meta) => {
+                    info!(image = %spec.image, "image found in local cache");
+                    meta
+                }
+                None if self.config.pull_policy != PullPolicy::Never => {
+                    info!(image = %spec.image, "pulling image from catalog");
+                    image::pull::pull(store, &spec.image, &catalog).await?
+                }
+                None => {
+                    return Err(ImageError::ImageNotFound {
+                        name: spec.image.clone(),
+                    }
+                    .into());
+                }
+            };
+
+            // Arch validation
+            let node_arch = match std::env::consts::ARCH {
+                "x86_64" => "amd64",
+                "aarch64" => "arm64",
+                other => other,
+            };
+            if image_meta.arch != "unknown" && image_meta.arch != node_arch {
+                return Err(ImageError::ArchMismatch {
+                    image_arch: image_meta.arch.clone(),
+                    node_arch: node_arch.to_string(),
+                }
+                .into());
+            }
+
+            // Create instance dir
+            let instance_id = InstanceId::new();
+            let inst_dir = disk::InstanceDir::create(&self.config.instance_base, &instance_id)?;
+            let inst_path = inst_dir.path().to_path_buf();
+
+            // Clone base image
+            let base_image_path = store.image_path(&spec.image);
+            let min_disk = image_meta.min_disk_mb as u32;
+            let effective_size_bytes =
+                match disk::clone_image(&base_image_path, &inst_dir, spec.disk_size_mb, min_disk) {
+                    Ok(size) => {
+                        info!(
+                            vm_id = %vm_id_str,
+                            instance = %instance_id,
+                            "image cloned to instance dir"
+                        );
+                        size
+                    }
+                    Err(e) => {
+                        inst_dir.cleanup().ok();
+                        return Err(e.into());
+                    }
+                };
+
+            // Generate cloud-init (if applicable)
+            if image_meta.cloud_init && spec.ssh_key.is_some() {
+                let cloud_config = CloudInitConfig {
+                    hostname: vm_id_str.clone(),
+                    ssh_authorized_keys: vec![spec.ssh_key.clone().unwrap()],
+                    default_user: image_meta
+                        .default_username
+                        .clone()
+                        .unwrap_or_else(|| "ubuntu".to_string()),
+                    users: vec![],
+                    network_config: None,
+                    user_data_extra: None,
+                };
+                match disk::generate_cloud_init(&cloud_config, &inst_dir, &instance_id) {
+                    Ok(ci_path) => {
+                        info!(vm_id = %vm_id_str, "cloud-init config-drive generated");
+                        cloud_init_path = Some(ci_path);
+                    }
+                    Err(e) => {
+                        inst_dir.cleanup().ok();
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            // Write instance metadata
+            let effective_mb = (effective_size_bytes / (1024 * 1024)) as u32;
+            let inst_meta = disk::InstanceMeta {
+                image_source: spec.image.clone(),
+                image_sha: image_meta.sha256.clone(),
+                arch: image_meta.arch.clone(),
+                requested_disk_size_mb: spec.disk_size_mb,
+                effective_disk_size_mb: effective_mb,
+                hostname: vm_id_str.clone(),
+                created_at: std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs()
+                    .to_string(),
+                vm_name: vm_id_str.clone(),
+            };
+            if let Err(e) = inst_dir.write_metadata(&inst_meta) {
+                inst_dir.cleanup().ok();
+                return Err(e.into());
+            }
+
+            instance_rootfs = Some(inst_dir.rootfs_path());
+            instance_dir_path = Some(inst_path);
+        }
+
+        // -- Build RuntimeSpec and delegate to the runtime --------------------
+        let rootfs_path = if let Some(ref rootfs) = instance_rootfs {
+            rootfs.clone()
+        } else {
+            // When image management is disabled, use image name as path
+            // (same behaviour as before — resolve happens inside the runtime).
+            self.config.image_dir.join(format!("{}.raw", spec.image))
+        };
+
+        let runtime_spec = RuntimeSpec {
+            vcpus: spec.vcpus,
+            memory_mb: spec.memory_mb,
+            rootfs_path,
+            cloud_init_path,
+            network: spec.network.clone(),
+            gpu: spec.gpu.clone(),
+        };
+
+        let handle = match self.runtime.create(&vm_id_str, &runtime_spec).await {
+            Ok(h) => h,
+            Err(e) => {
+                // Cleanup instance dir on runtime failure.
+                if let Some(ref p) = instance_dir_path {
+                    let _ = std::fs::remove_dir_all(p);
+                }
+                return Err(e);
+            }
+        };
+
+        // -- Build VmRuntimeState from the RuntimeHandle ----------------------
         let now = now_unix();
+        let state = crate::runtime::VmRuntimeState {
+            vm_id: spec.id.clone(),
+            pid: handle.pid,
+            socket_path: handle.runtime_dir.join("api.sock"),
+            cgroup_path: None,
+            ch_binary_path: self.ch_binary.clone(),
+            ch_binary_version: process::get_ch_version(&self.ch_binary)
+                .unwrap_or_else(|| "unknown".to_string()),
+            vcpus: spec.vcpus,
+            memory_mb: spec.memory_mb,
+            launched_at: now,
+            last_ping_at: Some(now),
+            last_error: None,
+            current_phase: crate::phase::VmPhase::Running,
+            reconnect_source: crate::runtime::ReconnectSource::FreshSpawn,
+            image_name: Some(spec.image.clone()),
+            instance_dir_path,
+            runtime_handle: Some(handle),
+        };
+
         let status = state.to_status(now);
         let image_name = spec.image.clone();
 
@@ -440,18 +577,17 @@ impl VmManager {
         Ok(status)
     }
 
-    /// Shut down a running VM via the 4-level kill chain.
+    /// Shut down a running VM via the runtime backend.
     ///
-    /// Acquires the VM's mutex, calls `process::kill_vm`, and emits a
+    /// Acquires the VM's mutex, delegates to `self.runtime.stop()`, and emits a
     /// `Stopped` event on success.
     pub async fn shutdown_vm(&self, id: &str) -> Result<(), ComputeError> {
         let vm_arc = self.get_vm(id).await?;
         let mut guard = vm_arc.lock().await;
 
-        let runtime_dir = RuntimeDir::from_existing(self.config.base_dir.join(id));
-        let client = ChClient::new(guard.socket_path.clone());
-
-        process::kill_vm(&mut guard, &client, &runtime_dir).await?;
+        let handle = guard.to_runtime_handle(&self.config.base_dir);
+        self.runtime.stop(&handle, false).await?;
+        guard.current_phase = crate::phase::VmPhase::Stopped;
 
         events::emit(
             &self.event_tx,
@@ -468,10 +604,9 @@ impl VmManager {
         let vm_arc = self.get_vm(id).await?;
         let mut guard = vm_arc.lock().await;
 
-        let runtime_dir = RuntimeDir::from_existing(self.config.base_dir.join(id));
-        let client = ChClient::new(guard.socket_path.clone());
-
-        process::kill_vm_force(&mut guard, &client, &runtime_dir).await?;
+        let handle = guard.to_runtime_handle(&self.config.base_dir);
+        self.runtime.stop(&handle, true).await?;
+        guard.current_phase = crate::phase::VmPhase::Stopped;
 
         events::emit(
             &self.event_tx,
@@ -501,16 +636,17 @@ impl VmManager {
         retain_disk: bool,
     ) -> Result<(), ComputeError> {
         let vm_arc = self.get_vm(id).await?;
-        let mut guard = vm_arc.lock().await;
-
-        let runtime_dir = RuntimeDir::from_existing(self.config.base_dir.join(id));
-        let client = ChClient::new(guard.socket_path.clone());
+        let guard = vm_arc.lock().await;
 
         // Capture image name before delete for refcount tracking.
         let image_name = guard.image_name.clone();
         let instance_dir_path = guard.instance_dir_path.clone();
 
-        process::delete_vm(&mut guard, &client, &runtime_dir).await?;
+        let handle = guard.to_runtime_handle(&self.config.base_dir);
+        drop(guard);
+
+        // Delegate to the runtime backend for stop + cleanup of runtime artifacts.
+        self.runtime.delete(&handle).await?;
 
         // Clean up instance directory (if image management was used).
         if let Some(ref inst_path) = instance_dir_path {
@@ -530,9 +666,6 @@ impl VmManager {
                 info!(path = %inst_path.display(), "instance directory cleaned up");
             }
         }
-
-        // Drop the guard before acquiring the write lock on the map.
-        drop(guard);
 
         {
             let mut map = self.vms.write().await;

--- a/layers/compute/src/process.rs
+++ b/layers/compute/src/process.rs
@@ -224,7 +224,7 @@ pub fn scan_runtime_dirs(base: &Path) -> Vec<RuntimeDir> {
 /// First attempts `waitpid(WNOHANG)` to reap zombie children (the CH process
 /// is our direct child but its `Child` handle was forgotten to avoid pidfd
 /// issues). Without this, zombies appear alive to `kill(pid, 0)`.
-fn is_pid_alive(pid: u32) -> bool {
+pub(crate) fn is_pid_alive(pid: u32) -> bool {
     // SAFETY: waitpid with WNOHANG is non-blocking and only reaps our own children.
     unsafe {
         let mut status: libc::c_int = 0;
@@ -236,7 +236,7 @@ fn is_pid_alive(pid: u32) -> bool {
 
 /// Poll every 200ms until the PID exits or timeout is reached.
 /// Returns `true` if the process exited within the timeout.
-async fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
+pub(crate) async fn wait_for_pid_exit(pid: u32, timeout: Duration) -> bool {
     let poll_interval = Duration::from_millis(200);
     let start = tokio::time::Instant::now();
 
@@ -559,7 +559,7 @@ pub async fn spawn_vm(
 }
 
 /// Inner spawn logic. Separated so the caller can catch errors and clean up.
-async fn spawn_vm_inner(
+pub(crate) async fn spawn_vm_inner(
     vm_id_str: &str,
     ch_binary: &Path,
     runtime_dir: &RuntimeDir,
@@ -713,11 +713,12 @@ async fn spawn_vm_inner(
         reconnect_source: ReconnectSource::FreshSpawn,
         image_name: Some(spec.image.clone()),
         instance_dir_path: None, // Caller (spawn_vm) sets these
+        runtime_handle: None,    // Caller sets from RuntimeHandle
     })
 }
 
 /// Get the Cloud Hypervisor version by running `ch_binary --version`.
-fn get_ch_version(ch_binary: &Path) -> Option<String> {
+pub(crate) fn get_ch_version(ch_binary: &Path) -> Option<String> {
     let output = std::process::Command::new(ch_binary)
         .arg("--version")
         .output()
@@ -728,7 +729,7 @@ fn get_ch_version(ch_binary: &Path) -> Option<String> {
 }
 
 /// Compute a SHA256 hash of the VmSpec JSON for change detection.
-fn compute_spec_hash(spec: &VmSpec) -> String {
+pub(crate) fn compute_spec_hash(spec: &VmSpec) -> String {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 
@@ -1265,6 +1266,7 @@ pub async fn reconnect(base_dir: &Path, event_tx: broadcast::Sender<VmEvent>) ->
             reconnect_source: ReconnectSource::Recovered,
             image_name: meta.image_name.clone(),
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         events::emit(
@@ -1628,6 +1630,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1659,6 +1662,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1690,6 +1694,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1723,6 +1728,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -1932,6 +1938,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));
@@ -2069,6 +2076,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -2120,6 +2128,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -2236,6 +2245,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));

--- a/layers/compute/src/runtime.rs
+++ b/layers/compute/src/runtime.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::phase::VmPhase;
+use crate::runtime_backend::{RuntimeHandle, RuntimeType};
 use crate::types::{VmId, VmStatus};
 
 /// How this VM's runtime state was established.
@@ -43,10 +44,26 @@ pub(crate) struct VmRuntimeState {
     pub(crate) image_name: Option<String>,
     /// Path to the instance directory (for cleanup on delete).
     pub(crate) instance_dir_path: Option<PathBuf>,
+    /// Handle returned by the runtime backend that created this workload.
+    pub(crate) runtime_handle: Option<RuntimeHandle>,
 }
 
 #[allow(dead_code)]
 impl VmRuntimeState {
+    /// Build a `RuntimeHandle` from this state, using the stored handle if
+    /// available, or constructing one from the pid / base_dir.
+    pub(crate) fn to_runtime_handle(&self, base_dir: &std::path::Path) -> RuntimeHandle {
+        if let Some(ref h) = self.runtime_handle {
+            return h.clone();
+        }
+        RuntimeHandle {
+            id: self.vm_id.0.clone(),
+            pid: self.pid,
+            runtime_type: RuntimeType::Vm,
+            runtime_dir: base_dir.join(&self.vm_id.0),
+        }
+    }
+
     /// Produce the public external view of this VM's state.
     ///
     /// This is what forge and the control plane see. Internal details like
@@ -91,6 +108,7 @@ mod tests {
             reconnect_source: ReconnectSource::FreshSpawn,
             image_name: None,
             instance_dir_path: None,
+            runtime_handle: None,
         }
     }
 

--- a/layers/compute/src/runtime_backend.rs
+++ b/layers/compute/src/runtime_backend.rs
@@ -118,6 +118,14 @@ pub trait ComputeRuntime: Send + Sync {
 
     /// Human-readable name for this runtime backend (e.g., "cloud-hypervisor").
     fn name(&self) -> &str;
+
+    /// Return runtime-specific health warnings.
+    ///
+    /// Each runtime checks its own prerequisites (e.g., ChRuntime checks KVM,
+    /// CH binary, and kernel; ContainerRuntime checks crun and runsc).
+    fn health_warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/layers/compute/src/runtime_ch.rs
+++ b/layers/compute/src/runtime_ch.rs
@@ -59,56 +59,244 @@ impl ChRuntime {
     pub fn kernel_path(&self) -> &Path {
         &self.kernel_path
     }
+
+    /// Return runtime-specific health warnings.
+    ///
+    /// Checks for KVM, CH binary, and kernel availability.
+    pub fn health_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if !Path::new("/dev/kvm").exists() {
+            warnings.push("KVM not available — VMs cannot boot".to_string());
+        }
+        if !self.ch_binary.exists() {
+            warnings.push("cloud-hypervisor binary not found".to_string());
+        }
+        if !self.kernel_path.exists() {
+            warnings.push("kernel not found".to_string());
+        }
+        warnings
+    }
 }
 
 #[async_trait]
 impl ComputeRuntime for ChRuntime {
-    async fn create(&self, id: &str, _spec: &RuntimeSpec) -> Result<RuntimeHandle, ComputeError> {
-        // Note: The actual VM creation is still driven by VmManager::create_vm
-        // which calls process::spawn_vm directly, because spawn_vm needs the
-        // full VmSpec, image store, catalog, etc. This method provides the
-        // trait interface for future use when the manager is fully decoupled.
-        //
-        // For now, return the handle shape that would result from a spawn.
-        let runtime_dir = self.base_dir.join(id);
-        let pid_path = runtime_dir.join("pid");
+    async fn create(&self, id: &str, spec: &RuntimeSpec) -> Result<RuntimeHandle, ComputeError> {
+        use crate::config::{map, resolve, validate, ResolvedVolume};
+        use crate::preflight::run_preflight;
+        use crate::types::{VmId, VmSpec};
 
-        // Read PID from the runtime dir if it exists (post-spawn).
-        let pid = if pid_path.exists() {
-            let rd = RuntimeDir::from_existing(runtime_dir.clone());
-            rd.read_pid().unwrap_or(0)
-        } else {
-            0
+        info!(
+            vm_id = %id,
+            runtime = self.name(),
+            "ChRuntime::create: spawning Cloud Hypervisor VM"
+        );
+
+        // Build a VmSpec from RuntimeSpec so we can reuse validate/resolve/map.
+        let vm_spec = VmSpec {
+            id: VmId(id.to_string()),
+            vcpus: spec.vcpus,
+            memory_mb: spec.memory_mb,
+            image: spec.rootfs_path.to_string_lossy().into_owned(),
+            kernel: None,
+            network: spec.network.clone(),
+            volumes: vec![],
+            gpu: spec.gpu.clone(),
+            ssh_key: None,
+            disk_size_mb: None,
         };
 
-        Ok(RuntimeHandle {
-            id: id.to_string(),
-            pid,
-            runtime_type: RuntimeType::Vm,
-            runtime_dir,
-        })
+        // Step 1: validate
+        let validated = validate(&vm_spec).map_err(|errors| {
+            ComputeError::Config(
+                errors
+                    .into_iter()
+                    .next()
+                    .expect("at least one config error"),
+            )
+        })?;
+
+        // Step 2: resolve (use rootfs_path directly)
+        let mut resolved = resolve(
+            &validated,
+            spec.rootfs_path.parent().unwrap_or(Path::new("/")),
+            &self.kernel_path,
+        )
+        .map_err(|errors| {
+            ComputeError::Config(
+                errors
+                    .into_iter()
+                    .next()
+                    .expect("at least one config error"),
+            )
+        })?;
+
+        // Override rootfs path with the one from RuntimeSpec.
+        resolved.rootfs_path = spec.rootfs_path.clone();
+
+        // If cloud-init was generated, add it as a volume.
+        if let Some(ref ci_path) = spec.cloud_init_path {
+            resolved.volume_paths.insert(
+                0,
+                ResolvedVolume {
+                    path: ci_path.clone(),
+                    read_only: true,
+                },
+            );
+        }
+
+        // Step 3: compute socket path for preflight and map
+        let runtime_dir_path = self.base_dir.join(id);
+        let socket_path = runtime_dir_path.join("api.sock");
+
+        // Step 4: map
+        let vm_config = map(&resolved, &socket_path);
+
+        // Step 5: preflight
+        if let Err(e) = run_preflight(&resolved, &self.ch_binary, &socket_path) {
+            return Err(ComputeError::Preflight(
+                e.into_iter().next().expect("at least one preflight error"),
+            ));
+        }
+
+        // Step 6: create RuntimeDir
+        let runtime_dir = RuntimeDir::create(&self.base_dir, id)?;
+
+        // Step 7: spawn inner (from here on, failure must clean up)
+        let result =
+            process::spawn_vm_inner(id, &self.ch_binary, &runtime_dir, &vm_config, &vm_spec).await;
+
+        match result {
+            Ok(state) => {
+                let handle = RuntimeHandle {
+                    id: id.to_string(),
+                    pid: state.pid,
+                    runtime_type: RuntimeType::Vm,
+                    runtime_dir: runtime_dir.path().to_path_buf(),
+                };
+                info!(
+                    vm_id = %id,
+                    pid = state.pid,
+                    "ChRuntime::create: VM started"
+                );
+                Ok(handle)
+            }
+            Err(e) => {
+                let _ = runtime_dir.cleanup();
+                Err(e)
+            }
+        }
     }
 
-    async fn stop(&self, handle: &RuntimeHandle, _force: bool) -> Result<(), ComputeError> {
-        // The actual kill chain is still driven by VmManager via process::kill_vm
-        // because it needs the VmRuntimeState and ChClient. This trait method
-        // provides the interface contract.
-        debug!(
+    async fn stop(&self, handle: &RuntimeHandle, force: bool) -> Result<(), ComputeError> {
+        use crate::client::ChClient;
+
+        info!(
             id = %handle.id,
             runtime = self.name(),
-            "stop requested (delegated to VmManager)"
+            force = force,
+            "ChRuntime::stop: stopping VM"
         );
+
+        let pid = handle.pid;
+        let socket_path = handle.runtime_dir.join("api.sock");
+        let client = ChClient::new(socket_path);
+        let runtime_dir = RuntimeDir::from_existing(handle.runtime_dir.clone());
+
+        // Check if already dead.
+        if !process::is_pid_alive(pid) {
+            debug!(id = %handle.id, "process already dead");
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+
+        // Level 1: graceful shutdown (30s) — skipped when force=true
+        if !force {
+            info!(id = %handle.id, "kill chain level 1: shutdown_graceful");
+            if let Err(e) = client.shutdown_graceful().await {
+                debug!(id = %handle.id, error = %e, "shutdown_graceful failed, continuing");
+            } else if process::wait_for_pid_exit(pid, std::time::Duration::from_secs(30)).await {
+                info!(id = %handle.id, "process exited after graceful shutdown");
+                let _ = runtime_dir.cleanup();
+                return Ok(());
+            }
+        }
+
+        // Level 2: shutdown_force (10s)
+        if !process::is_pid_alive(pid) {
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+        info!(id = %handle.id, "kill chain level 2: shutdown_force");
+        if let Err(e) = client.shutdown_force().await {
+            debug!(id = %handle.id, error = %e, "shutdown_force failed, continuing");
+        } else if process::wait_for_pid_exit(pid, std::time::Duration::from_secs(10)).await {
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+
+        // Level 3: SIGTERM (5s)
+        if !process::is_pid_alive(pid) {
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+        info!(id = %handle.id, "kill chain level 3: SIGTERM");
+        unsafe {
+            libc::kill(pid as i32, libc::SIGTERM);
+        }
+        if process::wait_for_pid_exit(pid, std::time::Duration::from_secs(5)).await {
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+
+        // Level 4: SIGKILL
+        if !process::is_pid_alive(pid) {
+            let _ = runtime_dir.cleanup();
+            return Ok(());
+        }
+        info!(id = %handle.id, "kill chain level 4: SIGKILL");
+        unsafe {
+            libc::kill(pid as i32, libc::SIGKILL);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        if process::is_pid_alive(pid) {
+            return Err(crate::error::ProcessError::SignalFailed {
+                signal: "SIGKILL".to_string(),
+                pid,
+            }
+            .into());
+        }
+
+        let _ = runtime_dir.cleanup();
         Ok(())
     }
 
     async fn delete(&self, handle: &RuntimeHandle) -> Result<(), ComputeError> {
-        // Same delegation pattern as stop — the actual delete uses process::delete_vm
-        // through VmManager which has access to the full runtime state.
+        use crate::client::ChClient;
+
         debug!(
             id = %handle.id,
             runtime = self.name(),
-            "delete requested (delegated to VmManager)"
+            "ChRuntime::delete"
         );
+
+        // Stop the process if it is still alive.
+        if process::is_pid_alive(handle.pid) {
+            self.stop(handle, true).await?;
+        }
+
+        // Best-effort: tell CH to delete (may fail if process is already gone).
+        let socket_path = handle.runtime_dir.join("api.sock");
+        let client = ChClient::new(socket_path);
+        let _ = client.delete().await;
+
+        // Cleanup runtime dir.
+        let runtime_dir = RuntimeDir::from_existing(handle.runtime_dir.clone());
+        if let Err(e) = runtime_dir.cleanup() {
+            debug!(id = %handle.id, error = %e, "runtime dir cleanup failed");
+        }
+
+        info!(id = %handle.id, "ChRuntime::delete: VM deleted and cleaned up");
         Ok(())
     }
 

--- a/layers/compute/src/runtime_container.rs
+++ b/layers/compute/src/runtime_container.rs
@@ -670,6 +670,17 @@ impl ComputeRuntime for ContainerRuntime {
     fn name(&self) -> &str {
         "container (gVisor)"
     }
+
+    fn health_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        if !self.crun_binary.exists() {
+            warnings.push("crun binary not found".to_string());
+        }
+        if !self.runsc_binary.exists() {
+            warnings.push("runsc (gVisor) binary not found".to_string());
+        }
+        warnings
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **VmManager.create_vm** now performs image management (pull, clone, cloud-init) then delegates the actual spawn to `self.runtime.create()` via a `RuntimeSpec`, instead of calling `process::spawn_vm()` directly
- **VmManager.shutdown_vm / shutdown_vm_force** delegate to `self.runtime.stop(&handle, force)` instead of `process::kill_vm()`
- **VmManager.delete_vm** delegates to `self.runtime.delete(&handle)` instead of `process::delete_vm()`
- **ChRuntime** now has real implementations for `create`, `stop`, and `delete` (previously stubs)
- **Health check** is runtime-aware: each runtime reports its own prerequisites (ChRuntime: KVM/CH/kernel; ContainerRuntime: crun/runsc) instead of hardcoded KVM check
- **Status response** includes the active `runtime` name in JSON
- Container runtime is actually used on VPS without KVM

## Test plan

- [x] `cargo build --workspace` — clean, no warnings
- [x] `cargo test -p syfrah-compute` — all 445 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] Verify on a KVM host that VMs still boot via ChRuntime
- [ ] Verify on a VPS without KVM that container mode is selected and works
- [ ] Check `/compute/status` JSON includes `"runtime": "cloud-hypervisor"` or `"container (gVisor)"`

Closes #620