### PR TITLE
docs: convert E2E tests to prompt-based .md files

### DIFF
--- a/tests/e2e/scenarios/01_fabric_mesh_formation.md
+++ b/tests/e2e/scenarios/01_fabric_mesh_formation.md
@@ -1,0 +1,54 @@
+# Test: 3 nodes form a WireGuard mesh via CLI
+
+## Objective
+
+- All daemons start successfully
+- Each node sees 2 peers
+- syfrah0 interface exists on all nodes
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 3 nodes see 2 peers each (timeout: 30s).
+
+### 2. Execute the test
+
+- Verify: The syfrah daemon is running
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+- Verify: `syfrah0` interface exists (`ip link show syfrah0`)
+
+## Expected results
+
+- All daemons start successfully
+- Each node sees 2 peers
+- syfrah0 interface exists on all nodes
+
+## Failure criteria
+
+- Any syfrah command returns a non-zero exit code unexpectedly
+- Expected output patterns are missing
+- Timeouts exceeded waiting for convergence

--- a/tests/e2e/scenarios/02_fabric_mesh_connectivity.md
+++ b/tests/e2e/scenarios/02_fabric_mesh_connectivity.md
@@ -1,0 +1,50 @@
+# Test: all nodes can ping each other via the WireGuard mesh
+
+## Objective
+
+- IPv6 mesh connectivity between all pairs of nodes
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 3 nodes see 2 peers each (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- IPv6 mesh connectivity between all pairs of nodes
+
+## Failure criteria
+
+- could not get mesh IPv6 (ipv6_1=<value>, ipv6_2=<value>, ipv6_3=<value>)

--- a/tests/e2e/scenarios/03_fabric_node_leave.md
+++ b/tests/e2e/scenarios/03_fabric_node_leave.md
@@ -1,0 +1,56 @@
+# Test: a node stops its daemon, remaining nodes continue
+
+## Objective
+
+- Node can be stopped cleanly
+- Remaining nodes still have their interface and connectivity
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Stopping node-3 daemon
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: The syfrah daemon is running
+- Verify: `syfrah0` interface exists (`ip link show syfrah0`)
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- Node can be stopped cleanly
+- Remaining nodes still have their interface and connectivity
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-leave-2

--- a/tests/e2e/scenarios/04_fabric_daemon_restart.md
+++ b/tests/e2e/scenarios/04_fabric_daemon_restart.md
@@ -1,0 +1,88 @@
+# Test: a daemon restarts from saved state and reconnects
+
+## Objective
+
+- Daemon can start from saved state
+- Peers are restored after restart
+- Connectivity works after restart
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Killing node-2 daemon process
+
+Wait 2 seconds.
+
+```bash
+pkill -f syfrah
+```
+
+
+### 3. Restarting node-2 daemon
+
+```bash
+rm -f /root/.syfrah/control.sock /root/.syfrah/daemon.pid
+```
+
+```bash
+ip link delete syfrah0
+```
+
+```bash
+ls -la /root/.syfrah/
+```
+
+```bash
+sh -c 'syfrah fabric start > /root/.syfrah/restart.log
+```
+
+
+### 4. restart.log output:
+
+Wait 2 seconds.
+
+```bash
+cat /root/.syfrah/restart.log
+```
+
+```bash
+cat /root/.syfrah/syfrah.log
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: The syfrah daemon is running
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- Daemon can start from saved state
+- Peers are restored after restart
+- Connectivity works after restart
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-restart-1

--- a/tests/e2e/scenarios/05_fabric_large_mesh.md
+++ b/tests/e2e/scenarios/05_fabric_large_mesh.md
@@ -1,0 +1,67 @@
+# Test: 5 nodes form a mesh
+
+## Objective
+
+- All 5 nodes join successfully
+- Each node sees 4 peers
+- End-to-end connectivity (node-1 ↔ node-5)
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 5 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+On node-4:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-4 --endpoint 172.20.0.13:51820
+```
+
+On node-5:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-5 --endpoint 172.20.0.14:51820
+```
+
+Wait until all 5 nodes see 4 peers each (timeout: 45s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- all 5 nodes converged to 4 peers
+
+## Failure criteria
+
+- convergence timed out
+- could not get mesh IPv6 (ipv6_1=<value>, ipv6_5=<value>)

--- a/tests/e2e/scenarios/06_fabric_network_partition.md
+++ b/tests/e2e/scenarios/06_fabric_network_partition.md
@@ -1,0 +1,51 @@
+# Test: Network partition between two nodes, then healing
+
+## Objective
+
+Network partition between two nodes, then healing.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+- Verify: assert_cannot_ping "e2e-part-1" "$ipv6_2"
+
+## Expected results
+
+- e2e-part-1 can ping <value>
+
+## Failure criteria
+
+- could not get mesh IPv6 (ipv6_2=<value>, ipv6_3=<value>)

--- a/tests/e2e/scenarios/07_fabric_concurrent_joins.md
+++ b/tests/e2e/scenarios/07_fabric_concurrent_joins.md
@@ -1,0 +1,53 @@
+# Test: Multiple nodes join simultaneously (race condition test)
+
+## Objective
+
+Multiple nodes join simultaneously (race condition test).
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 5 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Joining 4 nodes rapidly
+
+Wait 1 seconds.
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name "node-N" --endpoint "172.20.0.N:51820" --pin "<PIN>"
+```
+
+
+### 3. Waiting for convergence
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- all 5 nodes converged to 4 peers
+- no duplicate peers in state
+
+## Failure criteria
+
+- convergence timed out
+- <value> duplicate peer(s) found in state

--- a/tests/e2e/scenarios/08_fabric_secret_rotation.md
+++ b/tests/e2e/scenarios/08_fabric_secret_rotation.md
@@ -1,0 +1,76 @@
+# Test: Full secret rotation flow
+
+## Objective
+
+Full secret rotation flow.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric stop
+```
+
+```bash
+pkill -f syfrah
+```
+
+```bash
+syfrah fabric rotate --yes
+```
+
+```bash
+syfrah fabric leave --yes
+```
+
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+
+## Expected results
+
+- secret rotated (different from original)
+- peer list cleared after rotation
+- node-2 has the new secret
+
+## Failure criteria
+
+- secret did not change
+- peer list not cleared (has <value> peers)
+- node-2 has wrong secret

--- a/tests/e2e/scenarios/09_fabric_state_corruption.md
+++ b/tests/e2e/scenarios/09_fabric_state_corruption.md
@@ -1,0 +1,63 @@
+# Test: Corrupted state files — daemon must fail cleanly, not panic
+
+## Objective
+
+Corrupted state files — daemon must fail cleanly, not panic.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Test A: truncated JSON (no redb fallback)
+
+```bash
+sh -c 'rm -f /root/.syfrah/fabric.redb; echo "{\"mesh_na" > /root/.syfrah/state.json'
+```
+
+- Verify: assert_command_fails "e2e-corrupt-1" syfrah fabric start
+
+### 3. Test B: empty file (no redb fallback)
+
+```bash
+sh -c 'rm -f /root/.syfrah/fabric.redb; > /root/.syfrah/state.json'
+```
+
+- Verify: assert_command_fails "e2e-corrupt-1" syfrah fabric start
+
+### 4. Test C: binary garbage (no redb fallback)
+
+```bash
+sh -c 'rm -f /root/.syfrah/fabric.redb; dd if=/dev/urandom of=/root/.syfrah/state.json bs=256 count=1
+```
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+rm -rf /root/.syfrah
+```
+
+- Verify: assert_command_fails "e2e-corrupt-1" syfrah fabric start
+- Verify: The syfrah daemon is running
+
+## Expected results
+
+- All steps complete without errors
+- All verification checks pass
+
+## Failure criteria
+
+- Any syfrah command returns a non-zero exit code unexpectedly
+- Expected output patterns are missing
+- Timeouts exceeded waiting for convergence

--- a/tests/e2e/scenarios/100_ux_flow_reboot.md
+++ b/tests/e2e/scenarios/100_ux_flow_reboot.md
@@ -1,0 +1,66 @@
+# Test: UX Flow — Survive a reboot
+
+## Objective
+
+UX Flow — Survive a reboot.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (reboot-srv-1):
+```bash
+syfrah fabric init --name test-mesh --node-name reboot-srv-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On reboot-srv-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name reboot-srv-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Setting up 2-node mesh
+
+- Verify: `syfrah fabric peers` shows 1 peer(s)
+
+### 3. Step 1: Restarting server 2
+
+Restart the server (simulate a reboot).
+
+
+### 4. Step 5: Server 2 peers after reboot
+
+```bash
+syfrah fabric peers
+```
+
+
+### 5. Step 6: Server 1 peers after server 2 reboot
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: No duplicate entries in `syfrah fabric peers`
+- Verify: No epoch/1970 dates in output
+
+## Expected results
+
+- e2e-flow-reboot-2 daemon socket exists after reboot
+- server-2 sees server-1 after reboot
+- server-1 sees server-2 after reboot
+
+## Failure criteria
+
+- e2e-flow-reboot-2 daemon socket missing after reboot
+- server-2 lost server-1 after reboot
+- server-1 lost server-2 after reboot

--- a/tests/e2e/scenarios/101_ux_flow_scaling.md
+++ b/tests/e2e/scenarios/101_ux_flow_scaling.md
@@ -1,0 +1,51 @@
+# Test: UX Flow — Add 5 nodes
+
+## Objective
+
+UX Flow — Add 5 nodes.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (scale-node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name scale-node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On scale-node-${i}:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name scale-node-${i} --endpoint 172.20.0.$((9 + i)):51820
+```
+
+
+### 2. Server $i: joining mesh
+
+Wait 3 seconds.
+
+
+### 3. Waiting for full convergence
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: No duplicate entries in `syfrah fabric peers`
+- Verify: assert_regions_displayed "$node"
+- Verify: No epoch/1970 dates in output
+- Verify: assert_peer_count "$node" "$EXPECTED_PEERS"
+
+## Expected results
+
+- all <value> nodes converged to <value> peers
+
+## Failure criteria
+
+- convergence timeout

--- a/tests/e2e/scenarios/102_ux_flow_pin_onboarding.md
+++ b/tests/e2e/scenarios/102_ux_flow_pin_onboarding.md
@@ -1,0 +1,65 @@
+# Test: UX Flow — Zero-interaction PIN onboarding
+
+## Objective
+
+UX Flow — Zero-interaction PIN onboarding.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Step 1: Server 1 creates mesh
+
+```bash
+syfrah fabric init --name pin-mesh --node-name pin-srv-1 --endpoint 172.20.0.10:51820
+```
+
+
+### 2. Step 2: Server 1 starts peering with auto PIN
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric peering start --pin "<PIN>"
+```
+
+
+### 3. Step 3: Server 2 joins with PIN (zero interaction)
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name pin-srv-2 --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+- Verify: Output contains `joined\|approved\|accepted`
+
+### 4. Step 4: Verify mesh formed
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: Output contains `pin-srv-2`
+- Verify: Output contains `pin-srv-1`
+- Verify: No duplicate entries in `syfrah fabric peers`
+- Verify: No epoch/1970 dates in output
+
+## Expected results
+
+- PIN join: automatic approval (no interaction)
+- server-1 sees server-2
+- server-2 sees server-1
+
+## Failure criteria
+
+- PIN join: no auto-approval
+- server-1 doesn't see server-2
+- server-2 doesn't see server-1

--- a/tests/e2e/scenarios/103_ux_flow_secret_rotation.md
+++ b/tests/e2e/scenarios/103_ux_flow_secret_rotation.md
@@ -1,0 +1,71 @@
+# Test: UX Flow — Secret rotation
+
+## Objective
+
+UX Flow — Secret rotation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (rot-srv-1):
+```bash
+syfrah fabric init --name test-mesh --node-name rot-srv-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On rot-srv-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name rot-srv-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Setting up 2-node mesh
+
+```bash
+syfrah fabric token
+```
+
+- Verify: `syfrah fabric peers` shows 1 peer(s)
+
+### 3. Step 1: Stop daemon
+
+Wait 2 seconds.
+
+
+### 4. Step 2: Rotate secret
+
+```bash
+syfrah fabric rotate --yes
+```
+
+
+### 5. Step 4: Check new secret
+
+```bash
+syfrah fabric token
+```
+
+- Verify: `syfrah fabric status` does not contain `anyhow`
+- Verify: `syfrah fabric status` does not contain `os error`
+
+## Expected results
+
+- initial secret captured: <value>...
+- rotate: shows confirmation
+- rotate: requires daemon running (clear message)
+- token: shows secret after rotation flow
+
+## Failure criteria
+
+- could not capture initial secret
+- rotate: unclear output
+- token: no secret after rotation

--- a/tests/e2e/scenarios/104_ux_flow_churn.md
+++ b/tests/e2e/scenarios/104_ux_flow_churn.md
@@ -1,0 +1,77 @@
+# Test: UX Flow — Nodes coming and going (churn)
+
+## Objective
+
+UX Flow — Nodes coming and going (churn).
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (churn-srv-1):
+```bash
+syfrah fabric init --name test-mesh --node-name churn-srv-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On churn-srv-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name churn-srv-2 --endpoint 172.20.0.11:51820
+```
+
+On churn-srv-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name churn-srv-3 --endpoint 172.20.0.12:51820
+```
+
+On churn-srv-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name churn-srv-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 3 nodes see 2 peers each (timeout: 60s).
+
+### 2. Setting up 3-node mesh
+
+Wait 3 seconds.
+
+
+### 3. Verifying initial mesh
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+### 4. Final validation
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: No epoch/1970 dates in output
+
+## Expected results
+
+- initial 3-node mesh converged
+- round <value>: node 3 sees <value> active peer(s)
+- <value> sees <value> active peers (>= 2)
+
+## Failure criteria
+
+- initial convergence failed
+- round <value>: node 3 has no active peers
+- <value> sees <value> active peers (expected >= 2)

--- a/tests/e2e/scenarios/105_ux_errors_init.md
+++ b/tests/e2e/scenarios/105_ux_errors_init.md
@@ -1,0 +1,38 @@
+# Test: UX Errors — init error messages
+
+## Objective
+
+UX Errors — init error messages.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name err-node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Testing: init when mesh already exists
+
+```bash
+syfrah fabric init --name another-mesh --node-name err-node-2 --endpoint 172.20.0.10:51820
+```
+
+
+## Expected results
+
+- double init: says already exists
+- double init: suggests 'syfrah fabric leave'
+- double init: no raw errors
+
+## Failure criteria
+
+- double init: unclear message
+- double init: doesn't suggest leave command
+- double init: contains raw error

--- a/tests/e2e/scenarios/106_ux_errors_join.md
+++ b/tests/e2e/scenarios/106_ux_errors_join.md
@@ -1,0 +1,78 @@
+# Test: UX Errors — join error messages
+
+## Objective
+
+UX Errors — join error messages.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (err-join-srv-1):
+```bash
+syfrah fabric init --name test-mesh --node-name err-join-srv-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On err-join-srv-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name err-join-srv-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Testing: join to unreachable IP
+
+```bash
+syfrah fabric join 172.20.0.99:51821 --node-name err-join-2 --endpoint 172.20.0.11:51820 --pin 1234
+```
+
+
+### 3. Testing: join when peering not active
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name err-join-2 --endpoint 172.20.0.11:51820 --pin 1234
+```
+
+
+### 4. Testing: join when state exists
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name err-join-2b --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+
+### 5. Testing: join no arguments
+
+```bash
+syfrah fabric join
+```
+
+
+### 6. Testing: join retry after failure
+
+- Verify: assert_join_retry_works "e2e-err-join-3" "172.20.0.10:51821" "172.20.0.12" "err-join-3"
+
+## Expected results
+
+- join unreachable: no raw OS error
+- join no peering: no raw error
+- join with state: mentions existing state
+- join with state: suggests full command path
+- join with state: mentions leave
+- join no args: shows usage
+
+## Failure criteria
+
+- join unreachable: raw OS error visible
+- join no peering: raw 'early eof' visible
+- join with state: unclear
+- join with state: no leave suggestion
+- join no args: no usage info

--- a/tests/e2e/scenarios/107_ux_errors_lifecycle.md
+++ b/tests/e2e/scenarios/107_ux_errors_lifecycle.md
@@ -1,0 +1,94 @@
+# Test: UX Errors — lifecycle command error messages
+
+## Objective
+
+UX Errors — lifecycle command error messages.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name life-node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Testing: stop when not running
+
+```bash
+syfrah fabric stop
+```
+
+
+### 3. Testing: start without init
+
+```bash
+syfrah fabric start
+```
+
+
+### 4. Testing: leave without mesh
+
+```bash
+syfrah fabric leave --yes
+```
+
+
+### 5. Testing: double leave
+
+```bash
+syfrah fabric leave --yes
+```
+
+
+### 6. Testing: peers without mesh
+
+```bash
+syfrah fabric peers
+```
+
+
+### 7. Testing: status without mesh
+
+```bash
+syfrah fabric status
+```
+
+
+### 8. Testing: leave then join cycle
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+syfrah fabric init --name re-mesh --node-name life-node-1 --endpoint 172.20.0.10:51820
+```
+
+
+## Expected results
+
+- stop not running: helpful message
+- start without init: suggests init/join
+- leave no mesh: says nothing to do
+- double leave: says nothing to do
+- peers no mesh: suggests init/join
+- status no mesh: suggests init/join
+- leave then init: works first try
+
+## Failure criteria
+
+- stop not running: unclear
+- start without init: unclear
+- leave no mesh: unclear
+- double leave: unclear
+- peers no mesh: unclear
+- status no mesh: unclear
+- leave then init: failed

--- a/tests/e2e/scenarios/108_ux_errors_commands.md
+++ b/tests/e2e/scenarios/108_ux_errors_commands.md
@@ -1,0 +1,59 @@
+# Test: UX Errors — wrong command paths and suggestions
+
+## Objective
+
+UX Errors — wrong command paths and suggestions.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name cmd-node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Testing: syfrah without subcommand
+
+```bash
+syfrah
+```
+
+
+### 3. Testing: syfrah with wrong subcommand
+
+```bash
+syfrah peering
+```
+
+```bash
+syfrah init
+```
+
+```bash
+syfrah join
+```
+
+
+### 4. Testing: suggested commands in error output are valid
+
+- Verify: `syfrah fabric status` runs without errors
+
+## Expected results
+
+- syfrah bare: shows help/commands
+- syfrah peering: shows help or error
+- syfrah init: shows help or error
+- syfrah join: shows help or error
+
+## Failure criteria
+
+- syfrah bare: no help
+- syfrah peering: no guidance
+- syfrah init: no guidance
+- syfrah join: no guidance

--- a/tests/e2e/scenarios/109_ux_errors_no_raw_errors.md
+++ b/tests/e2e/scenarios/109_ux_errors_no_raw_errors.md
@@ -1,0 +1,61 @@
+# Test: UX Errors — no raw Rust errors in any output
+
+## Objective
+
+UX Errors — no raw Rust errors in any output.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name raw-node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Testing: commands with no mesh
+
+```bash
+"syfrah fabric peers" "syfrah fabric status" "syfrah fabric stop" "syfrah fabric start" "syfrah fabric leave" "syfrah fabric token" "syfrah --help" "syfrah fabric --help"; do
+```
+
+
+### 3. Testing: commands with running mesh
+
+```bash
+"syfrah fabric peers" "syfrah fabric status" "syfrah fabric token"; do
+```
+
+
+### 4. Testing: join to bad target
+
+```bash
+sh -c "syfrah fabric join 10.99.99.99:51821 --node-name test --endpoint 172.20.0.10:51820"
+```
+
+
+### 5. Testing: double init
+
+```bash
+sh -c "syfrah fabric init --name test2 --node-name n2 --endpoint 172.20.0.10:51820"
+```
+
+
+## Expected results
+
+- <value> (no mesh): clean output
+- <value> (running): clean output
+- join bad target: clean output
+- double init: clean output
+
+## Failure criteria
+
+- <value> (no mesh): contains raw error
+- <value> (running): contains raw error
+- join bad target: contains raw error
+- double init: contains raw error

--- a/tests/e2e/scenarios/10_fabric_stale_pid.md
+++ b/tests/e2e/scenarios/10_fabric_stale_pid.md
@@ -1,0 +1,86 @@
+# Test: SIGKILL leaves stale PID file — restart must recover
+
+## Objective
+
+SIGKILL leaves stale PID file — restart must recover.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until all 2 nodes see 1 peers each (timeout: 30s).
+
+### 2. Killing node-1 daemon with SIGKILL
+
+Wait 2 seconds.
+
+```bash
+pkill -9 -f syfrah
+```
+
+- Verify: assert_state_exists "e2e-pid-1"
+
+### 3. Restarting from saved state
+
+```bash
+rm -f /root/.syfrah/control.sock
+```
+
+```bash
+ip link delete syfrah0
+```
+
+```bash
+ls -la /root/.syfrah/
+```
+
+```bash
+sh -c 'syfrah fabric start > /root/.syfrah/restart.log
+```
+
+
+### 4. restart.log output:
+
+```bash
+cat /root/.syfrah/restart.log
+```
+
+```bash
+cat /root/.syfrah/syfrah.log
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: The syfrah daemon is running
+- Verify: `syfrah0` interface exists (`ip link show syfrah0`)
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- stale PID file exists after SIGKILL
+- PID file already cleaned (acceptable)
+
+## Failure criteria
+
+- e2e-pid-1 did not see 1 peer within 30s
+- could not get mesh IPv6 for e2e-pid-2

--- a/tests/e2e/scenarios/11_fabric_rejoin_new_key.md
+++ b/tests/e2e/scenarios/11_fabric_rejoin_new_key.md
@@ -1,0 +1,65 @@
+# Test: Node leaves and rejoins — gets new WG keypair
+
+## Objective
+
+Node leaves and rejoins — gets new WG keypair.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+pkill -f syfrah
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- node-3 has new WG key after rejoin
+
+## Failure criteria
+
+- node-3 WG key unchanged after rejoin
+- could not get mesh IPv6 (ipv6_1=<value>, ipv6_3=<value>)

--- a/tests/e2e/scenarios/12_fabric_convergence_time.md
+++ b/tests/e2e/scenarios/12_fabric_convergence_time.md
@@ -1,0 +1,51 @@
+# Test: 10-node mesh convergence time measurement
+
+## Objective
+
+10-node mesh convergence time measurement.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-$i:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-$i --endpoint 172.20.0.N:51820
+```
+
+Wait until all 10 nodes see 9 peers each (timeout: 60s).
+
+### 2. Waiting for full convergence
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- 10 nodes converged in <value>s
+- convergence time under 45s threshold
+
+## Failure criteria
+
+- convergence took <value>s (threshold: 45s)
+- mesh did not converge within 60s
+- could not get mesh IPv6 for e2e-conv-10

--- a/tests/e2e/scenarios/13_fabric_tunnel_throughput.md
+++ b/tests/e2e/scenarios/13_fabric_tunnel_throughput.md
@@ -1,0 +1,45 @@
+# Test: Measure WireGuard tunnel throughput between two nodes
+
+## Objective
+
+Measure WireGuard tunnel throughput between two nodes.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Starting receiver on node-2
+
+Wait 2 seconds.
+
+
+## Expected results
+
+- 20MB transfer completed in <value>s (>= 2 MB/s)
+- average RTT: <value>ms
+- ping completed (could not parse RTT)
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-tp-2
+- 20MB transfer took <value>s (too slow)

--- a/tests/e2e/scenarios/14_fabric_rapid_scale_down.md
+++ b/tests/e2e/scenarios/14_fabric_rapid_scale_down.md
@@ -1,0 +1,55 @@
+# Test: Kill half the nodes abruptly, remaining nodes survive
+
+## Objective
+
+Kill half the nodes abruptly, remaining nodes survive.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-$i:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-$i --endpoint 172.20.0.N:51820
+```
+
+Wait until each node sees 5 active peer(s) (timeout: 30s).
+
+### 2. Killing nodes 4, 5, 6
+
+Wait 5 seconds.
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: The syfrah daemon is running
+- Verify: Ping the peer mesh IPv6 address successfully
+- Verify: assert_state_exists "e2e-down-1"
+- Verify: assert_state_exists "e2e-down-2"
+- Verify: assert_state_exists "e2e-down-3"
+
+## Expected results
+
+- All steps complete without errors
+- All verification checks pass
+
+## Failure criteria
+
+- could not get mesh IPv6 (ipv6_2=<value>, ipv6_3=<value>)

--- a/tests/e2e/scenarios/15_fabric_two_meshes.md
+++ b/tests/e2e/scenarios/15_fabric_two_meshes.md
@@ -1,0 +1,51 @@
+# Test: Two independent meshes on the same network
+
+## Objective
+
+Two independent meshes on the same network.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 4 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name alpha-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric peering start --pin "2222"
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: `syfrah fabric peers` shows 1 peer(s)
+- Verify: Ping the peer mesh IPv6 address successfully
+- Verify: assert_cannot_ping "e2e-alpha-1" "$beta2_ipv6"
+
+## Expected results
+
+- meshes have different secrets
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-alpha-2
+- could not get mesh IPv6 for e2e-beta-2
+- meshes have same secret (should be impossible)

--- a/tests/e2e/scenarios/16_fabric_stress_max_nodes.md
+++ b/tests/e2e/scenarios/16_fabric_stress_max_nodes.md
@@ -1,0 +1,69 @@
+# Test: Stress test: maximum node count on a 2-vCPU runner
+
+## Objective
+
+Stress test: maximum node count on a 2-vCPU runner.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-$i:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-$i --endpoint 172.20.0.N:51820
+```
+
+
+### 2. Joining $EXPECTED nodes
+
+Wait 1 seconds.
+
+
+### 3. Waiting for full convergence ($NODE_COUNT nodes, $EXPECTED peers each)
+
+```bash
+syfrah fabric peers
+```
+
+
+### 4. Checking leader memory
+
+```bash
+bash -c 'cat /proc/$(cat /root/.syfrah/daemon.pid)/status
+```
+
+```bash
+wc -c /root/.syfrah/state.json
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- <value> nodes converged in <value>s
+- leader RSS: <value>MB (under 100MB)
+- could not measure RSS (daemon may have exited)
+- state.json size: <value> bytes (under 50KB)
+
+## Failure criteria
+
+- mesh did not fully converge in 180s
+- leader RSS: <value>MB (over 100MB)
+- state.json size: <value> bytes (over 50KB)
+- could not get mesh IPv6 for e2e-max-<value>

--- a/tests/e2e/scenarios/17_fabric_stress_sustained_throughput.md
+++ b/tests/e2e/scenarios/17_fabric_stress_sustained_throughput.md
@@ -1,0 +1,51 @@
+# Test: Stress test: large data transfer via WireGuard tunnel
+
+## Objective
+
+Stress test: large data transfer via WireGuard tunnel.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+- Verify: The syfrah daemon is running
+
+## Expected results
+
+- 100MB transfer completed in <value>s
+- receiver got all 100MB (<value> bytes)
+- 10 rapid transfers all succeeded
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-stp-2
+- 100MB transfer took <value>s (too slow)
+- receiver got <value> bytes (expected <value>)
+- <value>/10 rapid transfers failed

--- a/tests/e2e/scenarios/18_fabric_stress_join_storm.md
+++ b/tests/e2e/scenarios/18_fabric_stress_join_storm.md
@@ -1,0 +1,60 @@
+# Test: Stress test: 10 nodes join in 10 seconds, measure leader CPU/RAM
+
+## Objective
+
+Stress test: 10 nodes join in 10 seconds, measure leader CPU/RAM.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Joining 9 nodes in rapid succession
+
+Wait 1 seconds.
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name "node-N" --endpoint "172.20.0.N:51820" --pin "<PIN>"
+```
+
+
+### 3. Waiting for convergence
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: The syfrah daemon is running
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- join storm: <value> nodes converged in <value>s
+- leader RSS after storm: <value>MB
+- could not measure RSS
+
+## Failure criteria
+
+- join storm: mesh did not converge in 60s
+- leader RSS after storm: <value>MB (high)
+- could not get mesh IPv6 for e2e-storm-<value>

--- a/tests/e2e/scenarios/19_fabric_stress_churn.md
+++ b/tests/e2e/scenarios/19_fabric_stress_churn.md
@@ -1,0 +1,93 @@
+# Test: Stress test: nodes repeatedly join and leave for 90 seconds
+
+## Objective
+
+Stress test: nodes repeatedly join and leave for 90 seconds.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 20s).
+
+### 2. Running $CYCLES join/leave cycles
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name "churn-2-c$cycle" --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name "churn-3-c$cycle" --endpoint 172.20.0.12:51820 --pin "<PIN>"
+```
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+pkill -f syfrah
+```
+
+```bash
+syfrah fabric leave --yes
+```
+
+```bash
+pkill -f syfrah
+```
+
+```bash
+rm -rf /root/.syfrah
+```
+
+```bash
+rm -rf /root/.syfrah
+```
+
+
+### 3. Final join after churn
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name "churn-2-final" --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+pgrep -c -f syfrah
+```
+
+- Verify: The syfrah daemon is running
+- Verify: `syfrah0` interface exists (`ip link show syfrah0`)
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- no zombie processes on churn node (<value> syfrah processes)
+- stable node state.json is valid JSON
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-churn-2
+- <value> syfrah processes on churn node (expected <= 1)
+- stable node state.json is invalid

--- a/tests/e2e/scenarios/20_fabric_stress_announcement_flood.md
+++ b/tests/e2e/scenarios/20_fabric_stress_announcement_flood.md
@@ -1,0 +1,68 @@
+# Test: Stress test: 12-node mesh, verify O(N²) announcements converge
+
+## Objective
+
+Stress test: 12-node mesh, verify O(N²) announcements converge.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-$i:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-$i --endpoint 172.20.0.N:51820
+```
+
+
+### 2. Joining $EXPECTED nodes sequentially
+
+Wait 1 seconds.
+
+
+### 3. Waiting for announcement flood to settle (N*(N-1)/2 = $((NODE_COUNT * EXPECTED / 2)) announcements)
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- all <value> nodes converged in <value>s after joins
+- all nodes see <value> peers
+
+## Failure criteria
+
+- did not converge in 90s
+- some nodes have incomplete peer views
+- could not get mesh IPv6 (ipv6_first=<value>, ipv6_last=<value>)
+- could not get mesh IPv6 for mid-mesh check

--- a/tests/e2e/scenarios/25_fabric_reconciliation.md
+++ b/tests/e2e/scenarios/25_fabric_reconciliation.md
@@ -1,0 +1,45 @@
+# Test: reconciliation loop re-adds peers after WireGuard reset
+
+## Objective
+
+reconciliation loop re-adds peers after WireGuard reset.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Waiting for reconciliation loop (polling up to 60s)
+
+Wait 5 seconds.
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- ping fails after WG peer removal (expected)
+- ping still works (WG may have re-added via reconcile already)
+- e2e-recon-1 can ping <value>
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-recon-2

--- a/tests/e2e/scenarios/26_fabric_peer_recovery.md
+++ b/tests/e2e/scenarios/26_fabric_peer_recovery.md
@@ -1,0 +1,49 @@
+# Test: unreachable peer recovers automatically when connectivity returns
+
+## Objective
+
+unreachable peer recovers automatically when connectivity returns.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Waiting for keepalive + health check recovery (polling up to 90s)
+
+Wait 5 seconds.
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- e2e-recov-1 can ping <value>
+- peer still in list after recovery
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-recov-2
+- peer missing from list

--- a/tests/e2e/scenarios/27_fabric_last_seen_update.md
+++ b/tests/e2e/scenarios/27_fabric_last_seen_update.md
@@ -1,0 +1,57 @@
+# Test: last_seen timestamp updates from WireGuard handshakes
+
+## Objective
+
+last_seen timestamp updates from WireGuard handshakes.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Waiting for health check to update last_seen (polling up to 90s)
+
+Wait 5 seconds.
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- peer has a WireGuard handshake timestamp
+- peer has handshake after ping
+- peer still active after health check (last_seen updated)
+- handshake is recent (seconds ago)
+- handshake present
+
+## Failure criteria
+
+- could not get mesh IPv6 for e2e-seen-2
+- no handshake detected
+- peer not active — last_seen may not have been updated
+- could not extract handshake text from peers output

--- a/tests/e2e/scenarios/28_fabric_zones_default.md
+++ b/tests/e2e/scenarios/28_fabric_zones_default.md
@@ -1,0 +1,59 @@
+# Test: default region/zone auto-generation
+
+## Objective
+
+default region/zone auto-generation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- node-1 has default region: default
+- node-1 has default zone: zone-1
+- peers output shows REGION column
+- peers output shows ZONE column
+
+## Failure criteria
+
+- node-1 missing default region
+- node-1 missing default zone
+- peers output missing REGION column
+- peers output missing ZONE column

--- a/tests/e2e/scenarios/29_fabric_zones_auto_increment.md
+++ b/tests/e2e/scenarios/29_fabric_zones_auto_increment.md
@@ -1,0 +1,85 @@
+# Test: zone auto-increments as nodes join
+
+## Objective
+
+zone auto-increments as nodes join.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until each node sees 2 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+cat /root/.syfrah/state.json
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- all 3 nodes have unique zones
+- all 3 nodes share the same region
+
+## Failure criteria
+
+- could not extract zone for one or more nodes (z1=<value>, z2=<value>, z3=<value>)
+- zone collision: <value>, <value>, <value>
+- could not extract region for one or more nodes (r1=<value>, r2=<value>, r3=<value>)
+- regions differ: <value>, <value>, <value>

--- a/tests/e2e/scenarios/30_fabric_zones_manual_override.md
+++ b/tests/e2e/scenarios/30_fabric_zones_manual_override.md
@@ -1,0 +1,39 @@
+# Test: manual --region and --zone override the defaults
+
+## Objective
+
+manual --region and --zone override the defaults.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- node-1 has manual region: eu-west
+- node-1 has manual zone: eu-west-paris-1
+- node-2 has manual region: eu-central
+- node-2 has manual zone: eu-central-frankfurt-1
+
+## Failure criteria
+
+- node-1 region override failed
+- node-1 zone override failed
+- node-2 region override failed
+- node-2 zone override failed

--- a/tests/e2e/scenarios/31_fabric_zones_mixed.md
+++ b/tests/e2e/scenarios/31_fabric_zones_mixed.md
@@ -1,0 +1,52 @@
+# Test: mix of auto and manual zones in the same mesh
+
+## Objective
+
+mix of auto and manual zones in the same mesh.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region custom-dc --zone custom-dc-rack1
+syfrah fabric start
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 3 nodes see 2 peers each (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- node-2 custom region preserved in mesh
+
+## Failure criteria
+
+- could not extract region for e2e-zmix-2
+- node-2 region: <value> (expected custom-dc)
+- could not get mesh IPv6 for e2e-zmix-2

--- a/tests/e2e/scenarios/32_fabric_zones_persist.md
+++ b/tests/e2e/scenarios/32_fabric_zones_persist.md
@@ -1,0 +1,40 @@
+# Test: region/zone survives daemon restart
+
+## Objective
+
+region/zone survives daemon restart.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric status
+```
+
+```bash
+pkill -f syfrah
+```
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- zone set before restart
+- zone preserved after restart
+
+## Failure criteria
+
+- could not extract zone before restart
+- zone before restart
+- could not extract zone after restart
+- zone after restart: <value> (expected my-region-zone-42)

--- a/tests/e2e/scenarios/33_fabric_zones_peers_display.md
+++ b/tests/e2e/scenarios/33_fabric_zones_peers_display.md
@@ -1,0 +1,53 @@
+# Test: syfrah fabric peers displays region/zone columns
+
+## Objective
+
+syfrah fabric peers displays region/zone columns.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+# Scenario: syfrah fabric peers displays region/zone columns
+```
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- peers output shows REGION column header
+- peers output shows ZONE column header
+- leader sees joiner's region (default)
+- leader sees joiner's zone
+- node-1 status shows its own region eu-west
+- joiner sees leader's region (eu-west)
+- joiner sees leader's zone (ew-zone-1)
+
+## Failure criteria
+
+- peers output missing REGION column header
+- peers output missing ZONE column header
+- leader does not see joiner's region
+- leader does not see joiner's zone
+- node-1 status missing region
+- joiner does not see leader's region
+- joiner does not see leader's zone

--- a/tests/e2e/scenarios/34_fabric_zones_5_nodes.md
+++ b/tests/e2e/scenarios/34_fabric_zones_5_nodes.md
@@ -1,0 +1,54 @@
+# Test: 5 nodes with default zones — all unique
+
+## Objective
+
+5 nodes with default zones — all unique.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-$i:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-$i --endpoint 172.20.0.N:51820
+```
+
+Wait until each node sees 4 active peer(s) (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status
+```
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- all 5 zones are unique
+- node-<value> region: default
+
+## Failure criteria
+
+- only <value> unique zones out of 5
+- node-<value>: could not extract region
+- node-<value> region: <value> (expected default)

--- a/tests/e2e/scenarios/35_fabric_zones_status_display.md
+++ b/tests/e2e/scenarios/35_fabric_zones_status_display.md
@@ -1,0 +1,42 @@
+# Test: syfrah fabric status shows region and zone
+
+## Objective
+
+syfrah fabric status shows region and zone.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Execute the test
+
+```bash
+# Scenario: syfrah fabric status shows region and zone
+```
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- status shows Region field
+- status shows zone field
+- default region is default
+
+## Failure criteria
+
+- status missing Region field
+- status missing zone field
+- unexpected default region

--- a/tests/e2e/scenarios/36_fabric_zones_propagation.md
+++ b/tests/e2e/scenarios/36_fabric_zones_propagation.md
@@ -1,0 +1,33 @@
+# Test: region/zone propagates to other nodes via peer announcements
+
+## Objective
+
+region/zone propagates to other nodes via peer announcements.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+
+## Expected results
+
+- node-3 sees node-1's region (dc-paris) via announcement
+- region propagation test (field present in protocol)
+
+## Failure criteria
+
+- Any syfrah command returns a non-zero exit code unexpectedly
+- Expected output patterns are missing
+- Timeouts exceeded waiting for convergence

--- a/tests/e2e/scenarios/37_fabric_zones_help.md
+++ b/tests/e2e/scenarios/37_fabric_zones_help.md
@@ -1,0 +1,27 @@
+# Test: --region and --zone flags appear in CLI help
+
+## Objective
+
+--region and --zone flags appear in CLI help.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+## Expected results
+
+- init --help shows --region flag
+- init --help shows --zone flag
+- join --help shows --region flag
+- join --help shows --zone flag
+
+## Failure criteria
+
+- init --help missing --region
+- init --help missing --zone
+- join --help missing --region
+- join --help missing --zone

--- a/tests/e2e/scenarios/38_fabric_concurrent_joins_stress.md
+++ b/tests/e2e/scenarios/38_fabric_concurrent_joins_stress.md
@@ -1,0 +1,56 @@
+# Test: Stress test for concurrent joins — zero delay, 10 nodes
+
+## Objective
+
+Stress test for concurrent joins — zero delay, 10 nodes.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.11:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 60s).
+
+### 2. Joining 9 nodes rapidly
+
+Wait 1 seconds.
+
+```bash
+syfrah fabric join 172.20.0.11:51821 --node-name "node-N" --endpoint "172.20.0.N:51820" --pin "<PIN>"
+```
+
+
+### 3. Waiting for full convergence
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+cat /root/.syfrah/state.json
+```
+
+
+## Expected results
+
+- all 10 nodes converged to 9 peers
+- e2e-stress-join-<value>: no duplicate peers
+
+## Failure criteria
+
+- convergence timed out
+- e2e-stress-join-<value>: <value> duplicate peer(s)

--- a/tests/e2e/scenarios/39_fabric_redb_json_consistency.md
+++ b/tests/e2e/scenarios/39_fabric_redb_json_consistency.md
@@ -1,0 +1,52 @@
+# Test: redb/JSON consistency after concurrent joins
+
+## Objective
+
+redb/JSON consistency after concurrent joins.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah state get fabric peers
+```
+
+```bash
+json_count=$(cat /root/.syfrah/state.json
+```
+
+```bash
+if cat /root/.syfrah/state.json
+```
+
+
+## Expected results
+
+- redb (<value>) and JSON (<value>) peer counts match
+- state.json is valid JSON
+
+## Failure criteria
+
+- redb (<value>) and JSON (<value>) peer counts diverge
+- state.json is invalid JSON

--- a/tests/e2e/scenarios/40_fabric_announcement_retry.md
+++ b/tests/e2e/scenarios/40_fabric_announcement_retry.md
@@ -1,0 +1,60 @@
+# Test: Announcement retry after temporary network failure
+
+## Objective
+
+Announcement retry after temporary network failure.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 2 nodes see 1 peers each (timeout: 30s).
+
+### 2. Joining node-3 while node-2 is blocked
+
+Wait 2 seconds.
+
+
+### 3. Waiting for node-2 to discover node-3
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+
+## Expected results
+
+- all nodes converged after announcement retry
+
+## Failure criteria
+
+- initial 2-node mesh did not converge
+- convergence timed out

--- a/tests/e2e/scenarios/41_fabric_announcement_all_fail.md
+++ b/tests/e2e/scenarios/41_fabric_announcement_all_fail.md
@@ -1,0 +1,50 @@
+# Test: All announcements fail — mesh must still converge via reconciliation
+
+## Objective
+
+All announcements fail — mesh must still converge via reconciliation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+On node-3:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-3 --endpoint 172.20.0.12:51820
+```
+
+Wait until all 3 nodes see 2 peers each (timeout: 90s).
+
+### 2. Waiting for reconciliation-based convergence (up to 90s)
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: `syfrah fabric peers` shows 2 peer(s)
+
+## Expected results
+
+- all nodes converged
+
+## Failure criteria
+
+- convergence timed out

--- a/tests/e2e/scenarios/42_fabric_custom_intervals.md
+++ b/tests/e2e/scenarios/42_fabric_custom_intervals.md
@@ -1,0 +1,51 @@
+# Test: Daemon uses custom intervals from config.toml
+
+## Objective
+
+Daemon uses custom intervals from config.toml.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until all 2 nodes see 1 peers each (timeout: 30s).
+
+### 2. Waiting 45s for fast unreachable detection (20s timeout + 10s check + margin)
+
+Wait 45 seconds.
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- status shows custom health_check_interval
+- status shows custom unreachable_timeout
+- node-2 marked unreachable with fast config
+
+## Failure criteria
+
+- initial mesh did not converge
+- status does not show custom health_check_interval
+- status does not show custom unreachable_timeout
+- node-2 not yet unreachable after 45s

--- a/tests/e2e/scenarios/43_fabric_reconcile_logging.md
+++ b/tests/e2e/scenarios/43_fabric_reconcile_logging.md
@@ -1,0 +1,49 @@
+# Test: Reconciliation recovers after WG interface is removed
+
+## Objective
+
+Reconciliation recovers after WG interface is removed.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+
+### 2. Execute the test
+
+```bash
+mkdir -p /root/.syfrah
+```
+
+```bash
+sh -c 'cat > /root/.syfrah/config.toml << EOF
+```
+
+
+- Verify: `syfrah fabric peers` shows 1 peer(s)
+
+## Expected results
+
+- daemon still running after WG interface removal
+
+## Failure criteria
+
+- daemon crashed after WG interface removal

--- a/tests/e2e/scenarios/47_fabric_error_messages.md
+++ b/tests/e2e/scenarios/47_fabric_error_messages.md
@@ -1,0 +1,43 @@
+# Test: CLI error messages are actionable
+
+## Objective
+
+CLI error messages are actionable.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+### 2. Testing: start without init
+
+```bash
+syfrah fabric start
+```
+
+
+### 3. Testing: double init
+
+```bash
+syfrah fabric init --name test2 --node-name node-2 --endpoint 172.20.0.10:51820
+```
+
+
+## Expected results
+
+- start without init suggests init/join
+- double init suggests leave
+
+## Failure criteria
+
+- start without init: unhelpful message
+- double init: unhelpful message

--- a/tests/e2e/scenarios/50_fabric_topology_basic.md
+++ b/tests/e2e/scenarios/50_fabric_topology_basic.md
@@ -1,0 +1,43 @@
+# Test: topology command shows tree after 3-node setup
+
+## Objective
+
+topology command shows tree after 3-node setup.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric topology
+```
+
+
+## Expected results
+
+- topology shows mesh name
+- topology shows region eu-west
+- topology shows zone eu-west-1a
+- topology shows node-1
+- topology shows node-2
+- topology shows node-3
+- topology header shows 3 nodes
+- topology shows default region for joiners
+
+## Failure criteria
+
+- topology missing mesh name
+- topology missing region eu-west
+- topology missing zone eu-west-1a
+- topology missing node-1
+- topology missing node-2
+- topology missing node-3
+- topology header missing node count
+- topology missing default region

--- a/tests/e2e/scenarios/51_fabric_topology_multi_region.md
+++ b/tests/e2e/scenarios/51_fabric_topology_multi_region.md
@@ -1,0 +1,47 @@
+# Test: 2 regions, cross-region peering + topology display
+
+## Objective
+
+2 regions, cross-region peering + topology display.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric topology
+```
+
+```bash
+syfrah fabric topology
+```
+
+
+## Expected results
+
+- topology shows eu-west region
+- topology shows us-east region
+- topology header shows 2 regions
+- topology shows zone eu-west-1a
+- topology shows zone eu-west-1b
+- topology shows zone us-east-1a
+- eu-west leader sees us-east peer in topology
+- us-east node sees eu-west in topology
+
+## Failure criteria
+
+- topology missing eu-west
+- topology missing us-east
+- topology header missing region count
+- topology missing zone eu-west-1a
+- topology missing zone eu-west-1b
+- topology missing zone us-east-1a
+- cross-region peer missing from topology
+- us-east node missing eu-west in topology

--- a/tests/e2e/scenarios/52_fabric_topology_filter.md
+++ b/tests/e2e/scenarios/52_fabric_topology_filter.md
@@ -1,0 +1,54 @@
+# Test: --region and --zone filters on topology command
+
+## Objective
+
+--region and --zone filters on topology command.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric topology --region eu-west
+```
+
+```bash
+syfrah fabric topology --zone eu-west-1a
+```
+
+```bash
+syfrah fabric topology --region nonexistent
+```
+
+```bash
+syfrah fabric topology --zone nonexistent
+```
+
+
+## Expected results
+
+- region filter shows eu-west
+- region filter hides us-east
+- region filter shows node-eu
+- zone filter shows eu-west-1a
+- zone filter shows node-eu in eu-west-1a
+- zone filter shows node-eu
+- invalid region filter gives helpful error
+- invalid zone filter gives helpful error
+
+## Failure criteria
+
+- region filter missing eu-west
+- region filter should hide us-east
+- region filter missing node-eu
+- zone filter missing eu-west-1a
+- zone filter missing node-eu
+- invalid region filter: unhelpful message
+- invalid zone filter: unhelpful message

--- a/tests/e2e/scenarios/53_fabric_topology_json.md
+++ b/tests/e2e/scenarios/53_fabric_topology_json.md
@@ -1,0 +1,61 @@
+# Test: topology --json output schema validation
+
+## Objective
+
+topology --json output schema validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric topology --json
+```
+
+```bash
+syfrah fabric topology --json --region eu-west
+```
+
+
+## Expected results
+
+- topology --json produces valid JSON
+- JSON has mesh_name field
+- JSON has total_nodes field
+- JSON has regions array
+- mesh_name is correct: json-mesh
+- total_nodes >= 2
+- regions array has <value> entries
+- region has name field
+- region has zones array with <value> entries
+- zone has name field
+- zone has nodes array with <value> entries
+- node has name field
+- node has mesh_ipv6 field
+- node has valid status
+- topology --json --region produces valid JSON
+
+## Failure criteria
+
+- topology --json is not valid JSON
+- JSON missing mesh_name field
+- JSON missing total_nodes field
+- JSON missing regions array
+- mesh_name incorrect
+- total_nodes unexpected
+- regions array empty
+- region missing name field
+- region zones array empty
+- zone missing name field
+- zone nodes array empty
+- node missing name field
+- node missing mesh_ipv6 field
+- node has unexpected status
+- topology --json --region is not valid JSON

--- a/tests/e2e/scenarios/54_fabric_topology_backward_compat.md
+++ b/tests/e2e/scenarios/54_fabric_topology_backward_compat.md
@@ -1,0 +1,72 @@
+# Test: old state.json (without topology field) loads correctly
+
+## Objective
+
+old state.json (without topology field) loads correctly.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until all 2 nodes see 1 peers each (timeout: 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric topology
+```
+
+```bash
+syfrah fabric topology --json
+```
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric stop
+```
+
+```bash
+syfrah fabric topology
+```
+
+
+## Expected results
+
+- topology shows default region for legacy nodes
+- legacy node-1 visible in topology
+- legacy node-2 visible in topology
+- topology --json works for legacy nodes
+- JSON shows default region for legacy nodes
+- peers command works alongside topology for legacy state
+- topology loads after stripping topology field from state
+
+## Failure criteria
+
+- topology fails with nodes that have no explicit region
+- legacy node-1 missing from topology
+- legacy node-2 missing from topology
+- topology --json fails for legacy nodes
+- JSON missing default region
+- peers command broken for legacy state
+- topology broken after stripping topology field

--- a/tests/e2e/scenarios/55_fabric_topology_validation.md
+++ b/tests/e2e/scenarios/55_fabric_topology_validation.md
@@ -1,0 +1,105 @@
+# Test: invalid region/zone names are rejected by init and join
+
+## Objective
+
+invalid region/zone names are rejected by init and join.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Testing: uppercase region
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region EU-WEST --zone eu-west-1a
+```
+
+
+### 2. Testing: leading dash in region
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region "-bad-region" --zone zone-1
+```
+
+
+### 3. Testing: trailing dash in region
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region "bad-region-" --zone zone-1
+```
+
+
+### 4. Testing: special characters in region
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region "eu_west" --zone zone-1
+```
+
+
+### 5. Testing: empty region
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region "" --zone zone-1
+```
+
+
+### 6. Testing: uppercase zone
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region eu-west --zone ZONE-A
+```
+
+
+### 7. Testing: leading dash in zone
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region eu-west --zone "-zone"
+```
+
+
+### 8. Testing: valid region/zone accepted
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820 --region eu-west --zone eu-west-1a
+```
+
+```bash
+syfrah fabric status
+```
+
+
+### 9. Testing: join with invalid region
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name node-2 --endpoint 172.20.0.11:51820 --pin "<PIN>" --region "BAD REGION" --zone zone-1
+```
+
+
+## Expected results
+
+- uppercase region rejected
+- leading dash region rejected
+- trailing dash region rejected
+- underscore in region rejected
+- empty region rejected
+- uppercase zone rejected
+- leading dash zone rejected
+- valid region accepted after rejections
+- join with invalid region rejected
+
+## Failure criteria
+
+- uppercase region not rejected
+- leading dash region not rejected
+- trailing dash region not rejected
+- underscore in region not rejected
+- empty region not rejected
+- uppercase zone not rejected
+- leading dash zone not rejected
+- valid init failed
+- join with invalid region not rejected

--- a/tests/e2e/scenarios/59_fabric_pid_safety.md
+++ b/tests/e2e/scenarios/59_fabric_pid_safety.md
@@ -1,0 +1,46 @@
+# Test: Fabric Pid Safety
+
+## Objective
+
+Fabric Pid Safety.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Execute the test
+
+```bash
+syfrah fabric stop
+```
+
+```bash
+bash -c 'echo 1 > /root/.syfrah/daemon.pid'
+```
+
+```bash
+syfrah fabric stop
+```
+
+
+## Expected results
+
+- refuses to kill non-syfrah PID
+- PID 1 (init) still alive
+
+## Failure criteria
+
+- did not refuse to kill fake PID
+- PID 1 was killed!

--- a/tests/e2e/scenarios/59_fabric_topology_peers.md
+++ b/tests/e2e/scenarios/59_fabric_topology_peers.md
@@ -1,0 +1,50 @@
+# Test: peers --topology shows grouped output by region/zone
+
+## Objective
+
+peers --topology shows grouped output by region/zone.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Execute the test
+
+```bash
+syfrah fabric peers --topology
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- peers --topology shows eu-west region
+- peers --topology shows us-east region
+- peers --topology shows zone eu-west-1b
+- peers --topology shows zone us-east-1a
+- peers --topology shows node-us
+- peers --topology shows node-eu-2
+- peers --topology shows node count in region header
+- peers --topology shows count in region header
+- flat peers shows column headers
+- flat peers shows all peers
+
+## Failure criteria
+
+- peers --topology missing eu-west
+- peers --topology missing us-east
+- peers --topology missing zone eu-west-1b
+- peers --topology missing zone us-east-1a
+- peers --topology missing node-us
+- peers --topology missing node-eu-2
+- peers --topology missing node count in region
+- flat peers missing column headers
+- flat peers missing some peers

--- a/tests/e2e/scenarios/70_compute_vm_create.md
+++ b/tests/e2e/scenarios/70_compute_vm_create.md
@@ -1,0 +1,78 @@
+# Test: VM creation lifecycle
+
+## Objective
+
+- A VM can be created with syfrah compute vm create
+- The VM appears in syfrah compute vm list
+- The VM phase is Running
+- syfrah compute vm get returns correct fields (vcpus, memory)
+- Runtime directory exists with valid metadata
+- PID file exists and the process is alive
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/list/get) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-create --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Creating test VM
+
+```bash
+syfrah compute vm create --name test-vm-1 --vcpu 2 --memory 512 --image alpine-3.20
+```
+
+
+### 3. Verify VM in list
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm list --json
+```
+
+
+### 4. Verify VM phase
+
+- Verify: VM `test-vm-1` is in `Running` phase
+
+### 5. Verify VM details
+
+```bash
+syfrah compute vm get test-vm-1 --json
+```
+
+
+## Expected results
+
+- VM creation command succeeded
+- VM test-vm-1 appears in vm list
+- VM has 2 vCPUs
+- VM has 512 MB memory
+- Runtime directory exists
+- meta.json is valid JSON
+- CH process <value> is alive
+
+## Failure criteria
+
+- VM creation command failed
+- VM test-vm-1 not in vm list
+- VM vCPUs: <value> (expected 2)
+- VM memory: <value> (expected 512)
+- Runtime directory /run/syfrah/vms/test-vm-1 missing
+- meta.json invalid or missing
+- CH process <value> is not alive
+- PID file missing or empty

--- a/tests/e2e/scenarios/71_compute_vm_stop_delete.md
+++ b/tests/e2e/scenarios/71_compute_vm_stop_delete.md
@@ -1,0 +1,78 @@
+# Test: VM stop and delete lifecycle
+
+## Objective
+
+- A running VM can be stopped
+- A stopped VM reaches Stopped phase
+- A VM can be deleted
+- Deleted VM no longer appears in list
+- Runtime directory is cleaned up after delete
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/stop/delete/list) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-stopdel --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create and verify VM is running
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name test-vm-sd --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+- Verify: VM `test-vm-sd` is in `Running` phase
+
+### 3. Stopping VM
+
+```bash
+syfrah compute vm stop test-vm-sd
+```
+
+- Verify: Wait until VM `test-vm-sd` reaches `Stopped` phase (timeout 15s)
+- Verify: VM `test-vm-sd` is in `Stopped` phase
+
+### 4. Deleting VM
+
+Wait 2 seconds.
+
+```bash
+syfrah compute vm delete test-vm-sd
+```
+
+
+### 5. Verify VM gone from list
+
+```bash
+syfrah compute vm list --json
+```
+
+
+## Expected results
+
+- VM stop command succeeded
+- VM delete command succeeded
+- VM test-vm-sd removed from list
+- Runtime directory cleaned up
+
+## Failure criteria
+
+- VM stop command failed
+- VM delete command failed
+- VM test-vm-sd still in list after delete
+- Runtime directory still exists after delete

--- a/tests/e2e/scenarios/72_compute_vm_reboot.md
+++ b/tests/e2e/scenarios/72_compute_vm_reboot.md
@@ -1,0 +1,59 @@
+# Test: VM reboot
+
+## Objective
+
+- A running VM can be rebooted
+- The VM returns to Running phase after reboot
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/list) and reboot support
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-reboot --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create VM
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name test-vm-rb --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+- Verify: VM `test-vm-rb` is in `Running` phase
+
+### 3. Rebooting VM
+
+```bash
+syfrah compute vm reboot "test-vm-rb"
+```
+
+
+### 4. Verify VM returns to Running
+
+Wait 3 seconds.
+
+- Verify: VM `test-vm-rb` is in `Running` phase
+
+## Expected results
+
+- VM reboot command succeeded
+- CH process still alive after reboot
+
+## Failure criteria
+
+- VM reboot command failed
+- CH process not alive after reboot

--- a/tests/e2e/scenarios/73_compute_vm_multiple.md
+++ b/tests/e2e/scenarios/73_compute_vm_multiple.md
@@ -1,0 +1,93 @@
+# Test: Multiple VMs on a single node
+
+## Objective
+
+- 3 VMs with different specs can be created
+- All 3 appear in vm list
+- Stopping one does not affect others
+- Deleting one does not affect others
+- Counts are correct at each step
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/stop/delete/list) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-multi --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Creating 3 VMs
+
+Wait 5 seconds.
+
+```bash
+syfrah compute vm create --name vm-alpha --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+```bash
+syfrah compute vm create --name vm-beta --vcpu 2 --memory 512 --image alpine-3.20
+```
+
+```bash
+syfrah compute vm create --name vm-gamma --vcpu 4 --memory 1024 --image alpine-3.20
+```
+
+
+### 3. Verify all 3 in list
+
+- Verify: assert_vm_count "e2e-compute-multi" 3
+- Verify: VM `vm-alpha` is in `Running` phase
+- Verify: VM `vm-beta` is in `Running` phase
+- Verify: VM `vm-gamma` is in `Running` phase
+
+### 4. Stopping vm-beta
+
+```bash
+syfrah compute vm stop vm-beta
+```
+
+- Verify: Wait until VM `vm-beta` reaches `Stopped` phase (timeout 15s)
+- Verify: VM `vm-alpha` is in `Running` phase
+- Verify: VM `vm-beta` is in `Stopped` phase
+- Verify: VM `vm-gamma` is in `Running` phase
+
+### 5. Deleting vm-beta
+
+Wait 2 seconds.
+
+```bash
+syfrah compute vm delete vm-beta
+```
+
+- Verify: assert_vm_count "e2e-compute-multi" 2
+
+### 6. Remaining VMs unaffected
+
+- Verify: VM `vm-alpha` is in `Running` phase
+- Verify: VM `vm-gamma` is in `Running` phase
+
+## Expected results
+
+- 3 VMs with different specs can be created
+- All 3 appear in vm list
+- Stopping one does not affect others
+- Deleting one does not affect others
+- Counts are correct at each step
+
+## Failure criteria
+
+- Any syfrah command returns a non-zero exit code unexpectedly
+- Expected output patterns are missing
+- Timeouts exceeded waiting for convergence

--- a/tests/e2e/scenarios/74_compute_vm_reconnect.md
+++ b/tests/e2e/scenarios/74_compute_vm_reconnect.md
@@ -1,0 +1,73 @@
+# Test: Daemon restart recovery — VM survives daemon restart
+
+## Objective
+
+- After killing the syfrah daemon and restarting, existing VMs are recovered
+- The CH process survives the daemon restart
+- syfrah compute vm list shows the VM after recovery
+- syfrah compute vm get returns correct info
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI and daemon reconnect logic must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-reconn --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create VM
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name test-vm-rc --vcpu 2 --memory 512 --image alpine-3.20
+```
+
+```bash
+cat /run/syfrah/vms/test-vm-rc/pid
+```
+
+- Verify: VM `test-vm-rc` is in `Running` phase
+
+### 3. Restarting syfrah daemon
+
+Wait 3 seconds.
+
+```bash
+syfrah fabric start
+```
+
+
+### 4. Verify VM recovered
+
+```bash
+syfrah compute vm list --json
+```
+
+- Verify: VM `test-vm-rc` is in `Running` phase
+
+## Expected results
+
+- Daemon killed (PID <value>)
+- CH process <value> survived daemon kill
+- VM test-vm-rc recovered after daemon restart
+- CH PID unchanged after daemon restart (<value>)
+
+## Failure criteria
+
+- Could not find daemon PID
+- CH process died with daemon
+- VM test-vm-rc not found after daemon restart
+- CH PID changed: <value> -> <value>

--- a/tests/e2e/scenarios/75_compute_vm_crash_detection.md
+++ b/tests/e2e/scenarios/75_compute_vm_crash_detection.md
@@ -1,0 +1,72 @@
+# Test: CH process crash detection
+
+## Objective
+
+- When the CH process is killed directly, the monitor detects it
+- The VM transitions to Failed phase
+- The failed VM appears correctly in vm list
+- The failed VM can be deleted and cleaned up
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI and process monitor must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-crash --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create VM
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name test-vm-crash --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+- Verify: VM `test-vm-crash` is in `Running` phase
+
+### 3. Waiting for crash detection (up to 15s)
+
+- Verify: Wait until VM `test-vm-crash` reaches `Failed` phase (timeout 15s)
+- Verify: VM `test-vm-crash` is in `Failed` phase
+
+### 4. Verify failed VM in list
+
+```bash
+syfrah compute vm list --json
+```
+
+
+### 5. Deleting failed VM
+
+Wait 2 seconds.
+
+```bash
+syfrah compute vm delete test-vm-crash
+```
+
+- Verify: assert_vm_count "e2e-compute-crash" 0
+
+## Expected results
+
+- CH process killed
+- Failed VM still visible in list
+- Runtime directory cleaned up after deleting failed VM
+
+## Failure criteria
+
+- Could not find CH PID
+- Failed VM not in list
+- Runtime directory still exists after deleting failed VM

--- a/tests/e2e/scenarios/76_compute_vm_status.md
+++ b/tests/e2e/scenarios/76_compute_vm_status.md
@@ -1,0 +1,67 @@
+# Test: Compute status endpoint with mixed VM states
+
+## Objective
+
+- syfrah compute status reports correct total VM count
+- syfrah compute status reports correct running VM count
+- Counts update correctly when VMs are stopped
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute status, vm create/stop) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-status --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create 2 VMs
+
+Wait 5 seconds.
+
+```bash
+syfrah compute vm create --name vm-run --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+```bash
+syfrah compute vm create --name vm-stop --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+- Verify: VM `vm-run` is in `Running` phase
+- Verify: VM `vm-stop` is in `Running` phase
+
+### 3. Stop one VM
+
+```bash
+syfrah compute vm stop vm-stop
+```
+
+- Verify: Wait until VM `vm-stop` reaches `Stopped` phase (timeout 15s)
+
+### 4. Checking compute status
+
+```bash
+syfrah compute status --json
+```
+
+
+## Expected results
+
+- total_vms = 2
+- running_vms = 1
+
+## Failure criteria
+
+- total_vms = <value> (expected 2)
+- running_vms = <value> (expected 1)

--- a/tests/e2e/scenarios/77_compute_vm_error_paths.md
+++ b/tests/e2e/scenarios/77_compute_vm_error_paths.md
@@ -1,0 +1,83 @@
+# Test: Compute error handling
+
+## Objective
+
+- Creating a VM with invalid spec (vcpus=0) returns an error
+- Stopping a non-existent VM returns an error or not-found
+- Deleting a non-existent VM returns an error or succeeds (idempotent)
+- Creating a duplicate-named VM returns an error
+- No leaked processes or runtime dirs after errors
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/stop/delete) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-errors --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Creating VM with vcpus=0 (should fail)
+
+```bash
+syfrah compute vm create --name bad-vm --vcpu 0 --memory 256 --image alpine-3.20) || EXIT_CODE=$?
+```
+
+
+### 3. Stopping non-existent VM (should fail)
+
+```bash
+syfrah compute vm stop ghost-vm
+```
+
+
+### 4. Deleting non-existent VM
+
+```bash
+syfrah compute vm delete ghost-vm
+```
+
+
+### 5. Creating VM, then creating duplicate
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name dup-vm --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+```bash
+syfrah compute vm create --name dup-vm --vcpu 1 --memory 256 --image alpine-3.20) || EXIT_CODE=$?
+```
+
+
+## Expected results
+
+- VM creation with vcpus=0 failed as expected
+- Stopping non-existent VM failed as expected
+- Stopping non-existent VM returned not-found message
+- Deleting non-existent VM returned success (idempotent)
+- Deleting non-existent VM returned not-found
+- Duplicate VM creation failed as expected
+- No leaked runtime directory for bad-vm
+- No leaked runtime directory for ghost-vm
+
+## Failure criteria
+
+- VM creation with vcpus=0 should have failed
+- Stopping non-existent VM unexpectedly succeeded
+- Deleting non-existent VM unexpected result (<value>)
+- Duplicate VM creation should have failed
+- Runtime directory leaked for bad-vm
+- Runtime directory leaked for ghost-vm

--- a/tests/e2e/scenarios/78_compute_vm_force_stop.md
+++ b/tests/e2e/scenarios/78_compute_vm_force_stop.md
@@ -1,0 +1,62 @@
+# Test: Force stop a VM
+
+## Objective
+
+- A running VM can be force-stopped
+- Force stop completes quickly (< 5 seconds)
+- The VM reaches Stopped phase
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Compute CLI (syfrah compute vm create/stop --force) must be implemented
+- ComputeHandler must be integrated into the daemon
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name compute-fstop --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Create VM
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name test-vm-fs --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+- Verify: VM `test-vm-fs` is in `Running` phase
+
+### 3. Force stopping VM
+
+```bash
+syfrah compute vm stop test-vm-fs
+```
+
+
+### 4. Verify Stopped phase
+
+Wait 2 seconds.
+
+- Verify: VM `test-vm-fs` is in `Stopped` phase
+
+## Expected results
+
+- Force stop command succeeded
+- Force stop completed in <value>s (< 5s)
+- CH process terminated after force stop
+
+## Failure criteria
+
+- Force stop command failed
+- Force stop took <value>s (expected < 5s)
+- CH process <value> still alive after force stop

--- a/tests/e2e/scenarios/79_compute_image_list.md
+++ b/tests/e2e/scenarios/79_compute_image_list.md
@@ -1,0 +1,61 @@
+# Test: Image listing with real images from catalog
+
+## Objective
+
+- syfrah compute image list returns images
+- alpine-3.20 appears in the list (pre-downloaded from catalog)
+- JSON output is valid and contains expected fields
+- The image file on disk is a real raw image (non-zero size)
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+- Compute CLI (syfrah compute image list) must be implemented
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name image-list --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Checking that real alpine-3.20.raw exists
+
+```bash
+stat -c%s /opt/syfrah/images/alpine-3.20.raw
+```
+
+```bash
+stat -c%s /opt/syfrah/vmlinux
+```
+
+```bash
+jq '.images | length' /opt/syfrah/catalog.json
+```
+
+
+## Expected results
+
+- alpine-3.20.raw is a real image (<value>) MB)
+- vmlinux kernel is a real file (<value>) KB)
+- alpine-3.20 appears in image list
+- JSON output is valid
+- JSON contains alpine-3.20 image entry
+- catalog.json has <value> image(s)
+
+## Failure criteria
+
+- alpine-3.20.raw is missing or too small (<value> bytes)
+- vmlinux is missing or too small (<value> bytes)
+- alpine-3.20 not in image list
+- JSON output is not valid JSON
+- JSON missing alpine-3.20
+- catalog.json has no images
+- catalog.json not found in container

--- a/tests/e2e/scenarios/80_compute_image_inspect.md
+++ b/tests/e2e/scenarios/80_compute_image_inspect.md
@@ -1,0 +1,49 @@
+# Test: Image inspection with real catalog images
+
+## Objective
+
+- Inspecting a known image returns metadata
+- Metadata contains expected fields (name, arch, format)
+- Inspecting a non-existent image returns an error
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+- Compute CLI (syfrah compute image inspect) must be implemented
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name image-inspect --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Execute the test
+
+```bash
+# - Compute CLI (syfrah compute image inspect) must be implemented
+```
+
+
+## Expected results
+
+- inspect output is valid JSON
+- inspect shows correct name
+- inspect shows format=raw
+- inspect shows non-zero size (<value> MB)
+- inspecting non-existent image fails as expected
+
+## Failure criteria
+
+- inspect output is not valid JSON
+- inspect name: '<value>' (expected alpine-3.20)
+- inspect format: '<value>' (expected raw)
+- inspect size_mb is 0 or missing
+- inspecting non-existent image did not fail

--- a/tests/e2e/scenarios/81_compute_image_import.md
+++ b/tests/e2e/scenarios/81_compute_image_import.md
@@ -1,0 +1,46 @@
+# Test: Image import from local file
+
+## Objective
+
+- A raw disk file can be imported with a custom name
+- The imported image appears in image list
+- The imported image can be inspected
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+- Compute CLI (syfrah compute image import) must be implemented
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name image-import --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Importing test-disk.raw as custom-os
+
+Wait 1 seconds.
+
+- Verify: assert_image_exists "e2e-image-import" "custom-os"
+
+## Expected results
+
+- created 8 MB test raw file
+- import command succeeded
+- custom-os appears in image list
+- duplicate import rejected
+
+## Failure criteria
+
+- failed to create test raw file
+- import command failed
+- custom-os not in image list
+- duplicate import not rejected

--- a/tests/e2e/scenarios/82_compute_image_delete.md
+++ b/tests/e2e/scenarios/82_compute_image_delete.md
@@ -1,0 +1,51 @@
+# Test: Image deletion
+
+## Objective
+
+- An imported image can be deleted
+- The deleted image no longer appears in list
+- The raw file is removed from disk
+- Deleting a non-existent image returns an error
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+- Compute CLI (syfrah compute image delete) must be implemented
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name image-delete --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Creating and importing disposable image
+
+Wait 1 seconds.
+
+- Verify: assert_image_exists "e2e-image-delete" "disposable"
+
+### 3. Deleting disposable image
+
+Wait 1 seconds.
+
+- Verify: assert_image_gone "e2e-image-delete" "disposable"
+
+## Expected results
+
+- delete command succeeded
+- disposable removed from image list
+- deleting non-existent image fails as expected
+
+## Failure criteria
+
+- delete command failed
+- disposable still in image list after delete
+- deleting non-existent image did not fail

--- a/tests/e2e/scenarios/83_compute_image_vm_lifecycle.md
+++ b/tests/e2e/scenarios/83_compute_image_vm_lifecycle.md
@@ -1,0 +1,77 @@
+# Test: VM lifecycle with real catalog images
+
+## Objective
+
+- A VM can be created using the real alpine-3.20 image from the catalog
+- The VM reaches Running phase
+- The instance directory contains a cloned rootfs (non-zero size)
+- The VM can be stopped and deleted cleanly
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+- Compute CLI must be implemented
+- Fake cloud-hypervisor must be installed in the Docker image
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name image-vm --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Creating VM with real alpine-3.20 image
+
+```bash
+syfrah compute vm create --name real-vm --vcpu 1 --memory 256 --image alpine-3.20
+```
+
+
+### 3. Checking instance rootfs size
+
+```bash
+sh -c 'ls -d /opt/syfrah/instances/*/rootfs.raw
+```
+
+
+### 4. Stopping VM
+
+```bash
+syfrah compute vm stop real-vm
+```
+
+- Verify: Wait until VM `real-vm` reaches `Stopped` phase (timeout 15s)
+- Verify: VM `real-vm` is in `Stopped` phase
+
+### 5. Deleting VM
+
+Wait 2 seconds.
+
+```bash
+syfrah compute vm delete real-vm
+```
+
+```bash
+syfrah compute vm list --json
+```
+
+
+## Expected results
+
+- VM creation with real image succeeded
+- instance rootfs is a real file (<value>) MB)
+- VM running (instance layout check skipped)
+- VM real-vm cleaned up
+
+## Failure criteria
+
+- VM creation with real image failed
+- instance rootfs is too small (<value> bytes)
+- VM real-vm still in list after delete

--- a/tests/e2e/scenarios/84_compute_image_catalog_integrity.md
+++ b/tests/e2e/scenarios/84_compute_image_catalog_integrity.md
@@ -1,0 +1,56 @@
+# Test: Catalog integrity verification
+
+## Objective
+
+- catalog.json is valid JSON and has the expected schema
+- Every image listed in the catalog has a corresponding .raw file on disk
+- The base_url in the catalog points to a valid GitHub release
+- The kernel entry exists and the vmlinux file is on disk
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+- Docker image built with real images from syfrah-images catalog
+
+## Steps
+
+### 1. Checking all catalog images have local files
+
+```bash
+stat -c%s "/opt/syfrah/images/${name}.raw"
+```
+
+
+### 2. Checking kernel entry
+
+```bash
+stat -c%s /opt/syfrah/vmlinux
+```
+
+
+## Expected results
+
+- catalog.json is valid JSON
+- catalog version is 1
+- base_url points to syfrah-images repo
+- image <value> exists on disk (<value>) MB)
+- all <value> catalog images present on disk
+- catalog has kernel entry (file=<value>)
+- kernel version
+- vmlinux on disk (<value>) KB)
+
+## Failure criteria
+
+- catalog.json is not valid JSON
+- catalog version: '<value>' (expected 1)
+- base_url unexpected
+- image <value> on disk but too small (<value> bytes)
+- image <value> in catalog but not on disk
+- only <value>/<value> catalog images present
+- catalog missing kernel entry
+- kernel version missing
+- vmlinux too small (<value> bytes)
+- vmlinux not found on disk

--- a/tests/e2e/scenarios/85_compute_cold_start.md
+++ b/tests/e2e/scenarios/85_compute_cold_start.md
@@ -1,0 +1,73 @@
+# Test: Cold start — fresh server, no pre-installed images
+
+## Objective
+
+Cold start — fresh server, no pre-installed images.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- KVM support (`/dev/kvm`) or container runtime fallback
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name cold-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Step 1: Verify no images on fresh install
+
+```bash
+syfrah compute image list --json
+```
+
+
+### 3. Step 4: Verify image in local list
+
+```bash
+syfrah compute image list --json
+```
+
+
+### 4. Step 5: Create VM with pulled image
+
+```bash
+syfrah compute vm create --name cold-test --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+- Verify: Wait until VM `cold-test` reaches `Running` phase (timeout 30s)
+
+### 5. Step 6: Cleanup
+
+```bash
+syfrah compute vm delete cold-test --yes
+```
+
+```bash
+syfrah compute image delete alpine-3.20 --yes
+```
+
+
+## Expected results
+
+- No images on fresh install
+- Catalog shows <value> images
+- Image pull succeeded and verified in image list
+- alpine-3.20 appears in local list
+- VM reached Running on KVM-capable host
+- VM creation correctly reported no KVM
+
+## Failure criteria
+
+- Expected empty image list, got
+- Catalog is empty or unreachable after 3 attempts
+- Image pull failed or image not found in list after 3 attempts
+- alpine-3.20 not found after pull
+- VM creation failed on KVM-capable host
+- VM creation failed with unclear error

--- a/tests/e2e/scenarios/86_compute_container_create.md
+++ b/tests/e2e/scenarios/86_compute_container_create.md
@@ -1,0 +1,100 @@
+# Test: Container runtime — create a real container (no KVM needed)
+
+## Objective
+
+- syfrah compute status shows "container" runtime
+- An image can be pulled from the catalog
+- A VM (actually a gVisor container) can be created
+- The container reaches Running phase
+- The container process (PID) is alive
+- The container can be stopped and deleted
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- Container runtime (`crun` / `runsc`) installed
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name container-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Step 1: Check compute status for container runtime
+
+```bash
+syfrah compute status
+```
+
+```bash
+syfrah compute status --json
+```
+
+
+### 3. Step 2: Pull alpine-3.20 image
+
+```bash
+sh -c 'rm -f /opt/syfrah/images/*.raw /opt/syfrah/images/images.json'
+```
+
+
+### 4. Step 3: Create VM (container-backed via gVisor/crun)
+
+```bash
+syfrah compute vm create --name ctr-test-1 --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+
+### 5. Step 4: Verify container reaches Running phase
+
+```bash
+syfrah compute vm get ctr-test-1 --json
+```
+
+
+### 6. Step 6: Stop the container
+
+```bash
+syfrah compute vm stop ctr-test-1
+```
+
+
+### 7. Step 7: Delete the container
+
+```bash
+syfrah compute vm delete ctr-test-1
+```
+
+```bash
+syfrah compute vm list --json
+```
+
+
+## Expected results
+
+- compute status shows container runtime
+- compute status JSON shows container runtime
+- compute status returned (runtime detection may vary)
+- Image alpine-3.20 pulled successfully
+- Container VM creation command accepted
+- Container ctr-test-1 reached Running
+- Container process <value> is alive
+- Container ctr-test-1 stopped
+- Container ctr-test-1 deleted
+
+## Failure criteria
+
+- compute status shows degraded/unavailable instead of container runtime
+- Failed to pull alpine-3.20 after 3 attempts
+- Container VM creation failed
+- Container ctr-test-1 did not reach Running (current: unknown)
+- Container process <value> is not alive
+- PID file missing or empty for ctr-test-1
+- Container ctr-test-1 did not stop
+- Container ctr-test-1 still in list after delete

--- a/tests/e2e/scenarios/87_compute_container_lifecycle.md
+++ b/tests/e2e/scenarios/87_compute_container_lifecycle.md
@@ -1,0 +1,136 @@
+# Test: Full container lifecycle — create, list, get, stop, start, delete
+
+## Objective
+
+- Multiple containers can be created
+- All containers appear in vm list
+- vm get returns correct spec fields
+- Containers can be stopped and restarted
+- Containers can be deleted
+- Final list is empty after full cleanup
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- Container runtime (`crun` / `runsc`) installed
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name lifecycle-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Pulling alpine-3.20 for lifecycle tests
+
+```bash
+sh -c 'rm -f /opt/syfrah/images/*.raw /opt/syfrah/images/images.json'
+```
+
+
+### 3. Step 1: Create container life-a
+
+```bash
+syfrah compute vm create --name life-a --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+
+### 4. Step 1b: Create container life-b
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm create --name life-b --image alpine-3.20 --vcpus 2 --memory 512
+```
+
+
+### 5. Step 2: Verify both containers in vm list
+
+```bash
+syfrah compute vm list --json
+```
+
+
+### 6. Step 3: Verify vm get fields
+
+```bash
+syfrah compute vm get life-a --json
+```
+
+```bash
+syfrah compute vm get life-b --json
+```
+
+
+### 7. Step 4: Verify both containers Running
+
+- Verify: Wait until VM `life-a` reaches `Running` phase (timeout 30s)
+- Verify: VM `life-a` is in `Running` phase
+- Verify: VM `life-b` is in `Running` phase
+
+### 8. Step 5: Stop life-a
+
+```bash
+syfrah compute vm stop life-a
+```
+
+- Verify: VM `life-b` is in `Running` phase
+
+### 9. Step 6: Restart life-a
+
+```bash
+syfrah compute vm start life-a
+```
+
+```bash
+syfrah compute vm get life-a --json
+```
+
+
+### 10. Step 7: Delete all containers
+
+```bash
+syfrah compute vm delete life-a
+```
+
+```bash
+syfrah compute vm delete life-b
+```
+
+```bash
+syfrah compute vm list --json
+```
+
+
+## Expected results
+
+- Image ready
+- Container life-a creation accepted
+- Container life-b creation accepted
+- vm list shows 2 containers
+- life-a in list
+- life-b in list
+- life-b has 2 vCPUs
+- life-b has 512 MB memory
+- life-a stopped
+- life-a restarted to Running
+- All containers deleted — list is empty
+
+## Failure criteria
+
+- Failed to pull alpine-3.20 — cannot proceed
+- Container life-a creation failed
+- Container life-b creation failed
+- vm list shows <value> containers (expected 2)
+- life-a missing from list
+- life-b missing from list
+- life-b vCPUs: <value> (expected 2)
+- life-b memory: <value> (expected 512)
+- life-a did not stop
+- life-a restart failed (phase: unknown)
+- After delete, vm list still has <value> entries

--- a/tests/e2e/scenarios/88_compute_container_start.md
+++ b/tests/e2e/scenarios/88_compute_container_start.md
@@ -1,0 +1,92 @@
+# Test: Container runtime — vm start for stopped containers
+
+## Objective
+
+- A running container can be stopped
+- `vm start` brings a stopped container back to Running
+- Idempotent start on an already-running VM succeeds (or is a no-op)
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- Container runtime (`crun` / `runsc`) installed
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name start-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Pulling alpine-3.20 for start tests
+
+```bash
+sh -c 'rm -f /opt/syfrah/images/*.raw /opt/syfrah/images/images.json'
+```
+
+
+### 3. Step 1: Create container start-vm
+
+```bash
+syfrah compute vm create --name start-vm --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+
+### 4. Step 3: Stop start-vm
+
+```bash
+syfrah compute vm stop start-vm
+```
+
+
+### 5. Step 4: Start start-vm (from Stopped)
+
+```bash
+syfrah compute vm start start-vm
+```
+
+```bash
+syfrah compute vm get start-vm --json
+```
+
+
+### 6. Step 5: Start start-vm again (already Running — idempotent)
+
+```bash
+syfrah compute vm start start-vm
+```
+
+```bash
+syfrah compute vm get start-vm --json
+```
+
+
+### 7. Cleanup
+
+```bash
+syfrah compute vm delete start-vm
+```
+
+
+## Expected results
+
+- Image ready
+- Container start-vm creation accepted
+- start-vm reached Running
+- start-vm stopped
+- start-vm returned to Running after vm start
+- Idempotent start: VM still Running
+
+## Failure criteria
+
+- Failed to pull alpine-3.20 — cannot proceed
+- Container start-vm creation failed
+- start-vm did not reach Running
+- start-vm did not stop
+- start-vm did not return to Running (phase: unknown)
+- Idempotent start changed phase to: unknown

--- a/tests/e2e/scenarios/89_compute_container_reconnect.md
+++ b/tests/e2e/scenarios/89_compute_container_reconnect.md
@@ -1,0 +1,97 @@
+# Test: Container runtime — container reconnect after daemon restart
+
+## Objective
+
+- A container VM can be created and reaches Running
+- After `fabric stop` + `fabric start`, the daemon reconnects
+- The container VM still appears in `vm list`
+- The container VM is still in Running phase (or recovers to it)
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- Container runtime (`crun` / `runsc`) installed
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name reconn-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Pulling alpine-3.20 for reconnect tests
+
+```bash
+sh -c 'rm -f /opt/syfrah/images/*.raw /opt/syfrah/images/images.json'
+```
+
+
+### 3. Step 1: Create container reconn-vm
+
+```bash
+syfrah compute vm create --name reconn-vm --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+
+### 4. Step 3: Stop daemon (fabric stop)
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric stop
+```
+
+
+### 5. Step 4: Restart daemon (fabric start)
+
+```bash
+syfrah fabric start
+```
+
+
+### 6. Step 5: Verify reconn-vm in vm list after daemon restart
+
+Wait 3 seconds.
+
+```bash
+syfrah compute vm list --json
+```
+
+
+### 7. Step 6: Verify reconn-vm phase after reconnect
+
+```bash
+syfrah compute vm get reconn-vm --json
+```
+
+
+### 8. Cleanup
+
+```bash
+syfrah compute vm delete reconn-vm
+```
+
+
+## Expected results
+
+- Image ready
+- Container reconn-vm creation accepted
+- reconn-vm reached Running
+- Daemon stopped
+- Daemon restarted
+- reconn-vm still in vm list after daemon restart
+- reconn-vm is Running after daemon restart
+- reconn-vm is Stopped after daemon restart (container may not survive daemon cycle)
+
+## Failure criteria
+
+- Failed to pull alpine-3.20 — cannot proceed
+- Container reconn-vm creation failed
+- reconn-vm did not reach Running
+- reconn-vm missing from vm list after daemon restart
+- reconn-vm unexpected phase after restart: unknown

--- a/tests/e2e/scenarios/90_compute_container_runtime_field.md
+++ b/tests/e2e/scenarios/90_compute_container_runtime_field.md
@@ -1,0 +1,88 @@
+# Test: Container runtime — runtime field in vm list and vm get
+
+## Objective
+
+- `vm list` output contains a RUNTIME column
+- The RUNTIME column shows "container" for container-backed VMs
+- `vm get --json` includes a runtime field with value "container"
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- Container runtime (`crun` / `runsc`) installed
+- Compute module enabled in the daemon
+
+## Steps
+
+### 1. Initialize the daemon
+
+```bash
+syfrah fabric init --name test-mesh --node-name runtime-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be fully ready (~2 seconds).
+
+### 2. Pulling alpine-3.20 for runtime field tests
+
+```bash
+sh -c 'rm -f /opt/syfrah/images/*.raw /opt/syfrah/images/images.json'
+```
+
+
+### 3. Step 1: Create container rt-vm
+
+```bash
+syfrah compute vm create --name rt-vm --image alpine-3.20 --vcpus 1 --memory 256
+```
+
+
+### 4. Step 3: Verify RUNTIME column in vm list
+
+```bash
+syfrah compute vm list
+```
+
+
+### 5. Step 5: Verify runtime field in vm list --json
+
+```bash
+syfrah compute vm list --json
+```
+
+
+### 6. Step 6: Verify Runtime field in vm get --json
+
+```bash
+syfrah compute vm get rt-vm --json
+```
+
+
+### 7. Cleanup
+
+```bash
+syfrah compute vm delete rt-vm
+```
+
+
+## Expected results
+
+- Image ready
+- Container rt-vm creation accepted
+- rt-vm reached Running
+- vm list output contains RUNTIME column header
+- vm list shows 'container' runtime for rt-vm
+- vm list --json shows runtime 'container' for rt-vm
+- vm list --json shows runtime 'container' (alternate field name)
+- vm get --json shows Runtime 'container' for rt-vm
+- vm get --json shows Runtime 'container' (alternate field name)
+
+## Failure criteria
+
+- Failed to pull alpine-3.20 — cannot proceed
+- Container rt-vm creation failed
+- rt-vm did not reach Running
+- vm list output missing RUNTIME column header
+- vm list does not show 'container' runtime
+- vm list --json missing runtime field for rt-vm
+- vm get --json missing Runtime field for rt-vm

--- a/tests/e2e/scenarios/91_ux_init_output.md
+++ b/tests/e2e/scenarios/91_ux_init_output.md
@@ -1,0 +1,58 @@
+# Test: UX — init command output validation
+
+## Objective
+
+UX — init command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Testing: init happy path output
+
+```bash
+syfrah fabric init --name test-mesh --node-name node-1 --endpoint 172.20.0.110:51820
+```
+
+- Verify: Output contains `node-1`
+- Verify: Output contains `fd[0-9a-f]`
+- Verify: Output contains `region\|zone`
+
+### 2. Testing: init suggested commands
+
+- Verify: `syfrah fabric status` runs without errors
+
+### 3. Testing: init output no raw errors
+
+- Verify: `syfrah fabric status` does not contain `anyhow`
+- Verify: `syfrah fabric status` does not contain `os error`
+- Verify: `syfrah fabric status` does not contain `stack backtrace`
+
+### 4. Testing: double init
+
+```bash
+syfrah fabric init --name test-mesh2 --node-name node-2 --endpoint 172.20.0.110:51820
+```
+
+
+## Expected results
+
+- init output does not leak secret
+- init output contains node name
+- init output contains IPv6 address
+- init output contains region/zone
+- double init says already exists
+- double init suggests 'syfrah fabric leave'
+
+## Failure criteria
+
+- init should not show secret
+- init output missing node name
+- init output missing IPv6 (fd prefix)
+- init output missing region/zone
+- double init: unclear message
+- double init doesn't suggest 'syfrah fabric leave'

--- a/tests/e2e/scenarios/92_ux_join_output.md
+++ b/tests/e2e/scenarios/92_ux_join_output.md
@@ -1,0 +1,78 @@
+# Test: UX — join command output validation
+
+## Objective
+
+UX — join command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name server-1 --endpoint 172.20.0.10:51820
+```
+
+Start the peering service:
+```bash
+syfrah fabric start
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Testing: join happy path output
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name server-2 --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+- Verify: Output contains `joined\|approved\|accepted`
+- Verify: Output contains `fd[0-9a-f]`
+
+### 3. Testing: join target unreachable
+
+```bash
+syfrah fabric join 172.20.0.99:51821 --node-name server-3 --endpoint 172.20.0.12:51820 --pin 1234
+```
+
+
+### 4. Testing: join when state exists
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name server-2b --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+
+### 5. Testing: join no args
+
+```bash
+syfrah fabric join
+```
+
+
+## Expected results
+
+- join output shows approval
+- join output shows IPv6
+- join output shows approval method
+- join unreachable: no raw OS error
+- join with state: mentions existing state
+- join with state: suggests 'syfrah fabric leave' (full path)
+- join with state: mentions leave command
+- join no args: shows usage/help
+
+## Failure criteria
+
+- join output missing approval confirmation
+- join output missing IPv6
+- join output missing approval method
+- join unreachable shows raw OS error
+- join with state: unclear message
+- join with state: doesn't suggest leave
+- join no args: no usage info

--- a/tests/e2e/scenarios/93_ux_peers_output.md
+++ b/tests/e2e/scenarios/93_ux_peers_output.md
@@ -1,0 +1,72 @@
+# Test: UX — peers command output validation
+
+## Objective
+
+UX — peers command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 3 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (alpha):
+```bash
+syfrah fabric init --name test-mesh --node-name alpha --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On bravo:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name bravo --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Testing: peers no duplicates
+
+- Verify: No duplicate entries in `syfrah fabric peers`
+
+### 3. Testing: peers region/zone displayed
+
+- Verify: assert_regions_displayed "e2e-ux-peers-1"
+- Verify: assert_regions_displayed "e2e-ux-peers-2"
+
+### 4. Testing: peers no epoch dates
+
+- Verify: No epoch/1970 dates in output
+
+### 5. Testing: peers names readable
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+### 6. Testing: peers with no mesh
+
+```bash
+syfrah fabric peers
+```
+
+
+## Expected results
+
+- peer name 'bravo' fully displayed
+- peer name 'alpha' fully displayed
+- peers no mesh: suggests init/join
+
+## Failure criteria
+
+- peer name 'bravo' truncated or missing
+- peer name 'alpha' truncated or missing
+- peers no mesh: unclear message

--- a/tests/e2e/scenarios/94_ux_status_output.md
+++ b/tests/e2e/scenarios/94_ux_status_output.md
@@ -1,0 +1,95 @@
+# Test: UX — status command output validation
+
+## Objective
+
+UX — status command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name status-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Testing: status shows visual sections
+
+```bash
+syfrah fabric status
+```
+
+- Verify: assert_output_contains "e2e-ux-status-1" "syfrah fabric status" "status-node"
+- Verify: assert_output_matches "e2e-ux-status-1" "syfrah fabric status" "fd[0-9a-f]"
+
+### 3. Testing: --show-secret reveals secret
+
+```bash
+syfrah fabric status --show-secret
+```
+
+
+### 4. Testing: --verbose shows config and metrics
+
+```bash
+syfrah fabric status --verbose
+```
+
+
+### 5. Testing: status after stop
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric status
+```
+
+
+### 6. Testing: status with no mesh
+
+```bash
+syfrah fabric status
+```
+
+
+## Expected results
+
+- status shows Mesh section
+- status shows Network section
+- status shows Peers section
+- status shows region/zone
+- status masks secret (shows --show-secret hint)
+- status does not leak full secret
+- --show-secret reveals full secret
+- config section hidden by default
+- --verbose shows config section
+- status shows daemon health
+- status shows interface health
+- status shows stopped state
+- status after stop: no raw errors
+- status no mesh: suggests init/join
+
+## Failure criteria
+
+- status missing Mesh section
+- status missing Network section
+- status missing Peers section
+- status missing region/zone
+- status does not mask secret
+- status leaks full secret in default mode
+- --show-secret did not reveal full secret
+- config section visible without --verbose
+- --verbose missing config section
+- status missing daemon health
+- status missing interface health
+- status after stop: unclear
+- status after stop: shows raw error
+- status no mesh: unclear message

--- a/tests/e2e/scenarios/95_ux_peering_output.md
+++ b/tests/e2e/scenarios/95_ux_peering_output.md
@@ -1,0 +1,55 @@
+# Test: UX — peering command output validation
+
+## Objective
+
+UX — peering command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (peer-node-1):
+```bash
+syfrah fabric init --name test-mesh --node-name peer-node-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On peer-node-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name peer-node-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Testing: peering resulted in connected mesh
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+### 3. Testing: no raw errors
+
+- Verify: `syfrah fabric status` does not contain `anyhow`
+- Verify: `syfrah fabric status` does not contain `os error`
+
+## Expected results
+
+- peering: peer visible after PIN join
+- peering: initiator visible to joiner
+
+## Failure criteria
+
+- peering: peer not visible after PIN join
+- peering: initiator not visible to joiner

--- a/tests/e2e/scenarios/96_ux_lifecycle_output.md
+++ b/tests/e2e/scenarios/96_ux_lifecycle_output.md
@@ -1,0 +1,86 @@
+# Test: UX — lifecycle command output validation
+
+## Objective
+
+UX — lifecycle command output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+```bash
+syfrah fabric init --name test-mesh --node-name life-node --endpoint 172.20.0.10:51820
+```
+
+Wait for the daemon to be responsive (up to 30s).
+
+### 2. Testing: stop when running
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric stop
+```
+
+
+### 3. Testing: stop when already stopped
+
+```bash
+syfrah fabric stop
+```
+
+
+### 4. Testing: start after stop
+
+```bash
+syfrah fabric start
+```
+
+- Verify: The syfrah daemon is running
+
+### 5. Testing: token output
+
+```bash
+syfrah fabric token
+```
+
+
+### 6. Testing: leave output
+
+```bash
+syfrah fabric leave --yes
+```
+
+
+### 7. Testing: double leave
+
+```bash
+syfrah fabric leave --yes
+```
+
+
+## Expected results
+
+- stop: clean stop message
+- stop when stopped: says not running
+- stop when stopped: no raw error
+- token: shows syf_sk_ format
+- leave: clean message
+- leave: no WireGuard warnings
+- double leave: says nothing to do
+
+## Failure criteria
+
+- stop: unclear message
+- stop when stopped: unclear
+- stop when stopped: raw error
+- token: missing syf_sk_ format
+- leave: unclear message
+- leave: WireGuard warnings visible
+- double leave: unclear

--- a/tests/e2e/scenarios/97_ux_help_output.md
+++ b/tests/e2e/scenarios/97_ux_help_output.md
@@ -1,0 +1,59 @@
+# Test: UX — help and version output validation
+
+## Objective
+
+UX — help and version output validation.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Testing: syfrah --help
+
+```bash
+syfrah --help
+```
+
+
+### 2. Testing: syfrah fabric --help
+
+```bash
+syfrah fabric --help
+```
+
+
+### 3. Testing: syfrah --version
+
+```bash
+syfrah --version
+```
+
+
+### 4. Testing: syfrah state --help
+
+```bash
+syfrah state --help
+```
+
+
+## Expected results
+
+- syfrah --help: lists fabric
+- syfrah --help: lists state
+- syfrah fabric --help: lists <value>
+- syfrah --version: not empty
+- syfrah --version: contains semver
+- syfrah state --help: lists <value>
+
+## Failure criteria
+
+- syfrah --help: missing fabric
+- syfrah --help: missing state
+- syfrah fabric --help: missing <value>
+- syfrah --version: empty output
+- syfrah --version: no semver found
+- syfrah state --help: missing <value>

--- a/tests/e2e/scenarios/98_ux_flow_first_mesh.md
+++ b/tests/e2e/scenarios/98_ux_flow_first_mesh.md
@@ -1,0 +1,85 @@
+# Test: UX Flow — First-time mesh setup
+
+## Objective
+
+UX Flow — First-time mesh setup.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Step 1: Server 1 creates mesh
+
+```bash
+syfrah fabric init --name first-mesh --node-name server-1 --endpoint 172.20.0.10:51820
+```
+
+
+### 2. Step 2: Server 1 starts peering
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric peering start --pin "<PIN>"
+```
+
+
+### 3. Step 3: Server 2 joins with PIN
+
+```bash
+syfrah fabric join 172.20.0.10:51821 --node-name server-2 --endpoint 172.20.0.11:51820 --pin "<PIN>"
+```
+
+- Verify: Output contains `joined\|approved\|accepted`
+
+### 4. Step 4: Verify bidirectional peer visibility
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: Output contains `server-2`
+- Verify: Output contains `server-1`
+
+### 5. Step 5: Region/zone displayed
+
+- Verify: assert_regions_displayed "e2e-flow-first-1"
+- Verify: assert_regions_displayed "e2e-flow-first-2"
+
+### 6. Step 6: Mesh connectivity via IPv6
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+```bash
+syfrah fabric status --json # extract mesh IPv6 address
+```
+
+- Verify: Ping the peer mesh IPv6 address successfully
+- Verify: No duplicate entries in `syfrah fabric peers`
+- Verify: No epoch/1970 dates in output
+
+## Expected results
+
+- init: secret not leaked
+- join: approval confirmed
+- server-1 sees server-2 in peers
+- server-2 sees server-1 in peers
+
+## Failure criteria
+
+- init: should not show secret
+- join: no approval shown
+- server-1 doesn't see server-2
+- server-2 doesn't see server-1
+- could not get mesh IPv6 addresses

--- a/tests/e2e/scenarios/99_ux_flow_leave_rejoin.md
+++ b/tests/e2e/scenarios/99_ux_flow_leave_rejoin.md
@@ -1,0 +1,90 @@
+# Test: UX Flow — Leave and rejoin
+
+## Objective
+
+UX Flow — Leave and rejoin.
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- 2 servers with network connectivity on port 51820/UDP
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Set up the mesh
+
+On the first node (lr-server-1):
+```bash
+syfrah fabric init --name test-mesh --node-name lr-server-1 --endpoint 172.20.0.10:51820
+syfrah fabric start
+```
+
+On lr-server-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name lr-server-2 --endpoint 172.20.0.11:51820
+```
+
+On lr-server-2:
+```bash
+syfrah fabric join --leader 172.20.0.10:51820 --node-name lr-server-2 --endpoint 172.20.0.11:51820
+```
+
+Wait until each node sees 1 active peer(s) (timeout: 30s).
+
+### 2. Setting up 2-node mesh
+
+- Verify: `syfrah fabric peers` shows 1 peer(s)
+
+### 3. Step 1: Server 2 leaves
+
+Wait 2 seconds.
+
+```bash
+syfrah fabric leave --yes
+```
+
+
+### 4. Step 2: Verify clean state after leave
+
+- Verify: assert_clean_state "e2e-flow-lr-2"
+
+### 5. Step 4: Peers visible after rejoin
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+
+### 6. Step 5: Correct peer counts
+
+```bash
+syfrah fabric peers
+```
+
+```bash
+syfrah fabric peers
+```
+
+- Verify: No epoch/1970 dates in output
+
+## Expected results
+
+- leave: clean message
+- server-1 sees server-2 after rejoin
+- server-2 sees server-1 after rejoin
+- server-1 has <value> active peer(s)
+- server-2 has <value> active peer(s)
+
+## Failure criteria
+
+- leave: unclear message
+- server-1 doesn't see server-2 after rejoin
+- server-2 doesn't see server-1 after rejoin
+- server-1 has 0 active peers
+- server-2 has 0 active peers


### PR DESCRIPTION
Convert all 88 deleted E2E test scripts into .md prompt files. Each file is a self-contained test that can be executed by giving the prompt to Claude on a test server.

## What changed

- Created `tests/e2e/scenarios/` with 88 `.md` files (one per original `.sh` test)
- Each file follows a consistent format: Objective, Prerequisites, Steps, Expected results, Failure criteria
- Docker-specific commands removed; replaced with direct `syfrah` commands
- Helper functions (`init_mesh`, `join_mesh`, `create_vm`, etc.) converted to actual CLI commands
- Assertions converted to human-readable verification instructions

## Coverage

- Fabric tests (01-59): mesh formation, connectivity, zones, topology, stress tests
- Compute VM tests (70-85): create, stop, reboot, images, cold start
- Compute container tests (86-90): gVisor/crun runtime
- UX tests (91-109): output validation, error messages, user flows