### PR TITLE
Add missing image field to HTTP VmResponse

### DIFF
--- a/layers/compute/src/handler.rs
+++ b/layers/compute/src/handler.rs
@@ -109,6 +109,8 @@ pub struct VmResponse {
     pub vcpus: u32,
     pub memory_mb: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<u64>,
@@ -144,6 +146,7 @@ fn vm_status_to_response(s: &VmStatus) -> VmResponse {
         phase: format!("{:?}", s.phase),
         vcpus: s.vcpus,
         memory_mb: s.memory_mb,
+        image: s.image.clone(),
         runtime: s.runtime.map(|r| match r {
             crate::runtime_backend::RuntimeType::Vm => "vm".to_string(),
             crate::runtime_backend::RuntimeType::Container => "container".to_string(),
@@ -318,6 +321,7 @@ async fn stop_vm(State(mgr): State<SharedManager>, Path(id): Path<String>) -> im
                     phase: "Stopped".to_string(),
                     vcpus: 0,
                     memory_mb: 0,
+                    image: None,
                     runtime: None,
                     created_at: None,
                     uptime_secs: None,


### PR DESCRIPTION
## Summary
- Add `image: Option<String>` field to `VmResponse` struct in `handler.rs` to match the control socket's `vm_status_to_json()` output
- Populate the field from `VmStatus.image` in `vm_status_to_response()`
- Add `image: None` to the fallback `VmResponse` in `stop_vm`

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p syfrah-compute` passes (478 tests)

Closes #675