### PR TITLE
Fix VPC attach/detach key consistency

### DIFF
--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -1426,10 +1426,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("org-persist.redb");
 
-        // First store instance: create VPC and attach
+        // First store instance: create org, VPC and attach
         {
             let db = LayerDb::open_at(&path).unwrap();
             let store = OrgStore::new(db);
+            store.create("acme").unwrap();
             store
                 .create_vpc(
                     "shared-vpc",


### PR DESCRIPTION
## Summary
- Fix misleading `project_name` parameter in `attachment_key` helper to `project_id`, matching how all callers invoke it (with `org/project` format). This prevents future misuse where someone passes a bare project name instead of the full project ID.
- Add `attach_then_detach_across_store_instances` test that reopens the redb database between attach and detach, verifying persistence across separate CLI invocations.

Closes #797

## Test plan
- [x] All 97 `syfrah-org` tests pass (including new persistence test)
- [x] Full `cargo test` passes (4 pre-existing disk-space failures in compute layer, unrelated)
- [x] `cargo clippy` clean
- [ ] CI green