### PR TITLE
fix: container create returns immediately after crun run -d + state

### DIFF
--- a/layers/compute/src/process.rs
+++ b/layers/compute/src/process.rs
@@ -23,6 +23,7 @@ use crate::image::types::{CloudInitConfig, ImageCatalog, ImageMeta, InstanceId, 
 use crate::phase::VmPhase;
 use crate::preflight::run_preflight;
 use crate::runtime::{ReconnectSource, VmRuntimeState};
+use crate::runtime_backend::RuntimeType;
 use crate::types::{VmEvent, VmId, VmSpec};
 
 // ---------------------------------------------------------------------------
@@ -1050,7 +1051,20 @@ pub async fn monitor_loop(
                 continue;
             }
 
-            // PID is alive — try ping on the socket.
+            // Containers have no API socket — PID check is sufficient.
+            let is_container = guard
+                .runtime_handle
+                .as_ref()
+                .map(|h| h.runtime_type == RuntimeType::Container)
+                .unwrap_or(false);
+
+            if is_container {
+                // PID is alive and that is all we can check for containers.
+                guard.last_ping_at = Some(now_unix());
+                continue;
+            }
+
+            // PID is alive — try ping on the CH API socket.
             let client = ChClient::with_timeout(guard.socket_path.clone(), Duration::from_secs(3));
             // Drop the guard before the async ping to avoid holding the lock across await.
             // We re-acquire after the ping completes.


### PR DESCRIPTION
## Summary

- The monitor loop (`monitor_loop` in `process.rs`) was pinging the Cloud Hypervisor API socket (`api.sock`) for **all** workloads, including containers which have no such socket
- This caused containers to be immediately marked as `Failed` by the monitor despite the container process being healthy (PID alive, `crun exec` working)
- Skip the socket ping for `RuntimeType::Container` workloads — PID liveness check is sufficient for container health monitoring

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test -p syfrah-compute` — 12 tests pass
- [x] `cargo clippy -p syfrah-compute` — clean
- [ ] Manual: create a container, verify it stays in Running state (not Failed)
- [ ] Manual: `crun list` shows status=running after create

Closes #654