### PR TITLE
Add VmPlacement type + redb persistence

### DIFF
--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod daemon;
 pub mod error;
 pub mod ipam;
+pub mod placement;
 pub mod store;
 pub mod ttl;
 pub mod types;
@@ -13,10 +14,11 @@ pub use api::OrgHandler;
 pub use cli::{EnvCommand, OrgCommand, ProjectCommand, SubnetCommand, VpcCommand};
 pub use error::OrgError;
 pub use ipam::{AllocationState, IpAllocation, IpamStore, SubnetBitmap};
+pub use placement::PlacementStore;
 pub use store::OrgStore;
 pub use types::{
-    Environment, EnvironmentId, Org, OrgId, PeeringId, PeeringStatus, Project, ProjectId, Subnet,
-    SubnetId, Vpc, VpcAttachment, VpcId, VpcOwner, VpcPeering,
+    Environment, EnvironmentId, Org, OrgId, PeeringId, PeeringStatus, PlacementAction, Project,
+    ProjectId, Subnet, SubnetId, VmPlacement, Vpc, VpcAttachment, VpcId, VpcOwner, VpcPeering,
 };
 pub use validation::validate_name;
 pub use vpc::{cidrs_overlap, parse_and_validate_cidr, validate_subnet_cidr, VpcStore};

--- a/layers/org/src/placement.rs
+++ b/layers/org/src/placement.rs
@@ -1,0 +1,72 @@
+//! VM placement persistence — tracks VM-to-node-to-subnet mapping.
+//!
+//! Backed by a redb table `vm_placements` with composite key `"{vpc_id}/{vm_id}"`.
+
+use syfrah_state::LayerDb;
+
+use crate::error::{OrgError, Result};
+use crate::types::VmPlacement;
+
+const TABLE: &str = "vm_placements";
+
+/// Persistent store for VM placements backed by redb.
+pub struct PlacementStore {
+    db: LayerDb,
+}
+
+impl PlacementStore {
+    /// Create a new `PlacementStore` with the given database handle.
+    pub fn new(db: LayerDb) -> Self {
+        Self { db }
+    }
+
+    /// Build the composite key for a placement entry.
+    fn key(vpc_id: &str, vm_id: &str) -> String {
+        format!("{vpc_id}/{vm_id}")
+    }
+
+    /// Add a VM placement record. Overwrites any existing entry for the same
+    /// vpc_id/vm_id pair.
+    pub fn add_placement(&self, placement: &VmPlacement) -> Result<()> {
+        let k = Self::key(&placement.vpc_id, &placement.vm_id);
+        self.db.set(TABLE, &k, placement)?;
+        Ok(())
+    }
+
+    /// Remove a VM placement record. Returns an error if the entry does not exist.
+    pub fn remove_placement(&self, vpc_id: &str, vm_id: &str) -> Result<()> {
+        let k = Self::key(vpc_id, vm_id);
+        let existed = self.db.delete(TABLE, &k)?;
+        if !existed {
+            return Err(OrgError::NotFound(format!("placement {vpc_id}/{vm_id}")));
+        }
+        Ok(())
+    }
+
+    /// Get a single placement by vpc_id and vm_id. Returns `None` if not found.
+    pub fn get_placement(&self, vpc_id: &str, vm_id: &str) -> Result<Option<VmPlacement>> {
+        let k = Self::key(vpc_id, vm_id);
+        Ok(self.db.get(TABLE, &k)?)
+    }
+
+    /// List all placements for a given VPC.
+    pub fn list_by_vpc(&self, vpc_id: &str) -> Result<Vec<VmPlacement>> {
+        let entries: Vec<(String, VmPlacement)> = self.db.list(TABLE)?;
+        let prefix = format!("{vpc_id}/");
+        Ok(entries
+            .into_iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, p)| p)
+            .collect())
+    }
+
+    /// List all placements hosted on a given node (fabric IPv6).
+    pub fn list_by_node(&self, hosting_node: &str) -> Result<Vec<VmPlacement>> {
+        let entries: Vec<(String, VmPlacement)> = self.db.list(TABLE)?;
+        Ok(entries
+            .into_iter()
+            .filter(|(_, p)| p.hosting_node == hosting_node)
+            .map(|(_, p)| p)
+            .collect())
+    }
+}

--- a/layers/org/src/tests.rs
+++ b/layers/org/src/tests.rs
@@ -1,15 +1,25 @@
 //! Full hierarchy integration test: Org -> Project -> Environment lifecycle.
+//! VM placement persistence tests.
 
 use std::collections::HashMap;
 
 use crate::error::OrgError;
+use crate::placement::PlacementStore;
 use crate::store::OrgStore;
+use crate::types::{PlacementAction, VmPlacement};
 
 fn temp_store() -> (tempfile::TempDir, OrgStore) {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("org-test.redb");
     let db = syfrah_state::LayerDb::open_at(&path).unwrap();
     (dir, OrgStore::new(db))
+}
+
+fn temp_placement_store() -> (tempfile::TempDir, PlacementStore) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("placement-test.redb");
+    let db = syfrah_state::LayerDb::open_at(&path).unwrap();
+    (dir, PlacementStore::new(db))
 }
 
 #[test]
@@ -121,4 +131,102 @@ fn org_project_env_lifecycle() {
         0,
         "projects should be empty"
     );
+}
+
+// ── VM Placement tests ──────────────────────────────────────────────
+
+fn make_placement(vpc: &str, vm: &str, node: &str, subnet: &str) -> VmPlacement {
+    VmPlacement {
+        vpc_id: vpc.to_string(),
+        vm_id: vm.to_string(),
+        vm_mac: format!("02:00:0a:00:01:{:02x}", vm.len()),
+        vm_ip: format!("10.0.1.{}", vm.len()),
+        subnet_id: subnet.to_string(),
+        hosting_node: node.to_string(),
+        action: PlacementAction::Add,
+        created_at: 1700000000,
+    }
+}
+
+#[test]
+fn create_placement() {
+    let (_dir, store) = temp_placement_store();
+
+    let p = make_placement("vpc-1", "vm-1", "fd00::1", "subnet-1");
+    store.add_placement(&p).unwrap();
+
+    let got = store.get_placement("vpc-1", "vm-1").unwrap();
+    assert_eq!(got, Some(p));
+}
+
+#[test]
+fn delete_placement() {
+    let (_dir, store) = temp_placement_store();
+
+    let p = make_placement("vpc-1", "vm-1", "fd00::1", "subnet-1");
+    store.add_placement(&p).unwrap();
+
+    store.remove_placement("vpc-1", "vm-1").unwrap();
+
+    let got = store.get_placement("vpc-1", "vm-1").unwrap();
+    assert!(got.is_none(), "placement should be gone after removal");
+
+    // Removing again should error.
+    let err = store.remove_placement("vpc-1", "vm-1").unwrap_err();
+    assert!(
+        matches!(err, OrgError::NotFound(_)),
+        "expected NotFound, got: {err}"
+    );
+}
+
+#[test]
+fn list_by_vpc() {
+    let (_dir, store) = temp_placement_store();
+
+    // Two VMs in vpc-1, one in vpc-2.
+    store
+        .add_placement(&make_placement("vpc-1", "vm-1", "fd00::1", "subnet-1"))
+        .unwrap();
+    store
+        .add_placement(&make_placement("vpc-1", "vm-2", "fd00::2", "subnet-1"))
+        .unwrap();
+    store
+        .add_placement(&make_placement("vpc-2", "vm-3", "fd00::1", "subnet-2"))
+        .unwrap();
+
+    let vpc1 = store.list_by_vpc("vpc-1").unwrap();
+    assert_eq!(vpc1.len(), 2, "expected 2 placements in vpc-1");
+    assert!(vpc1.iter().all(|p| p.vpc_id == "vpc-1"));
+
+    let vpc2 = store.list_by_vpc("vpc-2").unwrap();
+    assert_eq!(vpc2.len(), 1, "expected 1 placement in vpc-2");
+
+    let vpc3 = store.list_by_vpc("vpc-3").unwrap();
+    assert_eq!(vpc3.len(), 0, "expected 0 placements in vpc-3");
+}
+
+#[test]
+fn list_by_node() {
+    let (_dir, store) = temp_placement_store();
+
+    // Two VMs on node fd00::1, one on fd00::2.
+    store
+        .add_placement(&make_placement("vpc-1", "vm-1", "fd00::1", "subnet-1"))
+        .unwrap();
+    store
+        .add_placement(&make_placement("vpc-2", "vm-3", "fd00::1", "subnet-2"))
+        .unwrap();
+    store
+        .add_placement(&make_placement("vpc-1", "vm-2", "fd00::2", "subnet-1"))
+        .unwrap();
+
+    let node1 = store.list_by_node("fd00::1").unwrap();
+    assert_eq!(node1.len(), 2, "expected 2 placements on fd00::1");
+    assert!(node1.iter().all(|p| p.hosting_node == "fd00::1"));
+
+    let node2 = store.list_by_node("fd00::2").unwrap();
+    assert_eq!(node2.len(), 1, "expected 1 placement on fd00::2");
+
+    let node3 = store.list_by_node("fd00::99").unwrap();
+    assert_eq!(node3.len(), 0, "expected 0 placements on fd00::99");
 }

--- a/layers/org/src/types.rs
+++ b/layers/org/src/types.rs
@@ -158,3 +158,36 @@ pub struct Environment {
     pub created_at: u64,
     pub expires_at: Option<u64>,
 }
+
+/// Whether a VM placement is being added or removed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PlacementAction {
+    Add,
+    Remove,
+}
+
+impl fmt::Display for PlacementAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PlacementAction::Add => f.write_str("Add"),
+            PlacementAction::Remove => f.write_str("Remove"),
+        }
+    }
+}
+
+/// Tracks which node a VM is placed on, along with its network coordinates.
+///
+/// Persisted in the `vm_placements` redb table (key: "vpc_id/vm_id").
+/// Used for FDB distribution: when a VM is created or deleted, all nodes
+/// in the VPC must update their forwarding tables accordingly.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VmPlacement {
+    pub vpc_id: String,
+    pub vm_id: String,
+    pub vm_mac: String,
+    pub vm_ip: String,
+    pub subnet_id: String,
+    pub hosting_node: String,
+    pub action: PlacementAction,
+    pub created_at: u64,
+}

--- a/tests/e2e/scenarios/260_fdb_placement.md
+++ b/tests/e2e/scenarios/260_fdb_placement.md
@@ -1,0 +1,70 @@
+# Test: FDB VM placement persistence
+
+## Objective
+
+- A VM placement record can be created and retrieved
+- A VM placement record can be deleted
+- Placements can be listed by VPC (only returns entries for the queried VPC)
+- Placements can be listed by hosting node (only returns entries for the queried node)
+- Deleting a non-existent placement returns an error
+
+## Prerequisites
+
+- The `syfrah-org` crate is built
+- No daemon required (pure store tests against redb)
+
+## Steps
+
+### 1. Add a placement
+
+Create a `VmPlacement` record with action `Add` for vpc `vpc-1`, vm `vm-web-1`, MAC `02:00:0a:01:01:03`, IP `10.1.1.3`, subnet `subnet-frontend`, hosting node `fd00::1`.
+
+Store it via `PlacementStore::add_placement()`.
+
+**Expected**: `get_placement("vpc-1", "vm-web-1")` returns the stored record with all fields matching.
+
+### 2. Add additional placements
+
+Add two more placements:
+- `vpc-1 / vm-web-2` on node `fd00::2`, subnet `subnet-frontend`
+- `vpc-2 / vm-db-1` on node `fd00::1`, subnet `subnet-database`
+
+**Expected**: all three records are individually retrievable.
+
+### 3. List by VPC
+
+Call `list_by_vpc("vpc-1")`.
+
+**Expected**: returns exactly 2 placements (`vm-web-1` and `vm-web-2`), both with `vpc_id == "vpc-1"`.
+
+Call `list_by_vpc("vpc-2")`.
+
+**Expected**: returns exactly 1 placement (`vm-db-1`).
+
+### 4. List by node
+
+Call `list_by_node("fd00::1")`.
+
+**Expected**: returns exactly 2 placements (`vm-web-1` from vpc-1 and `vm-db-1` from vpc-2).
+
+Call `list_by_node("fd00::2")`.
+
+**Expected**: returns exactly 1 placement (`vm-web-2`).
+
+### 5. Remove a placement
+
+Call `remove_placement("vpc-1", "vm-web-1")`.
+
+**Expected**: succeeds. `get_placement("vpc-1", "vm-web-1")` returns `None`. `list_by_vpc("vpc-1")` returns 1 entry.
+
+### 6. Remove non-existent placement
+
+Call `remove_placement("vpc-1", "vm-web-1")` again.
+
+**Expected**: returns `NotFound` error.
+
+## Validation
+
+- All assertions pass in `cargo test -p syfrah-org`
+- `cargo clippy -p syfrah-org` reports no warnings
+- `cargo fmt -- --check` reports no formatting issues


### PR DESCRIPTION
## Summary

- Adds `PlacementAction` enum (`Add` / `Remove`) and `VmPlacement` struct to `syfrah-org` types, tracking VM-to-node-to-subnet mapping for FDB distribution (ADR-001 Step 7)
- Adds `PlacementStore` backed by redb table `vm_placements` (composite key `vpc_id/vm_id`) with `add_placement()`, `remove_placement()`, `get_placement()`, `list_by_vpc()`, `list_by_node()`
- Four unit tests: `create_placement`, `delete_placement`, `list_by_vpc`, `list_by_node`
- E2E scenario `260_fdb_placement.md`

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy -p syfrah-org` zero warnings
- [x] `cargo test -p syfrah-org` 188 tests pass (4 new)
- [x] `cargo build` full workspace compiles

Closes #751