### PR TITLE
Wire NetworkSetup into VmManager create_vm and delete_vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,6 +2427,8 @@ dependencies = [
  "syfrah-api",
  "syfrah-compute",
  "syfrah-core",
+ "syfrah-org",
+ "syfrah-overlay",
  "syfrah-state",
  "tempfile",
  "terminal_size",

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -11,12 +11,16 @@ use crate::events;
 use crate::image::store::ImageStore;
 use crate::image::types::{ImageCatalog, PullPolicy};
 use crate::network::{NetworkCleanup, NetworkInfo};
+use crate::network_setup::NetworkSetup;
 use crate::process;
 use crate::runtime::VmRuntimeState;
 use crate::runtime_backend::{ComputeRuntime, RuntimeSpec};
 use crate::runtime_ch;
 use crate::types::{VmEvent, VmId, VmSpec, VmStatus};
 
+use syfrah_org::ipam::IpamStore;
+use syfrah_org::store::OrgStore;
+use syfrah_org::PlacementStore;
 use syfrah_overlay::NetworkBackend;
 
 // ---------------------------------------------------------------------------
@@ -222,6 +226,14 @@ pub struct VmManager {
     /// Callback to remove a VmPlacement from the placement store. Args: (vpc_id, vm_id).
     /// If None, placement removal is skipped.
     placement_remover: Option<PlacementRemover>,
+    /// Org store for subnet/VPC resolution (shared with NetworkSetup).
+    org_store: Option<Arc<OrgStore>>,
+    /// IPAM store for IP allocation (shared with NetworkSetup).
+    ipam_store: Option<Arc<IpamStore>>,
+    /// Placement store for VM placement tracking (shared with NetworkSetup).
+    placement_store: Option<Arc<PlacementStore>>,
+    /// This node's fabric IPv6 address (for VXLAN local IP and placement).
+    local_node: Option<String>,
 }
 
 impl VmManager {
@@ -288,6 +300,10 @@ impl VmManager {
             bridge_vm_counter: None,
             ipam_releaser: None,
             placement_remover: None,
+            org_store: None,
+            ipam_store: None,
+            placement_store: None,
+            local_node: None,
         })
     }
 
@@ -309,6 +325,24 @@ impl VmManager {
         self.bridge_vm_counter = Some(bridge_vm_counter);
         self.ipam_releaser = Some(ipam_releaser);
         self.placement_remover = Some(placement_remover);
+    }
+
+    /// Set the network setup dependencies for VM creation.
+    ///
+    /// When these are set, `create_vm()` will run the full network setup
+    /// (IPAM allocation, bridge/VXLAN/TAP creation, nftables, NAT) for VMs
+    /// that have a `subnet` in their spec.
+    pub fn set_network_setup(
+        &mut self,
+        org_store: Arc<OrgStore>,
+        ipam_store: Arc<IpamStore>,
+        placement_store: Arc<PlacementStore>,
+        local_node: String,
+    ) {
+        self.org_store = Some(org_store);
+        self.ipam_store = Some(ipam_store);
+        self.placement_store = Some(placement_store);
+        self.local_node = Some(local_node);
     }
 
     /// Set the image catalog (e.g., after fetching from a remote endpoint).
@@ -428,6 +462,53 @@ impl VmManager {
                     .expect("at least one config error"),
             )
         })?;
+
+        // -- Network setup (IPAM, bridge, VXLAN, TAP, nftables, NAT) ----------
+        // Run before image management so cloud-init can include network config.
+        let mut network_result: Option<crate::network_setup::NetworkSetupResult> = None;
+        if let Some(ref subnet_info) = spec.subnet {
+            if let (
+                Some(ref org_store),
+                Some(ref ipam_store),
+                Some(ref placement_store),
+                Some(ref backend),
+                Some(ref local_node),
+            ) = (
+                &self.org_store,
+                &self.ipam_store,
+                &self.placement_store,
+                &self.network_backend,
+                &self.local_node,
+            ) {
+                let subnet_name = subnet_info.name.clone();
+                let ns = NetworkSetup::new(
+                    Arc::clone(org_store),
+                    Arc::clone(ipam_store),
+                    Arc::clone(placement_store),
+                    Arc::clone(backend),
+                    local_node.clone(),
+                );
+                match ns.setup(&vm_id_str, &subnet_name).await {
+                    Ok(result) => {
+                        info!(
+                            vm_id = %vm_id_str,
+                            ip = %result.ip,
+                            tap = %result.tap_name,
+                            "network setup complete"
+                        );
+                        network_result = Some(result);
+                    }
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            } else {
+                warn!(
+                    vm_id = %vm_id_str,
+                    "subnet specified but network setup dependencies not configured"
+                );
+            }
+        }
 
         // -- Image management (pull, clone, cloud-init) -----------------------
         // These steps stay in the manager; only the final spawn goes through
@@ -563,16 +644,21 @@ impl VmManager {
                 };
 
                 // Generate cloud-init (if applicable)
-                if image_meta.cloud_init && spec.ssh_key.is_some() {
+                let has_ssh = spec.ssh_key.is_some();
+                let has_network = network_result.is_some();
+                if image_meta.cloud_init && (has_ssh || has_network) {
+                    let ci_network = network_result
+                        .as_ref()
+                        .map(|nr| nr.cloud_init_network.clone());
                     let cloud_config = CloudInitConfig {
                         hostname: vm_id_str.clone(),
-                        ssh_authorized_keys: vec![spec.ssh_key.clone().unwrap()],
+                        ssh_authorized_keys: spec.ssh_key.clone().into_iter().collect(),
                         default_user: image_meta
                             .default_username
                             .clone()
                             .unwrap_or_else(|| "ubuntu".to_string()),
                         users: vec![],
-                        network_config: None,
+                        network_config: ci_network,
                         user_data_extra: None,
                     };
                     match disk::generate_cloud_init(&cloud_config, &inst_dir, &instance_id) {
@@ -622,12 +708,22 @@ impl VmManager {
             self.config.image_dir.join(format!("{}.raw", spec.image))
         };
 
+        // If network setup produced a TAP, use it as the network config.
+        let network = if let Some(ref nr) = network_result {
+            Some(crate::types::NetworkConfig {
+                tap_name: nr.tap_name.clone(),
+                mac: Some(nr.mac.clone()),
+            })
+        } else {
+            spec.network.clone()
+        };
+
         let runtime_spec = RuntimeSpec {
             vcpus: spec.vcpus,
             memory_mb: spec.memory_mb,
             rootfs_path,
             cloud_init_path,
-            network: spec.network.clone(),
+            network,
             gpu: spec.gpu.clone(),
             image_name: Some(spec.image.clone()),
         };
@@ -639,12 +735,80 @@ impl VmManager {
                 if let Some(ref p) = instance_dir_path {
                     let _ = std::fs::remove_dir_all(p);
                 }
+                // Rollback network setup on runtime failure.
+                if let Some(ref nr) = network_result {
+                    if let (
+                        Some(ref org_store),
+                        Some(ref ipam_store),
+                        Some(ref placement_store),
+                        Some(ref backend),
+                        Some(ref local_node),
+                    ) = (
+                        &self.org_store,
+                        &self.ipam_store,
+                        &self.placement_store,
+                        &self.network_backend,
+                        &self.local_node,
+                    ) {
+                        let ns = NetworkSetup::new(
+                            Arc::clone(org_store),
+                            Arc::clone(ipam_store),
+                            Arc::clone(placement_store),
+                            Arc::clone(backend),
+                            local_node.clone(),
+                        );
+                        if let Err(te) = ns
+                            .teardown(
+                                &vm_id_str,
+                                &nr.placement.vpc_id,
+                                &nr.placement.subnet_id,
+                                &nr.subnet_cidr,
+                                &nr.ip,
+                                &nr.tap_name,
+                            )
+                            .await
+                        {
+                            warn!(
+                                vm_id = %vm_id_str,
+                                error = %te,
+                                "failed to rollback network setup after runtime failure"
+                            );
+                        }
+                    }
+                }
                 return Err(e);
             }
         };
 
         // -- Build VmRuntimeState from the RuntimeHandle ----------------------
         let now = now_unix();
+
+        // Extract network metadata from setup result for runtime state.
+        let (vm_ip, vm_subnet, vm_vpc, net_info) = if let Some(ref nr) = network_result {
+            let info = NetworkInfo {
+                vpc_id: nr.placement.vpc_id.clone(),
+                subnet_id: nr.placement.subnet_id.clone(),
+                subnet_cidr: nr.subnet_cidr.clone(),
+                ip: nr.ip.clone(),
+                mac: nr.mac.clone(),
+                tap_name: nr.tap_name.clone(),
+                hosting_node: nr.placement.hosting_node.clone(),
+            };
+            (
+                Some(nr.ip.clone()),
+                Some(
+                    spec.subnet
+                        .as_ref()
+                        .map(|s| s.name.clone())
+                        .unwrap_or_default(),
+                ),
+                Some(nr.placement.vpc_id.clone()),
+                Some(info),
+            )
+        } else {
+            (None, None, None, None)
+        };
+
         let state = crate::runtime::VmRuntimeState {
             vm_id: spec.id.clone(),
             pid: handle.pid,
@@ -663,10 +827,10 @@ impl VmManager {
             image_name: Some(spec.image.clone()),
             instance_dir_path,
             runtime_handle: Some(handle),
-            ip: None,
-            subnet: None,
-            vpc: None,
-            network_info: None,
+            ip: vm_ip,
+            subnet: vm_subnet,
+            vpc: vm_vpc,
+            network_info: net_info,
         };
 
         let status = state.to_status(now);
@@ -676,6 +840,38 @@ impl VmManager {
         {
             let mut map = self.vms.write().await;
             map.insert(vm_id_str.clone(), Arc::new(Mutex::new(state)));
+        }
+
+        // Mark IPAM allocation as assigned now that the VM is booted.
+        if let Some(ref nr) = network_result {
+            if let (
+                Some(ref org_store),
+                Some(ref ipam_store),
+                Some(ref placement_store),
+                Some(ref backend),
+                Some(ref local_node),
+            ) = (
+                &self.org_store,
+                &self.ipam_store,
+                &self.placement_store,
+                &self.network_backend,
+                &self.local_node,
+            ) {
+                let ns = NetworkSetup::new(
+                    Arc::clone(org_store),
+                    Arc::clone(ipam_store),
+                    Arc::clone(placement_store),
+                    Arc::clone(backend),
+                    local_node.clone(),
+                );
+                if let Err(e) = ns.mark_assigned(&nr.placement.subnet_id, &nr.ip, &vm_id_str) {
+                    warn!(
+                        vm_id = %vm_id_str,
+                        error = %e,
+                        "failed to mark IPAM allocation as assigned (non-fatal)"
+                    );
+                }
+            }
         }
 
         // Increment image refcount.

--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -59,7 +59,7 @@ pub struct NetworkSetupResult {
 ///
 /// Holds references to the org store, IPAM store, placement store, and the
 /// network backend. Designed to be called from `VmManager::create_vm()`.
-pub struct NetworkSetup<B: NetworkBackend> {
+pub struct NetworkSetup<B: NetworkBackend + ?Sized> {
     org_store: Arc<OrgStore>,
     ipam_store: Arc<IpamStore>,
     placement_store: Arc<PlacementStore>,
@@ -68,7 +68,7 @@ pub struct NetworkSetup<B: NetworkBackend> {
     local_node: String,
 }
 
-impl<B: NetworkBackend> NetworkSetup<B> {
+impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
     /// Create a new `NetworkSetup` with the given dependencies.
     pub fn new(
         org_store: Arc<OrgStore>,

--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -11,6 +11,8 @@ categories.workspace = true
 [dependencies]
 syfrah-core = { path = "../core" }
 syfrah-compute = { path = "../compute" }
+syfrah-org = { path = "../org" }
+syfrah-overlay = { path = "../overlay" }
 syfrah-state = { path = "../state" }
 syfrah-api = { path = "../api" }
 wireguard-control = "1.7"

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1002,7 +1002,90 @@ pub async fn run_daemon(
     {
         let compute_config = syfrah_compute::ComputeConfig::default();
         match syfrah_compute::VmManager::new(compute_config) {
-            Ok(vm_manager) => {
+            Ok(mut vm_manager) => {
+                // Wire networking into VmManager: open org/ipam/placement stores
+                // and create the LinuxBackend for overlay operations.
+                let net_ok = match (
+                    syfrah_state::LayerDb::open("org"),
+                    syfrah_state::LayerDb::open("ipam"),
+                    syfrah_state::LayerDb::open("placement"),
+                ) {
+                    (Ok(org_db), Ok(ipam_db), Ok(placement_db)) => {
+                        let org_store = Arc::new(syfrah_org::store::OrgStore::new(org_db));
+                        let ipam_store = Arc::new(syfrah_org::ipam::IpamStore::new(ipam_db));
+                        let placement_store =
+                            Arc::new(syfrah_org::PlacementStore::new(placement_db));
+                        let backend: Arc<dyn syfrah_overlay::NetworkBackend> =
+                            Arc::new(syfrah_overlay::LinuxBackend::new());
+                        let local_node = my_record.mesh_ipv6.to_string();
+
+                        // Set up network cleanup callbacks for VM delete.
+                        let ipam_for_release = Arc::clone(&ipam_store);
+                        let placement_for_remove = Arc::clone(&placement_store);
+                        let placement_for_counter = Arc::clone(&placement_store);
+
+                        #[allow(clippy::type_complexity)]
+                        let bridge_counter: Arc<
+                            dyn Fn(&str, &str) -> usize + Send + Sync,
+                        > = {
+                            Arc::new(move |vpc_id, vm_id| {
+                                placement_for_counter
+                                    .list_by_vpc(vpc_id)
+                                    .unwrap_or_default()
+                                    .iter()
+                                    .filter(|p| p.vm_id != vm_id)
+                                    .count()
+                            })
+                        };
+                        #[allow(clippy::type_complexity)]
+                        let ipam_releaser: Arc<
+                            dyn Fn(&str, &str, &str) -> Result<(), String> + Send + Sync,
+                        > = Arc::new(move |subnet_id, subnet_cidr, ip| {
+                            ipam_for_release
+                                .release_ip(subnet_id, subnet_cidr, ip)
+                                .map_err(|e| e.to_string())
+                        });
+                        #[allow(clippy::type_complexity)]
+                        let placement_remover: Arc<
+                            dyn Fn(&str, &str) -> Result<(), String> + Send + Sync,
+                        > = Arc::new(move |vpc_id, vm_id| {
+                            placement_for_remove
+                                .remove_placement(vpc_id, vm_id)
+                                .map_err(|e| e.to_string())
+                        });
+
+                        vm_manager.set_network(
+                            Arc::clone(&backend),
+                            bridge_counter,
+                            ipam_releaser,
+                            placement_remover,
+                        );
+                        vm_manager.set_network_setup(
+                            org_store,
+                            ipam_store,
+                            placement_store,
+                            local_node,
+                        );
+
+                        info!("compute: networking wired (IPAM, bridge, VXLAN, TAP, nftables)");
+                        true
+                    }
+                    (org_res, ipam_res, placement_res) => {
+                        if let Err(e) = org_res {
+                            warn!("compute: failed to open org store: {e}");
+                        }
+                        if let Err(e) = ipam_res {
+                            warn!("compute: failed to open ipam store: {e}");
+                        }
+                        if let Err(e) = placement_res {
+                            warn!("compute: failed to open placement store: {e}");
+                        }
+                        warn!("compute: networking not available (store init failed)");
+                        false
+                    }
+                };
+                let _ = net_ok;
+
                 let vm_manager = Arc::new(vm_manager);
 
                 // Reconnect VMs that survived a daemon restart.


### PR DESCRIPTION
## Summary

- Integrates overlay networking (IPAM, bridge, VXLAN, TAP, nftables, NAT) into the VM creation lifecycle via `NetworkSetup.setup()`
- When `spec.subnet` is set, `create_vm()` allocates an IP, creates network infrastructure, passes TAP and cloud-init network config to the runtime, and marks the IPAM allocation as Assigned after boot
- On runtime failure, all network resources are rolled back (IP released, TAP deleted, placement removed)
- Daemon startup initializes OrgStore, IpamStore, PlacementStore, and LinuxBackend, wiring them into VmManager for both creation and deletion paths

## Test plan

- [x] All existing tests pass (`cargo test -p syfrah-compute`, `-p syfrah-org`, `-p syfrah-overlay`, `-p syfrah-fabric`)
- [x] All 10 `network_setup` tests pass (including rollback, teardown, cloud-init config)
- [x] `cargo fmt` and `cargo clippy` clean
- [ ] Deploy to test server: `syfrah org create acme && syfrah project create backend --org acme && syfrah env create production --project backend --org acme && syfrah subnet create frontend --env production --project backend --org acme`
- [ ] Create VM with subnet: `syfrah compute vm create --name web-1 --image alpine-3.20 --vcpus 1 --memory 512 --subnet frontend --project backend --org acme --ssh-key ~/.ssh/id_ed25519.pub`
- [ ] Verify `syfrah compute vm get web-1` shows IP, subnet, VPC
- [ ] Verify `ip link show | grep syf` shows bridge + TAP

Closes #848