### PR TITLE
Fix duplicate VNIs by making counter increment atomic

### DIFF
--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -344,12 +344,13 @@ impl OrgStore {
     }
 
     /// Allocate the next VNI. Starts at 100, monotonically increasing.
+    ///
+    /// Uses a single write transaction to read-then-increment the counter,
+    /// preventing concurrent callers from observing the same value.
     fn next_vni(&self) -> Result<u32> {
-        let current: Option<u32> = self.db.get(VNI_COUNTER_TABLE, VNI_COUNTER_KEY)?;
-        let vni = current.unwrap_or(VNI_START);
-        self.db
-            .set(VNI_COUNTER_TABLE, VNI_COUNTER_KEY, &(vni + 1))?;
-        Ok(vni)
+        Ok(self
+            .db
+            .atomic_next_counter(VNI_COUNTER_TABLE, VNI_COUNTER_KEY, VNI_START)?)
     }
 
     /// Create a VPC. Validates the name and CIDR (RFC 1918, prefix 8-28,
@@ -1195,6 +1196,27 @@ mod tests {
 
         assert_eq!(vpc1.vni, 100);
         assert_eq!(vpc2.vni, 101);
+    }
+
+    #[test]
+    fn vni_unique_and_sequential_for_five_vpcs() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+
+        let mut vnis = Vec::new();
+        for i in 0..5u8 {
+            let vpc = store
+                .create_vpc(
+                    &format!("vpc-{i}"),
+                    &format!("10.{i}.0.0/16"),
+                    VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                    false,
+                )
+                .unwrap();
+            vnis.push(vpc.vni);
+        }
+
+        assert_eq!(vnis, vec![100, 101, 102, 103, 104]);
     }
 
     #[test]

--- a/layers/state/src/lib.rs
+++ b/layers/state/src/lib.rs
@@ -333,6 +333,36 @@ impl LayerDb {
         Ok(())
     }
 
+    /// Atomically read, increment, and return a JSON-serialized counter.
+    ///
+    /// Performs the read and write in a single write transaction so concurrent
+    /// callers cannot observe the same value. Returns the value **before** the
+    /// increment (i.e. the allocated value).
+    pub fn atomic_next_counter(&self, table_name: &str, key: &str, start: u32) -> Result<u32> {
+        let table_def: TableDefinition<&str, &[u8]> = TableDefinition::new(table_name);
+
+        let write_txn = self.db.begin_write()?;
+        let current = {
+            let table = write_txn.open_table(table_def)?;
+            let access = table.get(key).map_err(StateError::Storage)?;
+            match access {
+                Some(v) => {
+                    let val: u32 = serde_json::from_slice(v.value())?;
+                    drop(v);
+                    val
+                }
+                None => start,
+            }
+        };
+        {
+            let mut table = write_txn.open_table(table_def)?;
+            let bytes = serde_json::to_vec(&(current + 1))?;
+            table.insert(key, bytes.as_slice())?;
+        }
+        write_txn.commit()?;
+        Ok(current)
+    }
+
     /// Delete the entire database file for this layer.
     pub fn destroy(layer: &str) -> Result<()> {
         let path = db_path(layer);


### PR DESCRIPTION
## Summary

- `next_vni()` was reading and writing the VNI counter in separate redb transactions, so concurrent calls could get the same VNI
- Added `LayerDb::atomic_next_counter()` that performs read-increment-write in a single write transaction
- Added unit test creating 5 VPCs and asserting VNIs are unique and sequential (100, 101, 102, 103, 104)

## Test plan

- [x] `cargo test -p syfrah-org -- vni` passes (4 tests including the new one)
- [x] `cargo clippy -p syfrah-state -p syfrah-org` clean
- [x] `cargo fmt` applied

Closes #810