### PR TITLE
Add org types, redb persistence, validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,6 +2455,9 @@ dependencies = [
  "serde",
  "serde_json",
  "syfrah-api",
+ "syfrah-state",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/layers/org/Cargo.toml
+++ b/layers/org/Cargo.toml
@@ -10,9 +10,12 @@ categories.workspace = true
 
 [dependencies]
 syfrah-api = { path = "../api" }
+syfrah-state = { path = "../state" }
 async-trait = "0.1"
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tempfile = "3"

--- a/layers/org/src/error.rs
+++ b/layers/org/src/error.rs
@@ -1,0 +1,24 @@
+/// Errors that can occur in org operations.
+#[derive(Debug, thiserror::Error)]
+pub enum OrgError {
+    #[error("org already exists: {0}")]
+    AlreadyExists(String),
+
+    #[error("org not found: {0}")]
+    NotFound(String),
+
+    #[error("invalid org name: {0}")]
+    InvalidName(String),
+
+    #[error("store error: {0}")]
+    StoreError(String),
+}
+
+impl From<syfrah_state::StateError> for OrgError {
+    fn from(e: syfrah_state::StateError) -> Self {
+        OrgError::StoreError(e.to_string())
+    }
+}
+
+/// Result type for org operations.
+pub type Result<T> = std::result::Result<T, OrgError>;

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -1,3 +1,11 @@
 pub mod api;
+pub mod error;
+pub mod store;
+pub mod types;
+pub mod validation;
 
 pub use api::OrgHandler;
+pub use error::OrgError;
+pub use store::OrgStore;
+pub use types::{Org, OrgId};
+pub use validation::validate_name;

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -1,0 +1,160 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use syfrah_state::LayerDb;
+
+use crate::error::{OrgError, Result};
+use crate::types::{Org, OrgId};
+use crate::validation::validate_name;
+
+const TABLE: &str = "orgs";
+
+/// Persistent store for organizations backed by redb.
+pub struct OrgStore {
+    db: LayerDb,
+}
+
+impl OrgStore {
+    /// Create a new `OrgStore` with the given database handle.
+    pub fn new(db: LayerDb) -> Self {
+        Self { db }
+    }
+
+    /// Create a new organization. Validates the name, checks for duplicates.
+    pub fn create(&self, name: &str) -> Result<Org> {
+        validate_name(name)?;
+
+        if self.db.exists(TABLE, name)? {
+            return Err(OrgError::AlreadyExists(name.to_string()));
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let org = Org {
+            id: OrgId(format!("org-{name}")),
+            name: name.to_string(),
+            created_at: now,
+        };
+
+        self.db.set(TABLE, name, &org)?;
+        Ok(org)
+    }
+
+    /// Get an organization by name. Returns `None` if it doesn't exist.
+    pub fn get(&self, name: &str) -> Result<Option<Org>> {
+        Ok(self.db.get(TABLE, name)?)
+    }
+
+    /// List all organizations.
+    pub fn list(&self) -> Result<Vec<Org>> {
+        let entries: Vec<(String, Org)> = self.db.list(TABLE)?;
+        Ok(entries.into_iter().map(|(_, org)| org).collect())
+    }
+
+    /// Delete an organization by name. Returns an error if it doesn't exist.
+    pub fn delete(&self, name: &str) -> Result<()> {
+        if !self.db.delete(TABLE, name)? {
+            return Err(OrgError::NotFound(name.to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (tempfile::TempDir, OrgStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("org-test.redb");
+        let db = LayerDb::open_at(&path).unwrap();
+        (dir, OrgStore::new(db))
+    }
+
+    #[test]
+    fn create_org() {
+        let (_dir, store) = temp_store();
+        let org = store.create("acme").unwrap();
+        assert_eq!(org.name, "acme");
+        assert_eq!(org.id.0, "org-acme");
+        assert!(org.created_at > 0);
+    }
+
+    #[test]
+    fn duplicate_name_rejected() {
+        let (_dir, store) = temp_store();
+        store.create("acme").unwrap();
+        let err = store.create("acme").unwrap_err();
+        assert!(matches!(err, OrgError::AlreadyExists(_)));
+    }
+
+    #[test]
+    fn invalid_name_rejected() {
+        let (_dir, store) = temp_store();
+
+        // spaces
+        assert!(matches!(
+            store.create("my org").unwrap_err(),
+            OrgError::InvalidName(_)
+        ));
+        // uppercase
+        assert!(matches!(
+            store.create("Acme").unwrap_err(),
+            OrgError::InvalidName(_)
+        ));
+        // special chars
+        assert!(matches!(
+            store.create("org@1").unwrap_err(),
+            OrgError::InvalidName(_)
+        ));
+        // too short
+        assert!(matches!(
+            store.create("ab").unwrap_err(),
+            OrgError::InvalidName(_)
+        ));
+        // too long
+        assert!(matches!(
+            store.create(&"x".repeat(64)).unwrap_err(),
+            OrgError::InvalidName(_)
+        ));
+    }
+
+    #[test]
+    fn delete_org() {
+        let (_dir, store) = temp_store();
+        store.create("acme").unwrap();
+        store.delete("acme").unwrap();
+        assert!(store.get("acme").unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_nonexistent_fails() {
+        let (_dir, store) = temp_store();
+        let err = store.delete("ghost").unwrap_err();
+        assert!(matches!(err, OrgError::NotFound(_)));
+    }
+
+    #[test]
+    fn list_orgs() {
+        let (_dir, store) = temp_store();
+        store.create("alpha").unwrap();
+        store.create("beta").unwrap();
+        store.create("gamma").unwrap();
+
+        let orgs = store.list().unwrap();
+        assert_eq!(orgs.len(), 3);
+
+        let names: Vec<&str> = orgs.iter().map(|o| o.name.as_str()).collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"beta"));
+        assert!(names.contains(&"gamma"));
+    }
+
+    #[test]
+    fn get_nonexistent() {
+        let (_dir, store) = temp_store();
+        assert!(store.get("does-not-exist").unwrap().is_none());
+    }
+}

--- a/layers/org/src/types.rs
+++ b/layers/org/src/types.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Unique identifier for an organization.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OrgId(pub String);
+
+impl fmt::Display for OrgId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// An organization — the root tenant in the Syfrah hierarchy.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Org {
+    pub id: OrgId,
+    pub name: String,
+    pub created_at: u64,
+}

--- a/layers/org/src/validation.rs
+++ b/layers/org/src/validation.rs
@@ -1,0 +1,85 @@
+use crate::error::OrgError;
+
+/// Validate an org name.
+///
+/// Rules: lowercase alphanumeric and hyphens only, 3-63 characters.
+/// Must not start or end with a hyphen.
+pub fn validate_name(name: &str) -> Result<(), OrgError> {
+    let len = name.len();
+    if !(3..=63).contains(&len) {
+        return Err(OrgError::InvalidName(format!(
+            "name must be 3-63 characters, got {len}"
+        )));
+    }
+
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        return Err(OrgError::InvalidName(
+            "name must contain only lowercase alphanumeric characters and hyphens".to_string(),
+        ));
+    }
+
+    if name.starts_with('-') || name.ends_with('-') {
+        return Err(OrgError::InvalidName(
+            "name must not start or end with a hyphen".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_names() {
+        assert!(validate_name("acme").is_ok());
+        assert!(validate_name("my-org").is_ok());
+        assert!(validate_name("org-123").is_ok());
+        assert!(validate_name("abc").is_ok());
+        assert!(validate_name(&"a".repeat(63)).is_ok());
+    }
+
+    #[test]
+    fn too_short() {
+        assert!(validate_name("ab").is_err());
+        assert!(validate_name("a").is_err());
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn too_long() {
+        assert!(validate_name(&"a".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn uppercase_rejected() {
+        assert!(validate_name("Acme").is_err());
+        assert!(validate_name("ACME").is_err());
+        assert!(validate_name("aCmE").is_err());
+    }
+
+    #[test]
+    fn spaces_rejected() {
+        assert!(validate_name("my org").is_err());
+        assert!(validate_name(" acme").is_err());
+    }
+
+    #[test]
+    fn special_chars_rejected() {
+        assert!(validate_name("my_org").is_err());
+        assert!(validate_name("my.org").is_err());
+        assert!(validate_name("my@org").is_err());
+        assert!(validate_name("org!").is_err());
+    }
+
+    #[test]
+    fn leading_trailing_hyphen_rejected() {
+        assert!(validate_name("-acme").is_err());
+        assert!(validate_name("acme-").is_err());
+        assert!(validate_name("-acme-").is_err());
+    }
+}

--- a/tests/e2e/scenarios/200_org_crud.md
+++ b/tests/e2e/scenarios/200_org_crud.md
@@ -1,0 +1,85 @@
+# Test: Org CRUD operations
+
+## Objective
+
+- Create, list, get, and delete organizations via the CLI
+- Validate that name constraints are enforced
+- Verify persistence across operations
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is running
+- Clean state (no existing orgs)
+
+## Steps
+
+### 1. Create an organization
+
+```bash
+syfrah org create acme
+```
+
+Expected output:
+```
+Organization created: acme
+```
+
+### 2. Create a second organization
+
+```bash
+syfrah org create beta-corp
+```
+
+Expected output:
+```
+Organization created: beta-corp
+```
+
+### 3. List organizations
+
+```bash
+syfrah org list
+```
+
+Expected: both `acme` and `beta-corp` appear in the output.
+
+### 4. Reject duplicate name
+
+```bash
+syfrah org create acme
+```
+
+Expected: error indicating the org already exists. Exit code non-zero.
+
+### 5. Reject invalid names
+
+```bash
+syfrah org create "My Org"
+syfrah org create AB
+syfrah org create ORG
+```
+
+Expected: each command returns an error about an invalid org name. Exit code non-zero.
+
+### 6. Delete an organization
+
+```bash
+syfrah org delete acme
+```
+
+Expected output confirms deletion. The org no longer appears in `syfrah org list`.
+
+### 7. Delete non-existent organization
+
+```bash
+syfrah org delete acme
+```
+
+Expected: error indicating org not found. Exit code non-zero.
+
+## Pass criteria
+
+- All create/list/delete operations succeed as described
+- Invalid and duplicate names are rejected with clear error messages
+- Deleted orgs do not appear in subsequent list calls


### PR DESCRIPTION
## Summary

- Add `OrgId` newtype, `Org` struct, and `OrgError` enum to `syfrah-org`
- Implement name validation: lowercase alphanumeric + hyphens, 3-63 chars
- Add `OrgStore` with redb persistence via `syfrah-state`: create, get, list, delete with duplicate/not-found checks
- 15 unit tests covering all CRUD operations, invalid names, duplicates, and edge cases
- E2E scenario `200_org_crud.md`

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p syfrah-org` — 15/15 passing
- [x] Full workspace `cargo test` passes

Closes #713