### PR TITLE
feat(compute): display network info in vm list/get

### DIFF
--- a/layers/compute/src/cli/vm.rs
+++ b/layers/compute/src/cli/vm.rs
@@ -249,8 +249,8 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
             } else {
                 let tw = super::term_width();
                 let header = format!(
-                    "{:<20} {:<20} {:<12} {:<12} {:<6} {:<10} {:<10}",
-                    "NAME", "IMAGE", "PHASE", "RUNTIME", "vCPUs", "MEMORY", "UPTIME"
+                    "{:<20} {:<20} {:<12} {:<16} {:<12} {:<6} {:<10} {:<10}",
+                    "NAME", "IMAGE", "PHASE", "IP", "RUNTIME", "vCPUs", "MEMORY", "UPTIME"
                 );
                 if console::Term::stdout().is_term() {
                     let truncated = &header[..header.len().min(tw)];
@@ -258,7 +258,7 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
                 } else {
                     println!("{}", &header[..header.len().min(tw)]);
                 }
-                println!("{}", "-".repeat(90.min(tw)));
+                println!("{}", "-".repeat(106.min(tw)));
                 if vms.is_empty() {
                     println!("(no VMs)");
                 } else {
@@ -266,6 +266,7 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
                         let name = vm.get("id").and_then(|n| n.as_str()).unwrap_or("?");
                         let image = vm.get("image").and_then(|i| i.as_str()).unwrap_or("");
                         let phase = vm.get("phase").and_then(|p| p.as_str()).unwrap_or("?");
+                        let ip = vm.get("ip").and_then(|i| i.as_str()).unwrap_or("-");
                         let runtime = vm.get("runtime").and_then(|r| r.as_str()).unwrap_or("-");
                         let vcpus = vm.get("vcpus").and_then(|v| v.as_u64()).unwrap_or(0);
                         let memory = vm.get("memory_mb").and_then(|m| m.as_u64()).unwrap_or(0);
@@ -276,7 +277,8 @@ async fn run_list(json: bool) -> anyhow::Result<()> {
                             .unwrap_or_else(|| "-".to_string());
                         let name = super::truncate(name, 19);
                         let image = super::truncate(image, 19);
-                        let row = format!("{name:<20} {image:<20} {phase:<12} {runtime:<12} {vcpus:<6} {memory:<10} {uptime:<10}");
+                        let ip = super::truncate(ip, 15);
+                        let row = format!("{name:<20} {image:<20} {phase:<12} {ip:<16} {runtime:<12} {vcpus:<6} {memory:<10} {uptime:<10}");
                         println!("{}", &row[..row.len().min(tw)]);
                     }
                 }
@@ -327,6 +329,9 @@ async fn run_get(id: String, json: bool) -> anyhow::Result<()> {
                     .and_then(|u| u.as_u64())
                     .map(format_uptime)
                     .unwrap_or_else(|| "-".to_string());
+                let ip = v.get("ip").and_then(|i| i.as_str()).unwrap_or("-");
+                let subnet_val = v.get("subnet").and_then(|s| s.as_str()).unwrap_or("-");
+                let vpc_val = v.get("vpc").and_then(|s| s.as_str()).unwrap_or("-");
                 println!("VM Details");
                 println!("  Name:      {name}");
                 println!("  Image:     {image}");
@@ -335,6 +340,9 @@ async fn run_get(id: String, json: bool) -> anyhow::Result<()> {
                 println!("  vCPUs:     {vcpus}");
                 println!("  Memory:    {memory} MB");
                 println!("  Uptime:    {uptime}");
+                println!("  IP:        {ip}");
+                println!("  Subnet:    {subnet_val}");
+                println!("  VPC:       {vpc_val}");
             }
             Ok(())
         }

--- a/layers/compute/src/control.rs
+++ b/layers/compute/src/control.rs
@@ -123,6 +123,9 @@ fn vm_status_to_json(s: &crate::types::VmStatus) -> serde_json::Value {
         "runtime": runtime,
         "created_at": s.created_at,
         "uptime_secs": s.uptime_secs,
+        "ip": s.ip,
+        "subnet": s.subnet,
+        "vpc": s.vpc,
     })
 }
 

--- a/layers/compute/src/handler.rs
+++ b/layers/compute/src/handler.rs
@@ -116,6 +116,12 @@ pub struct VmResponse {
     pub created_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uptime_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subnet: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vpc: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -150,6 +156,9 @@ fn vm_status_to_response(s: &VmStatus) -> VmResponse {
         runtime: s.runtime.map(|r| r.to_string()),
         created_at: s.created_at,
         uptime_secs: s.uptime_secs,
+        ip: s.ip.clone(),
+        subnet: s.subnet.clone(),
+        vpc: s.vpc.clone(),
     }
 }
 
@@ -322,6 +331,9 @@ async fn stop_vm(State(mgr): State<SharedManager>, Path(id): Path<String>) -> im
                     runtime: None,
                     created_at: None,
                     uptime_secs: None,
+                    ip: None,
+                    subnet: None,
+                    vpc: None,
                 }),
             )
                 .into_response(),
@@ -651,6 +663,9 @@ mod tests {
             runtime: Some(crate::runtime_backend::RuntimeType::Vm),
             created_at: Some(1700000000),
             uptime_secs: Some(3600),
+            ip: Some("10.1.1.3".to_string()),
+            subnet: Some("frontend".to_string()),
+            vpc: Some("default".to_string()),
         };
         let resp = vm_status_to_response(&status);
         assert_eq!(resp.id, "test-vm");
@@ -659,6 +674,9 @@ mod tests {
         assert_eq!(resp.memory_mb, 8192);
         assert_eq!(resp.created_at, Some(1700000000));
         assert_eq!(resp.uptime_secs, Some(3600));
+        assert_eq!(resp.ip.as_deref(), Some("10.1.1.3"));
+        assert_eq!(resp.subnet.as_deref(), Some("frontend"));
+        assert_eq!(resp.vpc.as_deref(), Some("default"));
     }
 
     #[test]
@@ -672,6 +690,9 @@ mod tests {
             runtime: None,
             created_at: None,
             uptime_secs: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
         let resp = vm_status_to_response(&status);
         let json = serde_json::to_string(&resp).unwrap();

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -616,6 +616,9 @@ impl VmManager {
             image_name: Some(spec.image.clone()),
             instance_dir_path,
             runtime_handle: Some(handle),
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let status = state.to_status(now);
@@ -888,6 +891,9 @@ impl VmManager {
                     image_name: handle.image_name.clone(),
                     instance_dir_path: None,
                     runtime_handle: Some(handle),
+                    ip: None,
+                    subnet: None,
+                    vpc: None,
                 };
                 map.insert(id, Arc::new(Mutex::new(state)));
                 recovered_count += 1;

--- a/layers/compute/src/process.rs
+++ b/layers/compute/src/process.rs
@@ -723,6 +723,9 @@ pub(crate) async fn spawn_vm_inner(
         image_name: Some(spec.image.clone()),
         instance_dir_path: None, // Caller (spawn_vm) sets these
         runtime_handle: None,    // Caller sets from RuntimeHandle
+        ip: None,
+        subnet: None,
+        vpc: None,
     })
 }
 
@@ -1301,6 +1304,9 @@ pub async fn reconnect(base_dir: &Path, event_tx: broadcast::Sender<VmEvent>) ->
             image_name: meta.image_name.clone(),
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         events::emit(
@@ -1686,6 +1692,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1718,6 +1727,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1750,6 +1762,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1784,6 +1799,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -1994,6 +2012,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));
@@ -2132,6 +2153,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -2184,6 +2208,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -2301,6 +2328,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));

--- a/layers/compute/src/runtime.rs
+++ b/layers/compute/src/runtime.rs
@@ -46,6 +46,12 @@ pub(crate) struct VmRuntimeState {
     pub(crate) instance_dir_path: Option<PathBuf>,
     /// Handle returned by the runtime backend that created this workload.
     pub(crate) runtime_handle: Option<RuntimeHandle>,
+    /// IP address assigned to the VM (e.g. "10.1.1.3").
+    pub(crate) ip: Option<String>,
+    /// Subnet the VM belongs to (e.g. "frontend").
+    pub(crate) subnet: Option<String>,
+    /// VPC the VM belongs to (e.g. "default").
+    pub(crate) vpc: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -88,6 +94,9 @@ impl VmRuntimeState {
             runtime: self.runtime_handle.as_ref().map(|h| h.runtime_type),
             created_at: Some(self.launched_at),
             uptime_secs,
+            ip: self.ip.clone(),
+            subnet: self.subnet.clone(),
+            vpc: self.vpc.clone(),
         }
     }
 }
@@ -114,6 +123,9 @@ mod tests {
             image_name: None,
             instance_dir_path: None,
             runtime_handle: None,
+            ip: None,
+            subnet: None,
+            vpc: None,
         }
     }
 

--- a/layers/compute/src/types.rs
+++ b/layers/compute/src/types.rs
@@ -110,6 +110,15 @@ pub struct VmStatus {
     pub created_at: Option<u64>,
     /// Seconds the VM has been running. `None` if not in the `Running` phase.
     pub uptime_secs: Option<u64>,
+    /// IP address assigned to the VM (e.g. "10.1.1.3").
+    #[serde(default)]
+    pub ip: Option<String>,
+    /// Subnet the VM belongs to (e.g. "frontend").
+    #[serde(default)]
+    pub subnet: Option<String>,
+    /// VPC the VM belongs to (e.g. "default").
+    #[serde(default)]
+    pub vpc: Option<String>,
 }
 
 /// Observable events emitted to forge via a broadcast channel.
@@ -280,6 +289,9 @@ mod tests {
             runtime: Some(RuntimeType::Vm),
             created_at: Some(1700000000),
             uptime_secs: Some(3600),
+            ip: None,
+            subnet: None,
+            vpc: None,
         };
         let json = serde_json::to_string(&status).unwrap();
         let back: VmStatus = serde_json::from_str(&json).unwrap();
@@ -369,5 +381,84 @@ mod tests {
         let spec: VmSpec = serde_json::from_str(json).unwrap();
         assert!(spec.ssh_key.is_none());
         assert!(spec.disk_size_mb.is_none());
+    }
+
+    #[test]
+    fn vm_list_shows_ip() {
+        let status = VmStatus {
+            vm_id: VmId("web-1".to_string()),
+            phase: VmPhase::Running,
+            vcpus: 2,
+            memory_mb: 2048,
+            image: Some("alpine-3.20".to_string()),
+            runtime: None,
+            created_at: Some(1700000000),
+            uptime_secs: Some(60),
+            ip: Some("10.1.1.3".to_string()),
+            subnet: Some("frontend".to_string()),
+            vpc: Some("default".to_string()),
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["ip"].as_str(), Some("10.1.1.3"));
+    }
+
+    #[test]
+    fn vm_get_shows_subnet() {
+        let status = VmStatus {
+            vm_id: VmId("db-1".to_string()),
+            phase: VmPhase::Running,
+            vcpus: 4,
+            memory_mb: 8192,
+            image: Some("ubuntu-24.04".to_string()),
+            runtime: None,
+            created_at: Some(1700000000),
+            uptime_secs: Some(3600),
+            ip: Some("10.1.2.3".to_string()),
+            subnet: Some("database".to_string()),
+            vpc: Some("default".to_string()),
+        };
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["subnet"].as_str(), Some("database"));
+    }
+
+    #[test]
+    fn vm_get_json_has_network_fields() {
+        let status = VmStatus {
+            vm_id: VmId("web-2".to_string()),
+            phase: VmPhase::Running,
+            vcpus: 2,
+            memory_mb: 2048,
+            image: Some("alpine-3.20".to_string()),
+            runtime: None,
+            created_at: Some(1700000000),
+            uptime_secs: Some(120),
+            ip: Some("10.1.1.4".to_string()),
+            subnet: Some("frontend".to_string()),
+            vpc: Some("prod-vpc".to_string()),
+        };
+        let json_str = serde_json::to_string(&status).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(json["ip"].as_str(), Some("10.1.1.4"));
+        assert_eq!(json["subnet"].as_str(), Some("frontend"));
+        assert_eq!(json["vpc"].as_str(), Some("prod-vpc"));
+    }
+
+    #[test]
+    fn vm_status_without_network_fields_deserializes() {
+        // Backward compatibility: JSON without ip/subnet/vpc should deserialize
+        let json = r#"{
+            "vm_id": "vm-old",
+            "phase": "Running",
+            "vcpus": 2,
+            "memory_mb": 1024,
+            "image": "alpine",
+            "runtime": null,
+            "created_at": 1700000000,
+            "uptime_secs": 60
+        }"#;
+        let status: VmStatus = serde_json::from_str(json).unwrap();
+        assert!(status.ip.is_none());
+        assert!(status.subnet.is_none());
+        assert!(status.vpc.is_none());
     }
 }

--- a/tests/e2e/scenarios/282_vm_network_display.md
+++ b/tests/e2e/scenarios/282_vm_network_display.md
@@ -1,0 +1,52 @@
+# 282 — VM network info in list/get output
+
+## Goal
+
+Verify that `vm list` and `vm get` display network information (IP, subnet, VPC)
+when present, and gracefully show placeholders when absent.
+
+## Preconditions
+
+- Daemon is running (`syfrah fabric init --name test-mesh`)
+- At least one VM exists (networking fields may be empty until overlay integration)
+
+## Steps
+
+### 1. List VMs — IP column present
+
+```bash
+syfrah compute vm list
+```
+
+**Expected**: Output table includes an `IP` column header between `PHASE` and `RUNTIME`.
+
+### 2. Get VM details — Subnet field present
+
+```bash
+syfrah compute vm get <vm-name>
+```
+
+**Expected**: Detail output includes `IP:`, `Subnet:`, and `VPC:` lines. When no
+network is configured the values show `-`.
+
+### 3. JSON output includes network fields
+
+```bash
+syfrah compute vm get <vm-name> --json
+```
+
+**Expected**: JSON output contains `"ip"`, `"subnet"`, and `"vpc"` keys. Values are
+`null` when no network is configured.
+
+### 4. List JSON includes network fields
+
+```bash
+syfrah compute vm list --json
+```
+
+**Expected**: Each VM object in the JSON array contains `"ip"`, `"subnet"`, and
+`"vpc"` keys.
+
+## Teardown
+
+None required — read-only validation of display output.


### PR DESCRIPTION
## Summary

- Add `ip`, `subnet`, `vpc` fields to `VmStatus`, `VmRuntimeState`, and `VmResponse`
- Add IP column to `vm list` table output
- Add IP, Subnet, VPC lines to `vm get` detail view
- Include `ip`, `subnet`, `vpc` in JSON output (both CLI and REST API)
- Add unit tests: `vm_list_shows_ip`, `vm_get_shows_subnet`, `vm_get_json_has_network_fields`, backward compat
- Add E2E scenario `282_vm_network_display.md`

Implements Step 9 display requirements from ADR-001.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] `cargo test -p syfrah-compute` all pass
- [x] New tests verify IP/subnet/VPC fields serialize correctly
- [x] Backward compatibility: VmStatus without network fields deserializes

Closes #759