### PR TITLE
Add E2E test prompts for networking scenarios

### DIFF
--- a/tests/e2e/scenarios/284_vm_ssh.md
+++ b/tests/e2e/scenarios/284_vm_ssh.md
@@ -1,0 +1,69 @@
+# 284 — SSH into VM
+
+## Goal
+Verify the full lifecycle: create org/project/env/subnet/VM with an SSH key,
+obtain the allocated IP from output, SSH in, run a command, and verify output.
+
+## Prerequisites
+- Syfrah daemon running with fabric mesh initialized
+- Image `alpine-3.20` available locally
+- SSH key pair at `~/.ssh/id_ed25519` / `~/.ssh/id_ed25519.pub`
+- No pre-existing org hierarchy (test creates everything)
+
+## Steps
+
+### 1. Create org hierarchy
+```bash
+syfrah org create acme
+syfrah org project create backend --org acme
+syfrah org env create production --project backend --org acme
+syfrah org vpc create default --cidr 10.0.0.0/16 --env production --project backend --org acme
+syfrah org subnet create frontend --cidr 10.0.1.0/24 --vpc default --env production --project backend --org acme
+```
+**Expected**: each command succeeds with confirmation output.
+
+### 2. Create VM with SSH key
+```bash
+syfrah compute vm create --name ssh-test --image alpine-3.20 \
+  --subnet frontend --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created, output includes allocated IP (e.g. `10.0.1.3`).
+
+### 3. Verify VM is running
+```bash
+syfrah compute vm get ssh-test
+```
+**Expected**: phase = `Running`, IP field shows allocated address.
+
+### 4. SSH into the VM
+```bash
+ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 root@10.0.1.3 "hostname"
+```
+**Expected**: prints the VM hostname (e.g. `ssh-test`).
+
+### 5. Run a command inside the VM
+```bash
+ssh root@10.0.1.3 "uname -a && ip addr show eth0"
+```
+**Expected**:
+- `uname` shows Linux kernel info
+- `eth0` has IP `10.0.1.3/24`
+
+### 6. Verify DNS resolution inside VM
+```bash
+ssh root@10.0.1.3 "cat /etc/resolv.conf"
+```
+**Expected**: nameserver entries for `8.8.8.8` and `1.1.1.1`.
+
+### 7. Cleanup
+```bash
+syfrah compute vm delete ssh-test
+```
+**Expected**: VM deleted, TAP interface removed, IP released.
+
+## Pass criteria
+- SSH connection succeeds on first attempt (within 30s timeout)
+- Command output is received correctly
+- Network configuration inside VM matches expected values
+- Cleanup leaves no orphaned resources

--- a/tests/e2e/scenarios/285_vm_cross_subnet_ping.md
+++ b/tests/e2e/scenarios/285_vm_cross_subnet_ping.md
@@ -1,0 +1,75 @@
+# 285 — Cross-subnet ping (same VPC, same node)
+
+## Goal
+Verify that two VMs in different subnets of the same VPC can communicate
+via bridge routing on a single node.
+
+## Prerequisites
+- Syfrah daemon running
+- Image `alpine-3.20` available locally
+- Org hierarchy: org `acme`, project `backend`, env `production`
+- VPC `default` with CIDR `10.0.0.0/16` and VNI 100
+
+## Steps
+
+### 1. Create two subnets in the same VPC
+```bash
+syfrah org subnet create frontend --cidr 10.0.1.0/24 --vpc default --env production --project backend --org acme
+syfrah org subnet create backend-net --cidr 10.0.2.0/24 --vpc default --env production --project backend --org acme
+```
+**Expected**: both subnets created successfully.
+
+### 2. Create VM in first subnet
+```bash
+syfrah compute vm create --name web-1 --image alpine-3.20 \
+  --subnet frontend --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.0.1.3`.
+
+### 3. Create VM in second subnet
+```bash
+syfrah compute vm create --name api-1 --image alpine-3.20 \
+  --subnet backend-net --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.0.2.3`.
+
+### 4. Verify both VMs share the same bridge
+```bash
+ip link show syfbr-vpc-default
+bridge link show | grep syftap
+```
+**Expected**: both `syftap-web-1` and `syftap-api-1` attached to `syfbr-vpc-default`.
+
+### 5. Ping from web-1 to api-1
+```bash
+ssh root@10.0.1.3 "ping -c 3 -W 5 10.0.2.3"
+```
+**Expected**: 3 packets transmitted, 3 received, 0% packet loss.
+
+### 6. Ping from api-1 to web-1
+```bash
+ssh root@10.0.2.3 "ping -c 3 -W 5 10.0.1.3"
+```
+**Expected**: 3 packets transmitted, 3 received, 0% packet loss.
+
+### 7. Verify routing inside VMs
+```bash
+ssh root@10.0.1.3 "ip route show"
+ssh root@10.0.2.3 "ip route show"
+```
+**Expected**: default route via respective subnet gateways (`10.0.1.1`, `10.0.2.1`).
+
+### 8. Cleanup
+```bash
+syfrah compute vm delete web-1
+syfrah compute vm delete api-1
+```
+**Expected**: both VMs deleted, TAPs removed, IPs released.
+
+## Pass criteria
+- Bidirectional ping succeeds between VMs in different subnets
+- Both VMs share the same VPC bridge
+- Routing tables correctly configured inside each VM
+- No packet loss on ping

--- a/tests/e2e/scenarios/286_vm_vpc_isolation.md
+++ b/tests/e2e/scenarios/286_vm_vpc_isolation.md
@@ -1,0 +1,79 @@
+# 286 — VPC isolation
+
+## Goal
+Verify that VMs in different VPCs CANNOT communicate with each other.
+Different VNIs means traffic stays isolated on separate bridges.
+
+## Prerequisites
+- Syfrah daemon running
+- Image `alpine-3.20` available locally
+- Org hierarchy: org `acme`, project `backend`, env `production`
+
+## Steps
+
+### 1. Create two separate VPCs
+```bash
+syfrah org vpc create vpc-alpha --cidr 10.1.0.0/16 --env production --project backend --org acme
+syfrah org vpc create vpc-beta --cidr 10.2.0.0/16 --env production --project backend --org acme
+```
+**Expected**: two VPCs with different VNIs created.
+
+### 2. Create subnets in each VPC
+```bash
+syfrah org subnet create net-a --cidr 10.1.1.0/24 --vpc vpc-alpha --env production --project backend --org acme
+syfrah org subnet create net-b --cidr 10.2.1.0/24 --vpc vpc-beta --env production --project backend --org acme
+```
+**Expected**: subnets created in their respective VPCs.
+
+### 3. Create VM in VPC alpha
+```bash
+syfrah compute vm create --name alpha-vm --image alpine-3.20 \
+  --subnet net-a --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.1.1.3`.
+
+### 4. Create VM in VPC beta
+```bash
+syfrah compute vm create --name beta-vm --image alpine-3.20 \
+  --subnet net-b --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.2.1.3`.
+
+### 5. Verify separate bridges
+```bash
+ip link show syfbr-vpc-alpha
+ip link show syfbr-vpc-beta
+```
+**Expected**: two distinct bridges, each with its own VXLAN and TAP.
+
+### 6. Attempt ping from alpha to beta (must FAIL)
+```bash
+ssh root@10.1.1.3 "ping -c 3 -W 3 10.2.1.3"
+```
+**Expected**: 100% packet loss. Ping MUST fail — no connectivity between VPCs.
+
+### 7. Attempt ping from beta to alpha (must FAIL)
+```bash
+ssh root@10.2.1.3 "ping -c 3 -W 3 10.1.1.3"
+```
+**Expected**: 100% packet loss. No route between VPCs.
+
+### 8. Verify nftables isolation
+```bash
+nft list ruleset | grep -E "syfbr-vpc-(alpha|beta)"
+```
+**Expected**: no forwarding rules between the two VPC bridges.
+
+### 9. Cleanup
+```bash
+syfrah compute vm delete alpha-vm
+syfrah compute vm delete beta-vm
+```
+
+## Pass criteria
+- Ping between VPCs fails with 100% packet loss
+- Each VPC has its own isolated bridge and VXLAN
+- No cross-VPC forwarding rules in nftables
+- This test PASSES when connectivity FAILS (isolation is the feature)

--- a/tests/e2e/scenarios/287_vm_internet_egress.md
+++ b/tests/e2e/scenarios/287_vm_internet_egress.md
@@ -1,0 +1,71 @@
+# 287 — Internet egress via SNAT
+
+## Goal
+Verify that a VM can access the internet via SNAT masquerade through the
+host's network. The overlay NAT rule should masquerade outbound traffic
+from the subnet CIDR.
+
+## Prerequisites
+- Syfrah daemon running on a node with internet access
+- Image `alpine-3.20` available locally
+- Org hierarchy with VPC and subnet configured
+- Host has IP forwarding enabled (`sysctl net.ipv4.ip_forward=1`)
+
+## Steps
+
+### 1. Create VM with networking
+```bash
+syfrah compute vm create --name egress-test --image alpine-3.20 \
+  --subnet frontend --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP in the subnet range.
+
+### 2. Verify NAT rules on host
+```bash
+nft list ruleset | grep masquerade
+```
+**Expected**: masquerade rule for subnet CIDR (e.g. `10.0.1.0/24`).
+
+### 3. Verify IP forwarding
+```bash
+sysctl net.ipv4.ip_forward
+```
+**Expected**: `net.ipv4.ip_forward = 1`.
+
+### 4. Test DNS resolution from inside VM
+```bash
+ssh root@10.0.1.3 "nslookup example.com"
+```
+**Expected**: DNS resolves successfully via `8.8.8.8` or `1.1.1.1`.
+
+### 5. Test HTTP egress
+```bash
+ssh root@10.0.1.3 "wget -q -O /dev/null -T 10 http://example.com && echo OK"
+```
+**Expected**: prints `OK` — HTTP request succeeds through NAT.
+
+### 6. Test HTTPS egress
+```bash
+ssh root@10.0.1.3 "wget -q -O /dev/null -T 10 https://example.com && echo OK"
+```
+**Expected**: prints `OK` — HTTPS works through NAT.
+
+### 7. Verify source IP is masqueraded
+From the VM, check the outbound source:
+```bash
+ssh root@10.0.1.3 "wget -q -O - https://ifconfig.me"
+```
+**Expected**: returns the host's public IP, NOT the VM's private IP.
+
+### 8. Cleanup
+```bash
+syfrah compute vm delete egress-test
+```
+**Expected**: VM deleted, NAT rules remain (other VMs may use them).
+
+## Pass criteria
+- VM can resolve DNS
+- VM can reach external HTTP and HTTPS endpoints
+- Outbound traffic is masqueraded through the host's public IP
+- No direct exposure of VM private IP to the internet

--- a/tests/e2e/scenarios/288_vm_peered_vpcs.md
+++ b/tests/e2e/scenarios/288_vm_peered_vpcs.md
@@ -1,0 +1,79 @@
+# 288 — Peered VPCs connectivity
+
+## Goal
+Verify that two VPCs can communicate after being peered. VPC peering
+adds forwarding rules between the two bridges, allowing cross-VPC traffic.
+
+## Prerequisites
+- Syfrah daemon running
+- Image `alpine-3.20` available locally
+- Org hierarchy: org `acme`, project `backend`, env `production`
+
+## Steps
+
+### 1. Create two VPCs
+```bash
+syfrah org vpc create vpc-web --cidr 10.10.0.0/16 --env production --project backend --org acme
+syfrah org vpc create vpc-db --cidr 10.20.0.0/16 --env production --project backend --org acme
+```
+**Expected**: two VPCs created with different VNIs.
+
+### 2. Create subnets
+```bash
+syfrah org subnet create web-net --cidr 10.10.1.0/24 --vpc vpc-web --env production --project backend --org acme
+syfrah org subnet create db-net --cidr 10.20.1.0/24 --vpc vpc-db --env production --project backend --org acme
+```
+
+### 3. Create VMs in each VPC
+```bash
+syfrah compute vm create --name web-srv --image alpine-3.20 \
+  --subnet web-net --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+
+syfrah compute vm create --name db-srv --image alpine-3.20 \
+  --subnet db-net --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VMs created in their respective subnets.
+
+### 4. Verify isolation BEFORE peering
+```bash
+ssh root@10.10.1.3 "ping -c 2 -W 3 10.20.1.3"
+```
+**Expected**: ping FAILS (100% packet loss) — VPCs are isolated.
+
+### 5. Peer the two VPCs
+```bash
+syfrah org vpc peer vpc-web vpc-db --env production --project backend --org acme
+```
+**Expected**: peering established, forwarding rules applied.
+
+### 6. Verify forwarding rules
+```bash
+nft list ruleset | grep -E "syfbr-vpc-(web|db)"
+```
+**Expected**: bidirectional forwarding rules between `syfbr-vpc-web` and `syfbr-vpc-db`.
+
+### 7. Ping from web to db AFTER peering
+```bash
+ssh root@10.10.1.3 "ping -c 3 -W 5 10.20.1.3"
+```
+**Expected**: 3 packets transmitted, 3 received, 0% packet loss.
+
+### 8. Ping from db to web AFTER peering
+```bash
+ssh root@10.20.1.3 "ping -c 3 -W 5 10.10.1.3"
+```
+**Expected**: bidirectional connectivity works.
+
+### 9. Cleanup
+```bash
+syfrah compute vm delete web-srv
+syfrah compute vm delete db-srv
+```
+
+## Pass criteria
+- No connectivity between VPCs before peering
+- Full bidirectional connectivity after peering
+- Forwarding rules present in nftables after peering
+- Peering is symmetric (both directions work)

--- a/tests/e2e/scenarios/289_vm_hub_spoke_isolation.md
+++ b/tests/e2e/scenarios/289_vm_hub_spoke_isolation.md
@@ -1,0 +1,92 @@
+# 289 — Hub and spoke isolation
+
+## Goal
+Verify hub-and-spoke VPC topology: spokes can reach the hub but CANNOT
+reach each other. Peering is NOT transitive.
+
+## Prerequisites
+- Syfrah daemon running
+- Image `alpine-3.20` available locally
+- Org hierarchy: org `acme`, project `infra`, env `production`
+
+## Steps
+
+### 1. Create three VPCs (hub + 2 spokes)
+```bash
+syfrah org vpc create hub --cidr 10.100.0.0/16 --env production --project infra --org acme
+syfrah org vpc create spoke-a --cidr 10.101.0.0/16 --env production --project infra --org acme
+syfrah org vpc create spoke-b --cidr 10.102.0.0/16 --env production --project infra --org acme
+```
+
+### 2. Create subnets in each VPC
+```bash
+syfrah org subnet create hub-net --cidr 10.100.1.0/24 --vpc hub --env production --project infra --org acme
+syfrah org subnet create spoke-a-net --cidr 10.101.1.0/24 --vpc spoke-a --env production --project infra --org acme
+syfrah org subnet create spoke-b-net --cidr 10.102.1.0/24 --vpc spoke-b --env production --project infra --org acme
+```
+
+### 3. Create VMs
+```bash
+syfrah compute vm create --name hub-vm --image alpine-3.20 \
+  --subnet hub-net --env production --project infra --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+
+syfrah compute vm create --name spoke-a-vm --image alpine-3.20 \
+  --subnet spoke-a-net --env production --project infra --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+
+syfrah compute vm create --name spoke-b-vm --image alpine-3.20 \
+  --subnet spoke-b-net --env production --project infra --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+
+### 4. Peer hub with each spoke
+```bash
+syfrah org vpc peer hub spoke-a --env production --project infra --org acme
+syfrah org vpc peer hub spoke-b --env production --project infra --org acme
+```
+**Expected**: two peerings created. No peering between spoke-a and spoke-b.
+
+### 5. Verify spoke-a can reach hub
+```bash
+ssh root@10.101.1.3 "ping -c 3 -W 5 10.100.1.3"
+```
+**Expected**: ping succeeds, 0% packet loss.
+
+### 6. Verify spoke-b can reach hub
+```bash
+ssh root@10.102.1.3 "ping -c 3 -W 5 10.100.1.3"
+```
+**Expected**: ping succeeds, 0% packet loss.
+
+### 7. Verify hub can reach both spokes
+```bash
+ssh root@10.100.1.3 "ping -c 3 -W 5 10.101.1.3"
+ssh root@10.100.1.3 "ping -c 3 -W 5 10.102.1.3"
+```
+**Expected**: both pings succeed.
+
+### 8. Verify spoke-a CANNOT reach spoke-b (critical)
+```bash
+ssh root@10.101.1.3 "ping -c 3 -W 3 10.102.1.3"
+```
+**Expected**: 100% packet loss. Peering is NOT transitive.
+
+### 9. Verify spoke-b CANNOT reach spoke-a (critical)
+```bash
+ssh root@10.102.1.3 "ping -c 3 -W 3 10.101.1.3"
+```
+**Expected**: 100% packet loss.
+
+### 10. Cleanup
+```bash
+syfrah compute vm delete hub-vm
+syfrah compute vm delete spoke-a-vm
+syfrah compute vm delete spoke-b-vm
+```
+
+## Pass criteria
+- Spoke-to-hub connectivity works in both directions
+- Spoke-to-spoke connectivity FAILS (no transitive peering)
+- This is a SECURITY test: spoke isolation is critical
+- Steps 8 and 9 are the most important — they MUST fail

--- a/tests/e2e/scenarios/290_vm_shared_vpc.md
+++ b/tests/e2e/scenarios/290_vm_shared_vpc.md
@@ -1,0 +1,85 @@
+# 290 — Shared VPC cross-project
+
+## Goal
+Verify that a shared VPC at the org level can be attached to multiple
+projects, and VMs in different projects can communicate within the
+shared VPC.
+
+## Prerequisites
+- Syfrah daemon running
+- Image `alpine-3.20` available locally
+- Org `acme` created
+
+## Steps
+
+### 1. Create two projects
+```bash
+syfrah org project create team-alpha --org acme
+syfrah org project create team-beta --org acme
+```
+
+### 2. Create environments in each project
+```bash
+syfrah org env create staging --project team-alpha --org acme
+syfrah org env create staging --project team-beta --org acme
+```
+
+### 3. Create a shared VPC at the org level
+```bash
+syfrah org vpc create shared-infra --cidr 10.50.0.0/16 --shared --org acme
+```
+**Expected**: shared VPC created, accessible by all projects in the org.
+
+### 4. Attach the shared VPC to both projects
+```bash
+syfrah org vpc attach shared-infra --project team-alpha --org acme
+syfrah org vpc attach shared-infra --project team-beta --org acme
+```
+
+### 5. Create subnets in the shared VPC for each project
+```bash
+syfrah org subnet create alpha-net --cidr 10.50.1.0/24 --vpc shared-infra --env staging --project team-alpha --org acme
+syfrah org subnet create beta-net --cidr 10.50.2.0/24 --vpc shared-infra --env staging --project team-beta --org acme
+```
+
+### 6. Create VMs in each project
+```bash
+syfrah compute vm create --name alpha-vm --image alpine-3.20 \
+  --subnet alpha-net --env staging --project team-alpha --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+
+syfrah compute vm create --name beta-vm --image alpine-3.20 \
+  --subnet beta-net --env staging --project team-beta --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: both VMs on the same VPC bridge despite being in different projects.
+
+### 7. Verify same bridge
+```bash
+bridge link show | grep -E "syftap-(alpha|beta)-vm"
+```
+**Expected**: both TAPs attached to the same `syfbr-vpc-shared-infra` bridge.
+
+### 8. Ping from alpha to beta
+```bash
+ssh root@10.50.1.3 "ping -c 3 -W 5 10.50.2.3"
+```
+**Expected**: ping succeeds — shared VPC allows cross-project communication.
+
+### 9. Ping from beta to alpha
+```bash
+ssh root@10.50.2.3 "ping -c 3 -W 5 10.50.1.3"
+```
+**Expected**: bidirectional connectivity works.
+
+### 10. Cleanup
+```bash
+syfrah compute vm delete alpha-vm
+syfrah compute vm delete beta-vm
+```
+
+## Pass criteria
+- VMs in different projects share the same VPC bridge
+- Cross-project ping succeeds within the shared VPC
+- Shared VPC is accessible from both projects
+- Subnet isolation within the shared VPC works correctly

--- a/tests/e2e/scenarios/291_vm_cross_node_vxlan.md
+++ b/tests/e2e/scenarios/291_vm_cross_node_vxlan.md
@@ -1,0 +1,111 @@
+# 291 — Multi-node cross-AZ over VXLAN
+
+## Goal
+Verify that VMs on different nodes in the same subnet can communicate
+over the VXLAN/WireGuard tunnel. This tests the full overlay stack:
+VXLAN encapsulation, FDB entries, ARP proxy, and WireGuard transport.
+
+## Prerequisites
+- Two nodes (`node-1`, `node-2`) in a WireGuard fabric mesh
+- Both nodes running the Syfrah daemon
+- Image `alpine-3.20` available on both nodes
+- Org hierarchy with VPC and subnet configured on both nodes
+- Fabric mesh verified: `syfrah fabric peers` shows both nodes
+
+## Steps
+
+### 1. Verify fabric mesh
+```bash
+# On node-1:
+syfrah fabric peers
+```
+**Expected**: `node-2` listed as a peer with status `Connected`.
+
+### 2. Create VM on node-1
+```bash
+# On node-1:
+syfrah compute vm create --name vm-node1 --image alpine-3.20 \
+  --subnet frontend --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.0.1.3` on node-1.
+
+### 3. Create VM on node-2
+```bash
+# On node-2:
+syfrah compute vm create --name vm-node2 --image alpine-3.20 \
+  --subnet frontend --env production --project backend --org acme \
+  --vcpus 1 --memory 1024 --ssh-key ~/.ssh/id_ed25519.pub
+```
+**Expected**: VM created with IP `10.0.1.4` on node-2.
+
+### 4. Verify VXLAN tunnels on both nodes
+```bash
+# On node-1:
+ip link show syfvx-vpc-default
+bridge fdb show dev syfvx-vpc-default | grep -v 00:00:00:00:00:00
+```
+**Expected**: VXLAN interface exists, FDB entry for node-2's VTEP IP.
+
+```bash
+# On node-2:
+ip link show syfvx-vpc-default
+bridge fdb show dev syfvx-vpc-default | grep -v 00:00:00:00:00:00
+```
+**Expected**: VXLAN interface exists, FDB entry for node-1's VTEP IP.
+
+### 5. Verify ARP proxy entries
+```bash
+# On node-1:
+ip neigh show dev syfvx-vpc-default
+```
+**Expected**: ARP proxy entry for `10.0.1.4` (node-2's VM) with its MAC.
+
+### 6. Ping from node-1 VM to node-2 VM
+```bash
+ssh root@10.0.1.3 "ping -c 5 -W 10 10.0.1.4"
+```
+**Expected**: 5 packets transmitted, 5 received, 0% packet loss.
+Latency should include WireGuard + VXLAN overhead.
+
+### 7. Ping from node-2 VM to node-1 VM
+```bash
+ssh root@10.0.1.4 "ping -c 5 -W 10 10.0.1.3"
+```
+**Expected**: bidirectional connectivity over VXLAN tunnel.
+
+### 8. Verify traffic path (optional)
+```bash
+# On node-1, capture VXLAN traffic:
+tcpdump -i wg0 -c 10 udp port 4789
+```
+While running ping from step 6. **Expected**: VXLAN-encapsulated packets
+visible on the WireGuard interface.
+
+### 9. Test MTU
+```bash
+ssh root@10.0.1.3 "ping -c 1 -s 1300 -M do 10.0.1.4"
+```
+**Expected**: succeeds (MTU 1350 accommodates 1300 + headers).
+
+```bash
+ssh root@10.0.1.3 "ping -c 1 -s 1400 -M do 10.0.1.4"
+```
+**Expected**: fails (exceeds VXLAN MTU after encapsulation overhead).
+
+### 10. Cleanup
+```bash
+# On node-1:
+syfrah compute vm delete vm-node1
+# On node-2:
+syfrah compute vm delete vm-node2
+```
+**Expected**: VMs deleted, FDB entries and ARP proxy entries removed on both nodes.
+
+## Pass criteria
+- Cross-node ping succeeds with 0% packet loss
+- VXLAN encapsulation verified via FDB entries
+- ARP proxy correctly resolves remote VM MACs
+- MTU is respected (1350 overlay MTU)
+- FDB entries cleaned up on VM deletion
+- This test requires a real 2-node setup — cannot be run on a single node


### PR DESCRIPTION
## Summary
- Creates 8 E2E test scenario files for server integration testing of the networking stack
- Covers SSH, cross-subnet ping, VPC isolation, internet egress, VPC peering, hub-spoke isolation, shared VPCs, and multi-node VXLAN
- These are manual test prompts for execution on a test server when the full stack is deployed

Closes #761 #762 #763 #764 #765 #766 #767 #768

## Test plan
- [x] Files follow existing E2E scenario format (goal, prerequisites, steps, pass criteria)
- [ ] Server testing to be done when full stack is deployed