### PR TITLE
fix: delete checks existence first, ISO timestamps, memory cap

### DIFF
--- a/layers/compute/src/cli/image.rs
+++ b/layers/compute/src/cli/image.rs
@@ -253,14 +253,34 @@ async fn run_import(path: PathBuf, name: String, arch: String) -> anyhow::Result
 }
 
 async fn run_delete(name: String, yes: bool) -> anyhow::Result<()> {
+    // Check that the image exists before prompting for confirmation.
+    let inspect_req = ComputeRequest::ImageInspect { name: name.clone() };
+    let inspect_resp = send_compute_request(&control_socket_path(), &inspect_req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
+            )
+        })?;
+
+    match inspect_resp {
+        ComputeResponse::ImageMeta(_) => {} // Image exists, proceed
+        ComputeResponse::Error(msg) => {
+            anyhow::bail!("{msg}");
+        }
+        _ => {
+            anyhow::bail!("unexpected response from daemon");
+        }
+    }
+
     if !yes {
         eprint!("Delete image {name}? This cannot be undone. [y/N] ");
         let mut answer = String::new();
         std::io::stdin().read_line(&mut answer)?;
         let answer = answer.trim();
         if answer != "y" && answer != "Y" {
-            println!("Aborted.");
-            return Ok(());
+            eprintln!("Aborted.");
+            std::process::exit(1);
         }
     }
 

--- a/layers/compute/src/cli/vm.rs
+++ b/layers/compute/src/cli/vm.rs
@@ -370,14 +370,34 @@ async fn run_stop(id: String, force: bool) -> anyhow::Result<()> {
 }
 
 async fn run_delete(id: String, yes: bool) -> anyhow::Result<()> {
+    // Check that the VM exists before prompting for confirmation.
+    let get_req = ComputeRequest::GetVm { id: id.clone() };
+    let get_resp = send_compute_request(&control_socket_path(), &get_req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "failed to connect to daemon: {e}\n\nIs the daemon running? Initialize with: syfrah fabric init --name <mesh-name>"
+            )
+        })?;
+
+    match get_resp {
+        ComputeResponse::Vm(_) => {} // VM exists, proceed
+        ComputeResponse::Error(msg) => {
+            anyhow::bail!("{msg}");
+        }
+        _ => {
+            anyhow::bail!("unexpected response from daemon");
+        }
+    }
+
     if !yes {
         eprint!("Delete VM {id}? This cannot be undone. [y/N] ");
         let mut answer = String::new();
         std::io::stdin().read_line(&mut answer)?;
         let answer = answer.trim();
         if answer != "y" && answer != "Y" {
-            println!("Aborted.");
-            return Ok(());
+            eprintln!("Aborted.");
+            std::process::exit(1);
         }
     }
 

--- a/layers/compute/src/config.rs
+++ b/layers/compute/src/config.rs
@@ -52,6 +52,12 @@ pub fn validate(spec: &VmSpec) -> Result<ValidatedSpec, Vec<ConfigError>> {
             value: spec.memory_mb,
         });
     }
+    // memory: must be <= 1_048_576 MB (1 TB practical cap)
+    if spec.memory_mb > 1_048_576 {
+        errors.push(ConfigError::InvalidMemory {
+            value: spec.memory_mb,
+        });
+    }
     // memory: must be a multiple of 2 (CH alignment requirement for hotplug)
     if spec.memory_mb >= 128 && !spec.memory_mb.is_multiple_of(2) {
         errors.push(ConfigError::InvalidMemory {
@@ -1058,5 +1064,22 @@ mod tests {
         let spec = minimal_spec();
         assert!(validate(&spec).is_ok());
         assert!(spec.disk_size_mb.is_none());
+    }
+
+    #[test]
+    fn validate_memory_1tb_ok() {
+        let mut spec = minimal_spec();
+        spec.memory_mb = 1_048_576; // exactly 1 TB
+        assert!(validate(&spec).is_ok());
+    }
+
+    #[test]
+    fn validate_memory_exceeds_1tb_rejected() {
+        let mut spec = minimal_spec();
+        spec.memory_mb = 1_048_578; // just over 1 TB (and even)
+        let errors = validate(&spec).unwrap_err();
+        assert!(errors
+            .iter()
+            .any(|e| matches!(e, ConfigError::InvalidMemory { .. })));
     }
 }

--- a/layers/compute/src/image/import.rs
+++ b/layers/compute/src/image/import.rs
@@ -93,10 +93,6 @@ fn import_inner(
         .map(|m| m.len() / (1024 * 1024))
         .unwrap_or(0);
 
-    let dur = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-
     let meta = ImageMeta {
         name: name.to_string(),
         arch: arch.to_string(),
@@ -115,7 +111,7 @@ fn import_inner(
         file: format!("{name}.raw"),
         container_file: None,
         container_sha256: None,
-        imported_at: Some(format!("{}Z", dur.as_secs())),
+        imported_at: Some(super::pull::iso8601_now()),
     };
 
     // 8. Update images.json (using metadata read before copy to avoid scan

--- a/layers/compute/src/image/pull.rs
+++ b/layers/compute/src/image/pull.rs
@@ -414,11 +414,35 @@ pub(crate) fn compute_sha256(path: &std::path::Path) -> Result<String, ImageErro
 }
 
 fn chrono_now() -> String {
-    // Simple ISO 8601 timestamp without pulling in chrono
+    iso8601_now()
+}
+
+/// Return the current UTC time as an ISO 8601 string (e.g. `2026-03-29T14:06:26Z`).
+pub(crate) fn iso8601_now() -> String {
     let dur = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
-    format!("{}Z", dur.as_secs())
+    let secs = dur.as_secs();
+
+    let mut days = (secs / 86400) as i64;
+    let day_secs = (secs % 86400) as u32;
+    let hour = day_secs / 3600;
+    let minute = (day_secs % 3600) / 60;
+    let second = day_secs % 60;
+
+    // civil_from_days algorithm (Howard Hinnant)
+    days += 719_468;
+    let era = (if days >= 0 { days } else { days - 146_096 }) / 146_097;
+    let doe = (days - era * 146_097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}T{hour:02}:{minute:02}:{second:02}Z")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **#633**: VM and image `delete` commands now verify the resource exists before showing the confirmation prompt, and abort (`n`) exits with code 1 instead of 0
- **#634**: `imported_at` timestamps now use ISO 8601 format (`2026-03-29T14:06:26Z`) instead of bare epoch seconds
- **#635**: Added memory upper bound validation of 1,048,576 MB (1 TB) to `config::validate()`

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test -p syfrah-compute` — 450 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt` — no changes
- [ ] Manual: `syfrah vm delete nonexistent-vm` should error before prompting
- [ ] Manual: `syfrah vm delete existing-vm` then type `n` — verify exit code is 1
- [ ] Manual: `syfrah image inspect <name>` — verify `imported_at` uses ISO 8601
- [ ] Manual: `syfrah vm create --memory 2000000 ...` — verify rejection

Closes #633
Closes #634
Closes #635