### PR TITLE
Add VPC peering types and redb persistence

### DIFF
--- a/layers/org/src/error.rs
+++ b/layers/org/src/error.rs
@@ -73,6 +73,15 @@ pub enum OrgError {
     #[error("project '{project}' is not attached to vpc '{vpc}'")]
     VpcNotAttached { vpc: String, project: String },
 
+    #[error("peering already exists between '{vpc_a}' and '{vpc_b}'")]
+    PeeringAlreadyExists { vpc_a: String, vpc_b: String },
+
+    #[error("peering not found between '{vpc_a}' and '{vpc_b}'")]
+    PeeringNotFound { vpc_a: String, vpc_b: String },
+
+    #[error("cannot peer a VPC with itself: {0}")]
+    SelfPeeringRejected(String),
+
     #[error("subnet already exists: {vpc}/{subnet}")]
     SubnetAlreadyExists { vpc: String, subnet: String },
 

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -6,8 +6,8 @@ use syfrah_state::LayerDb;
 
 use crate::error::{OrgError, Result};
 use crate::types::{
-    Environment, EnvironmentId, Org, OrgId, Project, ProjectId, Subnet, SubnetId, Vpc,
-    VpcAttachment, VpcId, VpcOwner,
+    Environment, EnvironmentId, Org, OrgId, PeeringId, PeeringStatus, Project, ProjectId, Subnet,
+    SubnetId, Vpc, VpcAttachment, VpcId, VpcOwner, VpcPeering,
 };
 use crate::validation::validate_name;
 use crate::vpc::{cidrs_overlap, parse_and_validate_cidr};
@@ -18,6 +18,7 @@ const ENVIRONMENTS_TABLE: &str = "environments";
 const VPCS_TABLE: &str = "vpcs";
 const VPC_ATTACHMENTS_TABLE: &str = "vpc_attachments";
 const SUBNETS_TABLE: &str = "subnets";
+const PEERINGS_TABLE: &str = "vpc_peerings";
 const VNI_COUNTER_TABLE: &str = "vni_counter";
 const VNI_COUNTER_KEY: &str = "counter";
 const VNI_START: u32 = 100;
@@ -470,10 +471,19 @@ impl OrgStore {
             .collect())
     }
 
-    /// Delete a VPC by name.
+    /// Delete a VPC by name. Fails if it has active peerings.
     pub fn delete_vpc(&self, name: &str) -> Result<()> {
         if !self.db.exists(VPCS_TABLE, name)? {
             return Err(OrgError::VpcNotFound(name.to_string()));
+        }
+
+        // Check for active peerings
+        let peerings = self.list_peerings_by_vpc(name)?;
+        if !peerings.is_empty() {
+            return Err(OrgError::VpcHasPeerings {
+                name: name.to_string(),
+                count: peerings.len(),
+            });
         }
 
         self.db.delete(VPCS_TABLE, name)?;
@@ -798,6 +808,96 @@ impl OrgStore {
         }
         self.db.delete(SUBNETS_TABLE, &key)?;
         Ok(())
+    }
+
+    // ── VPC Peering operations ──────────────────────────────────────
+
+    /// Normalize a peering key by sorting the two VPC names alphabetically.
+    /// This ensures "A/B" and "B/A" resolve to the same peering.
+    fn peering_key(vpc_a: &str, vpc_b: &str) -> (String, String, String) {
+        let (a, b) = if vpc_a <= vpc_b {
+            (vpc_a.to_string(), vpc_b.to_string())
+        } else {
+            (vpc_b.to_string(), vpc_a.to_string())
+        };
+        let key = format!("{a}/{b}");
+        (key, a, b)
+    }
+
+    /// Create a peering between two VPCs.
+    ///
+    /// Both VPCs must exist, self-peering is rejected, and duplicate
+    /// peerings are rejected. The key is normalized so that order of
+    /// vpc_a/vpc_b does not matter.
+    pub fn create_peering(&self, vpc_a: &str, vpc_b: &str) -> Result<VpcPeering> {
+        // Reject self-peering
+        if vpc_a == vpc_b {
+            return Err(OrgError::SelfPeeringRejected(vpc_a.to_string()));
+        }
+
+        // Verify both VPCs exist
+        if !self.db.exists(VPCS_TABLE, vpc_a)? {
+            return Err(OrgError::VpcNotFound(vpc_a.to_string()));
+        }
+        if !self.db.exists(VPCS_TABLE, vpc_b)? {
+            return Err(OrgError::VpcNotFound(vpc_b.to_string()));
+        }
+
+        let (key, a, b) = Self::peering_key(vpc_a, vpc_b);
+
+        // Reject duplicate
+        if self.db.exists(PEERINGS_TABLE, &key)? {
+            return Err(OrgError::PeeringAlreadyExists { vpc_a: a, vpc_b: b });
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let peering = VpcPeering {
+            id: PeeringId(format!("peer-{key}")),
+            vpc_a: a,
+            vpc_b: b,
+            status: PeeringStatus::Active,
+            created_at: now,
+        };
+
+        self.db.set(PEERINGS_TABLE, &key, &peering)?;
+        Ok(peering)
+    }
+
+    /// Delete (remove) a peering between two VPCs.
+    pub fn delete_peering(&self, vpc_a: &str, vpc_b: &str) -> Result<()> {
+        let (key, a, b) = Self::peering_key(vpc_a, vpc_b);
+
+        if !self.db.exists(PEERINGS_TABLE, &key)? {
+            return Err(OrgError::PeeringNotFound { vpc_a: a, vpc_b: b });
+        }
+
+        self.db.delete(PEERINGS_TABLE, &key)?;
+        Ok(())
+    }
+
+    /// List all peerings.
+    pub fn list_peerings(&self) -> Result<Vec<VpcPeering>> {
+        let entries: Vec<(String, VpcPeering)> = self.db.list(PEERINGS_TABLE)?;
+        Ok(entries.into_iter().map(|(_, p)| p).collect())
+    }
+
+    /// List peerings that involve a specific VPC.
+    pub fn list_peerings_by_vpc(&self, vpc_name: &str) -> Result<Vec<VpcPeering>> {
+        let all = self.list_peerings()?;
+        Ok(all
+            .into_iter()
+            .filter(|p| p.vpc_a == vpc_name || p.vpc_b == vpc_name)
+            .collect())
+    }
+
+    /// Get a specific peering between two VPCs, if it exists.
+    pub fn get_peering(&self, vpc_a: &str, vpc_b: &str) -> Result<Option<VpcPeering>> {
+        let (key, _, _) = Self::peering_key(vpc_a, vpc_b);
+        Ok(self.db.get(PEERINGS_TABLE, &key)?)
     }
 }
 
@@ -2029,5 +2129,201 @@ mod tests {
             .create_subnet(&vpc_name, &env_id, "second", None)
             .unwrap();
         assert_eq!(subnet.cidr, "10.1.1.0/24");
+    }
+
+    // ── Peering tests ───────────────────────────────────────────────
+
+    /// Helper: create an org with two VPCs for peering tests.
+    fn setup_for_peering(store: &OrgStore) -> (String, String) {
+        store.create("acme").unwrap();
+        store.create_project("acme", "backend").unwrap();
+        let owner = VpcOwner::Project(ProjectId("acme/backend".to_string()));
+        store
+            .create_vpc("vpc-alpha", "10.1.0.0/16", owner.clone(), false)
+            .unwrap();
+        store
+            .create_vpc("vpc-beta", "10.2.0.0/16", owner, false)
+            .unwrap();
+        ("vpc-alpha".to_string(), "vpc-beta".to_string())
+    }
+
+    #[test]
+    fn create_peering_succeeds() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        let peering = store.create_peering(&a, &b).unwrap();
+        assert_eq!(peering.vpc_a, "vpc-alpha");
+        assert_eq!(peering.vpc_b, "vpc-beta");
+        assert_eq!(peering.status, PeeringStatus::Active);
+        assert!(peering.created_at > 0);
+    }
+
+    #[test]
+    fn create_peering_reverse_order_normalizes() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        // Create with reversed order
+        let peering = store.create_peering(&b, &a).unwrap();
+        // Key is normalized alphabetically
+        assert_eq!(peering.vpc_a, "vpc-alpha");
+        assert_eq!(peering.vpc_b, "vpc-beta");
+    }
+
+    #[test]
+    fn create_peering_duplicate_rejected() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+        let err = store.create_peering(&a, &b).unwrap_err();
+        assert!(matches!(err, OrgError::PeeringAlreadyExists { .. }));
+    }
+
+    #[test]
+    fn create_peering_duplicate_reversed_rejected() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+        // Reversed order should also be rejected
+        let err = store.create_peering(&b, &a).unwrap_err();
+        assert!(matches!(err, OrgError::PeeringAlreadyExists { .. }));
+    }
+
+    #[test]
+    fn create_peering_self_rejected() {
+        let (_dir, store) = temp_store();
+        let (a, _) = setup_for_peering(&store);
+
+        let err = store.create_peering(&a, &a).unwrap_err();
+        assert!(matches!(err, OrgError::SelfPeeringRejected(_)));
+    }
+
+    #[test]
+    fn create_peering_vpc_not_found() {
+        let (_dir, store) = temp_store();
+        let (a, _) = setup_for_peering(&store);
+
+        let err = store.create_peering(&a, "ghost-vpc").unwrap_err();
+        assert!(matches!(err, OrgError::VpcNotFound(_)));
+    }
+
+    #[test]
+    fn delete_peering_succeeds() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+        store.delete_peering(&a, &b).unwrap();
+
+        let result = store.get_peering(&a, &b).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn delete_peering_not_found() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        let err = store.delete_peering(&a, &b).unwrap_err();
+        assert!(matches!(err, OrgError::PeeringNotFound { .. }));
+    }
+
+    #[test]
+    fn list_peerings_returns_all() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        // Add a third VPC
+        let owner = VpcOwner::Project(ProjectId("acme/backend".to_string()));
+        store
+            .create_vpc("vpc-gamma", "10.3.0.0/16", owner, false)
+            .unwrap();
+
+        store.create_peering(&a, &b).unwrap();
+        store.create_peering(&a, "vpc-gamma").unwrap();
+
+        let peerings = store.list_peerings().unwrap();
+        assert_eq!(peerings.len(), 2);
+    }
+
+    #[test]
+    fn list_peerings_by_vpc_filters() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        let owner = VpcOwner::Project(ProjectId("acme/backend".to_string()));
+        store
+            .create_vpc("vpc-gamma", "10.3.0.0/16", owner, false)
+            .unwrap();
+
+        store.create_peering(&a, &b).unwrap();
+        store.create_peering(&a, "vpc-gamma").unwrap();
+
+        // vpc-alpha is in both peerings
+        let alpha_peerings = store.list_peerings_by_vpc(&a).unwrap();
+        assert_eq!(alpha_peerings.len(), 2);
+
+        // vpc-beta is in one peering
+        let beta_peerings = store.list_peerings_by_vpc(&b).unwrap();
+        assert_eq!(beta_peerings.len(), 1);
+
+        // vpc-gamma is in one peering
+        let gamma_peerings = store.list_peerings_by_vpc("vpc-gamma").unwrap();
+        assert_eq!(gamma_peerings.len(), 1);
+    }
+
+    #[test]
+    fn peering_status_lifecycle() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        // Create -> Active
+        let peering = store.create_peering(&a, &b).unwrap();
+        assert_eq!(peering.status, PeeringStatus::Active);
+
+        // Delete -> gone
+        store.delete_peering(&a, &b).unwrap();
+        let result = store.get_peering(&a, &b).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_peering_succeeds() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+
+        let peering = store.get_peering(&a, &b).unwrap();
+        assert!(peering.is_some());
+        let p = peering.unwrap();
+        assert_eq!(p.vpc_a, "vpc-alpha");
+        assert_eq!(p.vpc_b, "vpc-beta");
+    }
+
+    #[test]
+    fn get_peering_reversed_order() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+
+        // Reversed order should still find the peering
+        let peering = store.get_peering(&b, &a).unwrap();
+        assert!(peering.is_some());
+    }
+
+    #[test]
+    fn delete_vpc_blocked_by_peering() {
+        let (_dir, store) = temp_store();
+        let (a, b) = setup_for_peering(&store);
+
+        store.create_peering(&a, &b).unwrap();
+
+        let err = store.delete_vpc(&a).unwrap_err();
+        assert!(matches!(err, OrgError::VpcHasPeerings { .. }));
     }
 }

--- a/layers/org/src/types.rs
+++ b/layers/org/src/types.rs
@@ -130,8 +130,8 @@ pub enum PeeringStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VpcPeering {
     pub id: PeeringId,
-    pub vpc_a: VpcId,
-    pub vpc_b: VpcId,
+    pub vpc_a: String,
+    pub vpc_b: String,
     pub status: PeeringStatus,
     pub created_at: u64,
 }

--- a/layers/org/src/vpc.rs
+++ b/layers/org/src/vpc.rs
@@ -597,10 +597,11 @@ impl VpcStore {
     /// List all active peerings that reference a given VPC.
     pub fn list_active_peerings_for_vpc(&self, vpc_id: &VpcId) -> Result<Vec<VpcPeering>> {
         let all: Vec<(String, VpcPeering)> = self.db.list(PEERINGS_TABLE)?;
+        let id_str = &vpc_id.0;
         Ok(all
             .into_iter()
             .filter(|(_, p)| {
-                (p.vpc_a == *vpc_id || p.vpc_b == *vpc_id) && p.status == PeeringStatus::Active
+                (p.vpc_a == *id_str || p.vpc_b == *id_str) && p.status == PeeringStatus::Active
             })
             .map(|(_, p)| p)
             .collect())
@@ -968,8 +969,8 @@ mod tests {
     fn make_peering(vpc_a: &VpcId, vpc_b: &VpcId) -> VpcPeering {
         VpcPeering {
             id: PeeringId(format!("peer-{}-{}", vpc_a, vpc_b)),
-            vpc_a: vpc_a.clone(),
-            vpc_b: vpc_b.clone(),
+            vpc_a: vpc_a.0.clone(),
+            vpc_b: vpc_b.0.clone(),
             status: PeeringStatus::Active,
             created_at: 1000,
         }

--- a/tests/e2e/scenarios/230_vpc_peering_crud.md
+++ b/tests/e2e/scenarios/230_vpc_peering_crud.md
@@ -1,0 +1,130 @@
+# Test: VPC Peering CRUD operations
+
+## Objective
+
+- Create, list, get, and delete VPC peerings via the CLI
+- Validate that self-peering and duplicate peering are rejected
+- Verify key normalization (order of VPCs does not matter)
+- Verify that a VPC with active peerings cannot be deleted
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is running
+- Clean state (no existing orgs, VPCs, or peerings)
+
+## Steps
+
+### 1. Set up org, project, and two VPCs
+
+```bash
+syfrah org create acme
+syfrah project create backend --org acme
+syfrah vpc create hub --project backend --org acme --cidr 10.1.0.0/16
+syfrah vpc create spoke-a --project backend --org acme --cidr 10.2.0.0/16
+syfrah vpc create spoke-b --project backend --org acme --cidr 10.3.0.0/16
+```
+
+### 2. Create a peering between hub and spoke-a
+
+```bash
+syfrah vpc peer --from hub --to spoke-a
+```
+
+Expected: peering created successfully, status Active.
+
+### 3. Create a peering between hub and spoke-b
+
+```bash
+syfrah vpc peer --from hub --to spoke-b
+```
+
+Expected: peering created successfully.
+
+### 4. List all peerings
+
+```bash
+syfrah vpc peerings
+```
+
+Expected: two peerings listed (hub/spoke-a and hub/spoke-b).
+
+### 5. List peerings for a specific VPC
+
+```bash
+syfrah vpc peerings --vpc hub
+```
+
+Expected: two peerings (hub is in both).
+
+```bash
+syfrah vpc peerings --vpc spoke-a
+```
+
+Expected: one peering (hub/spoke-a only).
+
+### 6. Reject self-peering
+
+```bash
+syfrah vpc peer --from hub --to hub
+```
+
+Expected: error — cannot peer a VPC with itself.
+
+### 7. Reject duplicate peering
+
+```bash
+syfrah vpc peer --from hub --to spoke-a
+```
+
+Expected: error — peering already exists.
+
+### 8. Reject duplicate peering (reversed order)
+
+```bash
+syfrah vpc peer --from spoke-a --to hub
+```
+
+Expected: error — peering already exists (key normalization).
+
+### 9. VPC deletion blocked by active peering
+
+```bash
+syfrah vpc delete hub
+```
+
+Expected: error — VPC has active peerings, cannot delete.
+
+### 10. Delete a peering
+
+```bash
+syfrah vpc unpeer --from hub --to spoke-a
+```
+
+Expected: peering deleted successfully.
+
+### 11. Verify peering is gone
+
+```bash
+syfrah vpc peerings --vpc hub
+```
+
+Expected: one peering remaining (hub/spoke-b).
+
+### 12. Delete remaining peering and VPC
+
+```bash
+syfrah vpc unpeer --from hub --to spoke-b
+syfrah vpc delete hub
+```
+
+Expected: both succeed — hub has no more peerings.
+
+## Cleanup
+
+```bash
+syfrah vpc delete spoke-a
+syfrah vpc delete spoke-b
+syfrah project delete backend --org acme
+syfrah org delete acme
+```


### PR DESCRIPTION
## Summary

- Implements VPC peering CRUD in `syfrah-org` (Step 4 of ADR-001 networking roadmap)
- Adds `create_peering`, `delete_peering`, `list_peerings`, `list_peerings_by_vpc`, `get_peering` store methods backed by redb `vpc_peerings` table
- Key normalization: VPC names are sorted alphabetically so `peer(A,B)` and `peer(B,A)` resolve to the same entry
- Validation: self-peering rejected, duplicate peering rejected, both VPCs must exist
- VPC deletion guard: VPCs with active peerings cannot be deleted
- New error variants: `PeeringAlreadyExists`, `PeeringNotFound`, `SelfPeeringRejected`
- Updated `VpcPeering.vpc_a`/`vpc_b` from `VpcId` to `String` (VPC name) to match store conventions

## Test plan

- [x] 14 unit tests covering create, delete, list, get, key normalization, self-peering rejection, duplicate rejection, VPC-not-found, and deletion guard
- [x] All 155 org crate tests pass
- [x] `cargo clippy` clean
- [x] E2E scenario `tests/e2e/scenarios/230_vpc_peering_crud.md` added

Closes #733