### PR TITLE
feat(overlay): scaffold crate + NetworkBackend trait + mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,7 +2476,10 @@ dependencies = [
  "serde",
  "serde_json",
  "syfrah-api",
+ "syfrah-core",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/layers/overlay/Cargo.toml
+++ b/layers/overlay/Cargo.toml
@@ -9,10 +9,14 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+syfrah-core = { path = "../core" }
 syfrah-api = { path = "../api" }
 async-trait = "0.1"
+thiserror.workspace = true
+tracing.workspace = true
+tokio = { workspace = true, features = ["sync"] }
 serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["test-util", "macros", "rt"] }

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -1,0 +1,73 @@
+use crate::error::Result;
+
+/// Abstraction over Linux networking primitives (VXLAN, bridge, TAP, nftables).
+///
+/// All operations are idempotent. The real implementation shells out to
+/// `ip`, `bridge`, and `nft`; the mock records calls for testing.
+#[async_trait::async_trait]
+pub trait NetworkBackend: Send + Sync {
+    // ── VXLAN ──────────────────────────────────────────────────────────
+
+    /// Create a VXLAN interface with the given VNI, bound to `local_ip` on `port`.
+    async fn create_vxlan(&self, name: &str, vni: u32, local_ip: &str, port: u16) -> Result<()>;
+
+    /// Delete a VXLAN interface.
+    async fn delete_vxlan(&self, name: &str) -> Result<()>;
+
+    /// Add a static FDB entry so the bridge knows which VTEP hosts a given MAC.
+    async fn add_fdb_entry(&self, bridge: &str, mac: &str, vtep: &str) -> Result<()>;
+
+    /// Remove a static FDB entry.
+    async fn remove_fdb_entry(&self, bridge: &str, mac: &str) -> Result<()>;
+
+    /// Populate the ARP proxy table on a VXLAN interface.
+    async fn add_arp_proxy(&self, vxlan: &str, ip: &str, mac: &str) -> Result<()>;
+
+    // ── Bridge ─────────────────────────────────────────────────────────
+
+    /// Create a Linux bridge.
+    async fn create_bridge(&self, name: &str) -> Result<()>;
+
+    /// Add a gateway IP to a bridge (e.g. subnet gateway).
+    async fn add_bridge_ip(&self, bridge: &str, ip: &str, prefix_len: u8) -> Result<()>;
+
+    /// Remove an IP from a bridge.
+    async fn remove_bridge_ip(&self, bridge: &str, ip: &str) -> Result<()>;
+
+    /// Delete a Linux bridge.
+    async fn delete_bridge(&self, name: &str) -> Result<()>;
+
+    /// Attach a network interface to a bridge.
+    async fn attach_to_bridge(&self, interface: &str, bridge: &str) -> Result<()>;
+
+    // ── TAP / veth ─────────────────────────────────────────────────────
+
+    /// Create a TAP device (used by Cloud Hypervisor VMs).
+    async fn create_tap(&self, name: &str) -> Result<()>;
+
+    /// Delete a TAP device.
+    async fn delete_tap(&self, name: &str) -> Result<()>;
+
+    /// Create a veth pair (used by containers).
+    async fn create_veth_pair(&self, name_a: &str, name_b: &str) -> Result<()>;
+
+    // ── Firewall ───────────────────────────────────────────────────────
+
+    /// Apply anti-spoofing + default ingress/egress rules for a VM.
+    async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()>;
+
+    /// Remove all firewall rules for a VM.
+    async fn remove_vm_rules(&self, tap: &str) -> Result<()>;
+
+    /// Enable SNAT/masquerade for a subnet behind a bridge.
+    async fn apply_nat(&self, bridge: &str, subnet_cidr: &str) -> Result<()>;
+
+    /// Remove NAT rules for a subnet.
+    async fn remove_nat(&self, bridge: &str, subnet_cidr: &str) -> Result<()>;
+
+    /// Allow forwarding between two peered VPC bridges.
+    async fn apply_peering_rules(&self, bridge_a: &str, bridge_b: &str) -> Result<()>;
+
+    /// Remove peering forwarding rules.
+    async fn remove_peering_rules(&self, bridge_a: &str, bridge_b: &str) -> Result<()>;
+}

--- a/layers/overlay/src/error.rs
+++ b/layers/overlay/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+/// Errors returned by overlay networking operations.
+#[derive(Debug, Error)]
+pub enum OverlayError {
+    /// A shell/system command failed.
+    #[error("command failed: {0}")]
+    CommandFailed(String),
+
+    /// The requested network interface does not exist.
+    #[error("interface not found: {0}")]
+    InterfaceNotFound(String),
+
+    /// A firewall / nftables rule could not be applied.
+    #[error("rule application failed: {0}")]
+    RuleApplicationFailed(String),
+}
+
+pub type Result<T> = std::result::Result<T, OverlayError>;

--- a/layers/overlay/src/lib.rs
+++ b/layers/overlay/src/lib.rs
@@ -1,3 +1,9 @@
 pub mod api;
+pub mod backend;
+pub mod error;
+pub mod mock;
 
 pub use api::OverlayHandler;
+pub use backend::NetworkBackend;
+pub use error::OverlayError;
+pub use mock::MockBackend;

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -1,0 +1,228 @@
+use std::sync::Mutex;
+
+use crate::backend::NetworkBackend;
+use crate::error::Result;
+
+/// In-memory mock that records every call for test assertions.
+pub struct MockBackend {
+    calls: Mutex<Vec<String>>,
+}
+
+impl MockBackend {
+    pub fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Return a snapshot of all recorded calls.
+    pub fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("lock poisoned").clone()
+    }
+
+    /// Clear recorded calls.
+    pub fn reset(&self) {
+        self.calls.lock().expect("lock poisoned").clear();
+    }
+
+    fn record(&self, call: String) {
+        self.calls.lock().expect("lock poisoned").push(call);
+    }
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl NetworkBackend for MockBackend {
+    // ── VXLAN ──────────────────────────────────────────────────────────
+
+    async fn create_vxlan(&self, name: &str, vni: u32, local_ip: &str, port: u16) -> Result<()> {
+        self.record(format!("create_vxlan({name}, {vni}, {local_ip}, {port})"));
+        Ok(())
+    }
+
+    async fn delete_vxlan(&self, name: &str) -> Result<()> {
+        self.record(format!("delete_vxlan({name})"));
+        Ok(())
+    }
+
+    async fn add_fdb_entry(&self, bridge: &str, mac: &str, vtep: &str) -> Result<()> {
+        self.record(format!("add_fdb_entry({bridge}, {mac}, {vtep})"));
+        Ok(())
+    }
+
+    async fn remove_fdb_entry(&self, bridge: &str, mac: &str) -> Result<()> {
+        self.record(format!("remove_fdb_entry({bridge}, {mac})"));
+        Ok(())
+    }
+
+    async fn add_arp_proxy(&self, vxlan: &str, ip: &str, mac: &str) -> Result<()> {
+        self.record(format!("add_arp_proxy({vxlan}, {ip}, {mac})"));
+        Ok(())
+    }
+
+    // ── Bridge ─────────────────────────────────────────────────────────
+
+    async fn create_bridge(&self, name: &str) -> Result<()> {
+        self.record(format!("create_bridge({name})"));
+        Ok(())
+    }
+
+    async fn add_bridge_ip(&self, bridge: &str, ip: &str, prefix_len: u8) -> Result<()> {
+        self.record(format!("add_bridge_ip({bridge}, {ip}, {prefix_len})"));
+        Ok(())
+    }
+
+    async fn remove_bridge_ip(&self, bridge: &str, ip: &str) -> Result<()> {
+        self.record(format!("remove_bridge_ip({bridge}, {ip})"));
+        Ok(())
+    }
+
+    async fn delete_bridge(&self, name: &str) -> Result<()> {
+        self.record(format!("delete_bridge({name})"));
+        Ok(())
+    }
+
+    async fn attach_to_bridge(&self, interface: &str, bridge: &str) -> Result<()> {
+        self.record(format!("attach_to_bridge({interface}, {bridge})"));
+        Ok(())
+    }
+
+    // ── TAP / veth ─────────────────────────────────────────────────────
+
+    async fn create_tap(&self, name: &str) -> Result<()> {
+        self.record(format!("create_tap({name})"));
+        Ok(())
+    }
+
+    async fn delete_tap(&self, name: &str) -> Result<()> {
+        self.record(format!("delete_tap({name})"));
+        Ok(())
+    }
+
+    async fn create_veth_pair(&self, name_a: &str, name_b: &str) -> Result<()> {
+        self.record(format!("create_veth_pair({name_a}, {name_b})"));
+        Ok(())
+    }
+
+    // ── Firewall ───────────────────────────────────────────────────────
+
+    async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
+        self.record(format!("apply_vm_rules({tap}, {mac}, {ip})"));
+        Ok(())
+    }
+
+    async fn remove_vm_rules(&self, tap: &str) -> Result<()> {
+        self.record(format!("remove_vm_rules({tap})"));
+        Ok(())
+    }
+
+    async fn apply_nat(&self, bridge: &str, subnet_cidr: &str) -> Result<()> {
+        self.record(format!("apply_nat({bridge}, {subnet_cidr})"));
+        Ok(())
+    }
+
+    async fn remove_nat(&self, bridge: &str, subnet_cidr: &str) -> Result<()> {
+        self.record(format!("remove_nat({bridge}, {subnet_cidr})"));
+        Ok(())
+    }
+
+    async fn apply_peering_rules(&self, bridge_a: &str, bridge_b: &str) -> Result<()> {
+        self.record(format!("apply_peering_rules({bridge_a}, {bridge_b})"));
+        Ok(())
+    }
+
+    async fn remove_peering_rules(&self, bridge_a: &str, bridge_b: &str) -> Result<()> {
+        self.record(format!("remove_peering_rules({bridge_a}, {bridge_b})"));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_backend_records_calls() {
+        let backend = MockBackend::new();
+        backend.create_bridge("syfbr-100").await.unwrap();
+
+        let calls = backend.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], "create_bridge(syfbr-100)");
+    }
+
+    #[tokio::test]
+    async fn trait_method_coverage() {
+        let b = MockBackend::new();
+
+        b.create_vxlan("syfvx-100", 100, "fd00::1", 4789)
+            .await
+            .unwrap();
+        b.delete_vxlan("syfvx-100").await.unwrap();
+        b.add_fdb_entry("syfbr-100", "02:00:0a:01:01:03", "fd00::2")
+            .await
+            .unwrap();
+        b.remove_fdb_entry("syfbr-100", "02:00:0a:01:01:03")
+            .await
+            .unwrap();
+        b.add_arp_proxy("syfvx-100", "10.1.1.3", "02:00:0a:01:01:03")
+            .await
+            .unwrap();
+
+        b.create_bridge("syfbr-100").await.unwrap();
+        b.add_bridge_ip("syfbr-100", "10.1.1.1", 24).await.unwrap();
+        b.remove_bridge_ip("syfbr-100", "10.1.1.1").await.unwrap();
+        b.delete_bridge("syfbr-100").await.unwrap();
+        b.attach_to_bridge("syfvx-100", "syfbr-100").await.unwrap();
+
+        b.create_tap("syftap-vm1").await.unwrap();
+        b.delete_tap("syftap-vm1").await.unwrap();
+        b.create_veth_pair("syfve-a", "syfve-b").await.unwrap();
+
+        b.apply_vm_rules("syftap-vm1", "02:00:0a:01:01:03", "10.1.1.3")
+            .await
+            .unwrap();
+        b.remove_vm_rules("syftap-vm1").await.unwrap();
+        b.apply_nat("syfbr-100", "10.1.1.0/24").await.unwrap();
+        b.remove_nat("syfbr-100", "10.1.1.0/24").await.unwrap();
+        b.apply_peering_rules("syfbr-100", "syfbr-200")
+            .await
+            .unwrap();
+        b.remove_peering_rules("syfbr-100", "syfbr-200")
+            .await
+            .unwrap();
+
+        let calls = b.calls();
+        assert_eq!(calls.len(), 19, "expected one call per trait method");
+
+        // Verify each method was recorded
+        assert!(calls[0].starts_with("create_vxlan("));
+        assert!(calls[1].starts_with("delete_vxlan("));
+        assert!(calls[2].starts_with("add_fdb_entry("));
+        assert!(calls[3].starts_with("remove_fdb_entry("));
+        assert!(calls[4].starts_with("add_arp_proxy("));
+        assert!(calls[5].starts_with("create_bridge("));
+        assert!(calls[6].starts_with("add_bridge_ip("));
+        assert!(calls[7].starts_with("remove_bridge_ip("));
+        assert!(calls[8].starts_with("delete_bridge("));
+        assert!(calls[9].starts_with("attach_to_bridge("));
+        assert!(calls[10].starts_with("create_tap("));
+        assert!(calls[11].starts_with("delete_tap("));
+        assert!(calls[12].starts_with("create_veth_pair("));
+        assert!(calls[13].starts_with("apply_vm_rules("));
+        assert!(calls[14].starts_with("remove_vm_rules("));
+        assert!(calls[15].starts_with("apply_nat("));
+        assert!(calls[16].starts_with("remove_nat("));
+        assert!(calls[17].starts_with("apply_peering_rules("));
+        assert!(calls[18].starts_with("remove_peering_rules("));
+
+        // Test reset
+        b.reset();
+        assert!(b.calls().is_empty());
+    }
+}

--- a/tests/e2e/scenarios/250_overlay_scaffold.md
+++ b/tests/e2e/scenarios/250_overlay_scaffold.md
@@ -1,0 +1,53 @@
+# Test: Overlay scaffold — NetworkBackend trait and MockBackend
+
+## Objective
+
+Validate that the `syfrah-overlay` crate compiles, the `NetworkBackend` trait is
+usable as a trait object, and the `MockBackend` correctly records and resets calls.
+
+## Prerequisites
+
+- Rust toolchain installed
+- Repository cloned and workspace builds (`cargo build`)
+
+## Steps
+
+### 1. Build the overlay crate
+
+```bash
+cargo build -p syfrah-overlay
+```
+
+**Expected**: compiles without errors.
+
+### 2. Run unit tests
+
+```bash
+cargo test -p syfrah-overlay
+```
+
+**Expected**: all tests pass, including:
+- `mock_backend_records_calls`
+- `trait_method_coverage`
+- `handler_returns_not_implemented`
+
+### 3. Verify trait object safety
+
+```bash
+cargo test -p syfrah-overlay -- trait_method_coverage
+```
+
+**Expected**: the mock implements `NetworkBackend` as `Send + Sync`, all 19
+trait methods are exercised, and call recording matches expectations.
+
+### 4. Verify reset clears state
+
+Covered by `trait_method_coverage` test — after calling `reset()`, `calls()`
+returns an empty vec.
+
+## Pass criteria
+
+- Crate compiles with no warnings under `cargo clippy`
+- All three unit tests pass
+- `MockBackend` records exactly one string per trait method call
+- `reset()` clears the call log


### PR DESCRIPTION
## Summary

- Scaffolds the `syfrah-overlay` crate with dependencies on `syfrah-core`, `async-trait`, `thiserror`, `tracing`, and `tokio`
- Adds `NetworkBackend` trait with 19 async methods covering VXLAN, bridge, TAP/veth, and firewall operations
- Implements `MockBackend` with thread-safe call recording (`Vec<String>` behind `Mutex`), `calls()`, and `reset()`
- Defines `OverlayError` with `CommandFailed`, `InterfaceNotFound`, and `RuleApplicationFailed` variants
- Re-exports all public types from `lib.rs`
- Adds E2E scenario `250_overlay_scaffold.md`

## Test plan

- [x] `cargo fmt` — no formatting changes needed
- [x] `cargo clippy -p syfrah-overlay -- -D warnings` — zero warnings
- [x] `cargo test -p syfrah-overlay` — 3 tests pass:
  - `mock_backend_records_calls` — creates bridge, verifies call recorded
  - `trait_method_coverage` — exercises all 19 trait methods, verifies recording + reset
  - `handler_returns_not_implemented` — existing handler test still passes

Closes #741