### PR TITLE
fix: container runtime name detection (starts_with)

### DIFF
--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -387,7 +387,7 @@ impl VmManager {
             use crate::image::types::{CloudInitConfig, InstanceId, RuntimeMode};
 
             let store = &self.image_store;
-            let is_container = self.runtime.name() == "container";
+            let is_container = self.runtime.name().starts_with("container");
             let runtime_mode = if is_container {
                 RuntimeMode::Container
             } else {


### PR DESCRIPTION
runtime.name() returns 'container (gVisor)' but code checked == 'container'. One-line fix.