### PR TITLE
Fix redb lock contention: route org CLI through daemon control socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ dependencies = [
  "async-trait",
  "clap",
  "console",
+ "dirs",
  "ipnet",
  "serde",
  "serde_json",

--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -939,11 +939,11 @@ async fn run() -> Result<()> {
             }
         },
         Commands::Compute { command } => syfrah_compute::cli::run(command).await,
-        Commands::Org { command } => syfrah_org::cli::run(command),
-        Commands::Project { command } => syfrah_org::cli::run_project(command),
-        Commands::Env { command } => syfrah_org::cli::run_env(command),
-        Commands::Vpc { command } => syfrah_org::cli::run_vpc(command),
-        Commands::Subnet { command } => syfrah_org::cli::run_subnet(command),
+        Commands::Org { command } => syfrah_org::cli::run(command).await,
+        Commands::Project { command } => syfrah_org::cli::run_project(command).await,
+        Commands::Env { command } => syfrah_org::cli::run_env(command).await,
+        Commands::Vpc { command } => syfrah_org::cli::run_vpc(command).await,
+        Commands::Subnet { command } => syfrah_org::cli::run_subnet(command).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             let mut buf = Vec::new();

--- a/layers/api/src/router.rs
+++ b/layers/api/src/router.rs
@@ -17,6 +17,8 @@ pub enum LayerRequest {
     Fabric(Vec<u8>),
     /// Request destined for the Compute layer.
     Compute(Vec<u8>),
+    /// Request destined for the Org layer.
+    Org(Vec<u8>),
 }
 
 /// Top-level response envelope returned to the client.
@@ -26,6 +28,8 @@ pub enum LayerResponse {
     Fabric(Vec<u8>),
     /// Response originating from the Compute layer.
     Compute(Vec<u8>),
+    /// Response originating from the Org layer.
+    Org(Vec<u8>),
     /// The requested layer is not registered in the router.
     UnknownLayer(String),
 }
@@ -70,6 +74,13 @@ impl LayerRouter {
                     LayerResponse::Compute(handler.handle(payload, caller_uid).await)
                 } else {
                     LayerResponse::UnknownLayer("compute".into())
+                }
+            }
+            LayerRequest::Org(payload) => {
+                if let Some(handler) = self.handlers.get("org") {
+                    LayerResponse::Org(handler.handle(payload, caller_uid).await)
+                } else {
+                    LayerResponse::UnknownLayer("org".into())
                 }
             }
         }

--- a/layers/compute/src/cli/vm.rs
+++ b/layers/compute/src/cli/vm.rs
@@ -184,21 +184,20 @@ pub(crate) fn normalize_disk_size(disk_size: Option<u32>) -> Option<u32> {
     }
 }
 
-/// Resolve a subnet for VM placement.
+/// Resolve a subnet for VM placement via the daemon's control socket.
 ///
 /// - If `--subnet` is given, look up that specific subnet in the environment.
 /// - If `--subnet` is NOT given but `--env/--project/--org` are, look up all
 ///   subnets in the environment. If exactly 1, use it. If 0 or 2+, error.
 /// - If none of the org context flags are given, returns `None` (no subnet).
-fn resolve_subnet(
+async fn resolve_subnet(
     subnet_name: Option<String>,
     env: Option<String>,
     project: Option<String>,
     org: Option<String>,
 ) -> anyhow::Result<Option<SubnetInfo>> {
-    // If no org context flags at all, skip subnet resolution
-    let (env_name, project_name, org_name) = match (&env, &project, &org) {
-        (Some(e), Some(p), Some(o)) => (e.as_str(), p.as_str(), o.as_str()),
+    // Validate argument completeness locally (no daemon needed)
+    match (&env, &project, &org) {
         (None, None, None) => {
             if subnet_name.is_some() {
                 anyhow::bail!(
@@ -207,69 +206,38 @@ fn resolve_subnet(
             }
             return Ok(None);
         }
+        (Some(_), Some(_), Some(_)) => { /* ok, proceed to daemon */ }
         _ => {
             anyhow::bail!("--env, --project, and --org must all be specified together");
         }
+    }
+
+    let req = syfrah_org::OrgRequest::SubnetResolve {
+        subnet_name,
+        env,
+        project,
+        org,
     };
+    let resp = syfrah_org::send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "cannot reach the syfrah daemon — is it running?\n\n\
+                 Error: {e}"
+            )
+        })?;
 
-    let env_id = syfrah_org::EnvironmentId(format!("{org_name}/{project_name}/{env_name}"));
-
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org database: {e}"))?;
-    let store = syfrah_org::OrgStore::new(db);
-
-    let subnets = store
-        .list_subnets_by_env(&env_id)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    match subnet_name {
-        Some(name) => {
-            // Look for the specific subnet by name
-            let subnet = subnets
-                .into_iter()
-                .find(|s| s.name == name)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "subnet '{name}' not found in environment '{env_name}'. \
-                         Create one with: syfrah subnet create {name} --env {env_name} --project {project_name} --org {org_name}"
-                    )
-                })?;
-            Ok(Some(SubnetInfo {
-                name: subnet.name,
-                cidr: subnet.cidr,
-                gateway: subnet.gateway,
-                vpc_id: subnet.vpc_id.0,
-                env_id: subnet.env_id.0,
-            }))
-        }
-        None => {
-            // Auto-select: must have exactly 1 subnet
-            match subnets.len() {
-                0 => {
-                    anyhow::bail!(
-                        "no subnet found for environment '{env_name}'. \
-                         Create one with: syfrah subnet create <name> --env {env_name} --project {project_name} --org {org_name}"
-                    );
-                }
-                1 => {
-                    let subnet = subnets.into_iter().next().unwrap();
-                    Ok(Some(SubnetInfo {
-                        name: subnet.name,
-                        cidr: subnet.cidr,
-                        gateway: subnet.gateway,
-                        vpc_id: subnet.vpc_id.0,
-                        env_id: subnet.env_id.0,
-                    }))
-                }
-                _ => {
-                    let names: Vec<&str> = subnets.iter().map(|s| s.name.as_str()).collect();
-                    anyhow::bail!(
-                        "environment '{env_name}' has multiple subnets: {}. Specify --subnet",
-                        names.join(", ")
-                    );
-                }
-            }
-        }
+    match resp {
+        syfrah_org::OrgResponse::SubnetResolved(None) => Ok(None),
+        syfrah_org::OrgResponse::SubnetResolved(Some(resolved)) => Ok(Some(SubnetInfo {
+            name: resolved.name,
+            cidr: resolved.cidr,
+            gateway: resolved.gateway,
+            vpc_id: resolved.vpc_id,
+            env_id: resolved.env_id,
+        })),
+        syfrah_org::OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
 }
 
@@ -295,7 +263,7 @@ async fn run_create(
     let disk_size_mb = normalize_disk_size(disk_size);
 
     // Resolve subnet if org/project/env context is provided
-    let subnet = resolve_subnet(subnet_name, env, project, org)?;
+    let subnet = resolve_subnet(subnet_name, env, project, org).await?;
 
     let req = ComputeRequest::CreateVm {
         name,
@@ -1060,10 +1028,10 @@ mod tests {
 
     // -- Subnet resolution tests ---------------------------------------------
 
-    #[test]
-    fn subnet_requires_org_context() {
+    #[tokio::test]
+    async fn subnet_requires_org_context() {
         // --subnet without --env/--project/--org should error
-        let result = resolve_subnet(Some("frontend".to_string()), None, None, None);
+        let result = resolve_subnet(Some("frontend".to_string()), None, None, None).await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1072,10 +1040,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn subnet_partial_org_context_errors() {
+    #[tokio::test]
+    async fn subnet_partial_org_context_errors() {
         // Only --env without --project/--org should error
-        let result = resolve_subnet(None, Some("production".to_string()), None, None);
+        let result = resolve_subnet(None, Some("production".to_string()), None, None).await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1084,10 +1052,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn subnet_none_when_no_context() {
+    #[tokio::test]
+    async fn subnet_none_when_no_context() {
         // No flags at all should return Ok(None)
-        let result = resolve_subnet(None, None, None, None);
+        let result = resolve_subnet(None, None, None, None).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -995,6 +995,31 @@ pub async fn run_daemon(
     let mut router = LayerRouter::new();
     router.register("fabric", Arc::new(fabric_layer_handler));
 
+    // -- Org layer integration -----------------------------------------------
+    //
+    // Open the org database once and share it between the org control handler
+    // and the compute layer. This avoids the redb exclusive-lock contention
+    // that previously prevented CLI commands from accessing org.redb while the
+    // daemon was running.
+    let shared_org_store: Option<Arc<syfrah_org::OrgStore>> =
+        match syfrah_state::LayerDb::open("org") {
+            Ok(org_db) => {
+                let store = Arc::new(syfrah_org::OrgStore::new(org_db));
+
+                // Register the org layer handler so CLI org/project/env/vpc/subnet
+                // commands are routed through the daemon's control socket.
+                let org_handler = syfrah_org::OrgLayerHandler::new(Arc::clone(&store));
+                router.register("org", Arc::new(org_handler));
+
+                info!("org layer initialised");
+                Some(store)
+            }
+            Err(e) => {
+                warn!("org layer init failed (non-fatal): {e}");
+                None
+            }
+        };
+
     // -- Compute layer integration ------------------------------------------
     //
     // Initialise VmManager, reconnect existing VMs, start the monitor loop,
@@ -1003,15 +1028,14 @@ pub async fn run_daemon(
         let compute_config = syfrah_compute::ComputeConfig::default();
         match syfrah_compute::VmManager::new(compute_config) {
             Ok(mut vm_manager) => {
-                // Wire networking into VmManager: open org/ipam/placement stores
-                // and create the LinuxBackend for overlay operations.
+                // Wire networking into VmManager: reuse the shared org store
+                // and open ipam/placement stores.
                 let net_ok = match (
-                    syfrah_state::LayerDb::open("org"),
+                    shared_org_store.clone(),
                     syfrah_state::LayerDb::open("ipam"),
                     syfrah_state::LayerDb::open("placement"),
                 ) {
-                    (Ok(org_db), Ok(ipam_db), Ok(placement_db)) => {
-                        let org_store = Arc::new(syfrah_org::store::OrgStore::new(org_db));
+                    (Some(org_store), Ok(ipam_db), Ok(placement_db)) => {
                         let ipam_store = Arc::new(syfrah_org::ipam::IpamStore::new(ipam_db));
                         let placement_store =
                             Arc::new(syfrah_org::PlacementStore::new(placement_db));
@@ -1071,8 +1095,8 @@ pub async fn run_daemon(
                         true
                     }
                     (org_res, ipam_res, placement_res) => {
-                        if let Err(e) = org_res {
-                            warn!("compute: failed to open org store: {e}");
+                        if org_res.is_none() {
+                            warn!("compute: org store not available");
                         }
                         if let Err(e) = ipam_res {
                             warn!("compute: failed to open ipam store: {e}");

--- a/layers/org/Cargo.toml
+++ b/layers/org/Cargo.toml
@@ -13,6 +13,7 @@ syfrah-api = { path = "../api" }
 syfrah-state = { path = "../state" }
 async-trait = "0.1"
 clap = { version = "4", features = ["derive"] }
+dirs = "6"
 console = "0.15"
 serde.workspace = true
 serde_json.workspace = true

--- a/layers/org/src/api.rs
+++ b/layers/org/src/api.rs
@@ -1,16 +1,601 @@
-use syfrah_api::handler::LayerHandler;
+//! Control socket types for the org layer.
+//!
+//! Follows the same pattern as `syfrah_compute::control`:
+//! - `OrgRequest` / `OrgResponse` are the typed messages
+//! - `OrgLayerHandler` adapts an `OrgStore` to the opaque `LayerHandler` trait
+//! - `send_org_request` is the client-side helper used by CLI commands
 
-/// Empty handler — implementation pending.
-pub struct OrgHandler;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use syfrah_api::handler::LayerHandler;
+use syfrah_api::{LayerRequest, LayerResponse};
+use tokio::net::UnixStream;
+
+use crate::store::OrgStore;
+use crate::types::{
+    Environment, EnvironmentId, Org, OrgId, PeeringStatus, Project, ProjectId, Subnet, Vpc,
+    VpcOwner, VpcPeering,
+};
+
+// ---------------------------------------------------------------------------
+// Request / Response enums
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum OrgRequest {
+    // -- Org --
+    OrgCreate {
+        name: String,
+    },
+    OrgList,
+    OrgDelete {
+        name: String,
+    },
+
+    // -- Project --
+    ProjectCreate {
+        name: String,
+        org: String,
+    },
+    ProjectList {
+        org: Option<String>,
+    },
+    ProjectDelete {
+        name: String,
+        org: String,
+    },
+
+    // -- Environment --
+    EnvCreate {
+        name: String,
+        project: String,
+        org: String,
+        ttl: Option<u64>,
+        deletion_protection: bool,
+        labels: HashMap<String, String>,
+    },
+    EnvList {
+        project: Option<String>,
+        org: Option<String>,
+    },
+    EnvDestroy {
+        name: String,
+        project: String,
+        org: String,
+    },
+    EnvExtend {
+        name: String,
+        project: String,
+        org: String,
+        ttl_seconds: u64,
+    },
+    EnvUpdate {
+        name: String,
+        project: String,
+        org: String,
+        deletion_protection: Option<bool>,
+    },
+
+    // -- VPC --
+    VpcCreate {
+        name: String,
+        org: String,
+        project: Option<String>,
+        shared: bool,
+        cidr: Option<String>,
+    },
+    VpcList {
+        org: Option<String>,
+        project: Option<String>,
+    },
+    VpcDelete {
+        name: String,
+    },
+    VpcAttach {
+        vpc: String,
+        project: String,
+    },
+    VpcDetach {
+        vpc: String,
+        project: String,
+    },
+    VpcPeer {
+        from: String,
+        to: String,
+    },
+    VpcUnpeer {
+        from: String,
+        to: String,
+    },
+    VpcPeeringsList {
+        vpc: Option<String>,
+    },
+
+    // -- Subnet --
+    SubnetCreate {
+        name: String,
+        env: String,
+        project: String,
+        org: String,
+        vpc: Option<String>,
+        cidr: Option<String>,
+    },
+    SubnetList {
+        env: Option<String>,
+        vpc: Option<String>,
+        project: Option<String>,
+        org: Option<String>,
+    },
+    SubnetDelete {
+        name: String,
+        vpc: Option<String>,
+    },
+
+    // -- Subnet resolution (used by compute layer) --
+    SubnetResolve {
+        subnet_name: Option<String>,
+        env: Option<String>,
+        project: Option<String>,
+        org: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum OrgResponse {
+    Org(Org),
+    OrgList(Vec<Org>),
+    Project(Project),
+    ProjectList(Vec<Project>),
+    Env(Environment),
+    EnvList(Vec<Environment>),
+    Vpc(Vpc),
+    VpcList(Vec<Vpc>),
+    PeeringList(Vec<VpcPeering>),
+    Subnet(Subnet),
+    SubnetList(Vec<Subnet>),
+    /// Resolved subnet info for VM placement (None = no subnet context).
+    SubnetResolved(Option<ResolvedSubnet>),
+    Ok,
+    Error(String),
+}
+
+/// Minimal subnet info returned by SubnetResolve, matching `SubnetInfo` in compute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedSubnet {
+    pub name: String,
+    pub cidr: String,
+    pub gateway: String,
+    pub vpc_id: String,
+    pub env_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// OrgLayerHandler — adapts OrgStore to LayerHandler
+// ---------------------------------------------------------------------------
+
+pub struct OrgLayerHandler {
+    store: Arc<OrgStore>,
+}
+
+impl OrgLayerHandler {
+    pub fn new(store: Arc<OrgStore>) -> Self {
+        Self { store }
+    }
+}
 
 #[async_trait::async_trait]
-impl LayerHandler for OrgHandler {
-    async fn handle(&self, _request: Vec<u8>, _caller_uid: Option<u32>) -> Vec<u8> {
-        serde_json::to_vec(&serde_json::json!({
-            "error": "not implemented",
-            "layer": "org"
-        }))
-        .unwrap_or_default()
+impl LayerHandler for OrgLayerHandler {
+    async fn handle(&self, request: Vec<u8>, _caller_uid: Option<u32>) -> Vec<u8> {
+        let req: OrgRequest = match serde_json::from_slice(&request) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = OrgResponse::Error(format!("invalid org request: {e}"));
+                return serde_json::to_vec(&resp).unwrap_or_default();
+            }
+        };
+
+        let resp = handle_org_request(&self.store, req);
+        serde_json::to_vec(&resp).unwrap_or_default()
+    }
+}
+
+const DEFAULT_PROJECT_CIDR: &str = "10.1.0.0/16";
+const DEFAULT_SHARED_CIDR: &str = "10.100.0.0/16";
+
+fn handle_org_request(store: &OrgStore, req: OrgRequest) -> OrgResponse {
+    match req {
+        // -- Org --
+        OrgRequest::OrgCreate { name } => match store.create(&name) {
+            Ok(org) => OrgResponse::Org(org),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::OrgList => match store.list() {
+            Ok(orgs) => OrgResponse::OrgList(orgs),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::OrgDelete { name } => match store.delete(&name) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+
+        // -- Project --
+        OrgRequest::ProjectCreate { name, org } => match store.create_project(&org, &name) {
+            Ok(project) => OrgResponse::Project(project),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::ProjectList { org } => {
+            let result = match org.as_deref() {
+                Some(org_name) => store.list_projects(org_name),
+                None => {
+                    let orgs = match store.list() {
+                        Ok(o) => o,
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    };
+                    let mut all = Vec::new();
+                    for o in &orgs {
+                        match store.list_projects(&o.name) {
+                            Ok(projects) => all.extend(projects),
+                            Err(e) => return OrgResponse::Error(e.to_string()),
+                        }
+                    }
+                    Ok(all)
+                }
+            };
+            match result {
+                Ok(projects) => OrgResponse::ProjectList(projects),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::ProjectDelete { name, org } => match store.delete_project(&org, &name) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+
+        // -- Environment --
+        OrgRequest::EnvCreate {
+            name,
+            project,
+            org,
+            ttl,
+            deletion_protection,
+            labels,
+        } => match store.create_env(&org, &project, &name, ttl, deletion_protection, labels) {
+            Ok(env) => OrgResponse::Env(env),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::EnvList { project, org } => match (&org, &project) {
+            (Some(o), Some(p)) => match store.list_envs(o, p) {
+                Ok(envs) => OrgResponse::EnvList(envs),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            },
+            _ => OrgResponse::Error("specify org and project to list environments".to_string()),
+        },
+        OrgRequest::EnvDestroy { name, project, org } => {
+            match store.delete_env(&org, &project, &name) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::EnvExtend {
+            name,
+            project,
+            org,
+            ttl_seconds,
+        } => match store.extend_env(&org, &project, &name, ttl_seconds) {
+            Ok(env) => OrgResponse::Env(env),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::EnvUpdate {
+            name,
+            project,
+            org,
+            deletion_protection,
+        } => {
+            if let Some(dp) = deletion_protection {
+                match store.update_env_protection(&org, &project, &name, dp) {
+                    Ok(env) => OrgResponse::Env(env),
+                    Err(e) => OrgResponse::Error(e.to_string()),
+                }
+            } else {
+                OrgResponse::Error("no update specified".to_string())
+            }
+        }
+
+        // -- VPC --
+        OrgRequest::VpcCreate {
+            name,
+            org,
+            project,
+            shared,
+            cidr,
+        } => {
+            if !shared && project.is_none() {
+                return OrgResponse::Error("--project is required for non-shared VPCs".to_string());
+            }
+            let (owner, cidr_str) = if shared {
+                let owner = VpcOwner::Org(OrgId(org.clone()));
+                let cidr_str = cidr.as_deref().unwrap_or(DEFAULT_SHARED_CIDR).to_string();
+                (owner, cidr_str)
+            } else {
+                let p = project.as_deref().unwrap();
+                let owner = VpcOwner::Project(ProjectId(format!("{org}/{p}")));
+                let cidr_str = cidr.as_deref().unwrap_or(DEFAULT_PROJECT_CIDR).to_string();
+                (owner, cidr_str)
+            };
+            match store.create_vpc(&name, &cidr_str, owner, shared) {
+                Ok(vpc) => OrgResponse::Vpc(vpc),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::VpcList { org, project } => {
+            let result = match (org.as_deref(), project.as_deref()) {
+                (Some(org_name), Some(proj_name)) => {
+                    let project_id = ProjectId(format!("{org_name}/{proj_name}"));
+                    store.list_vpcs_by_project(&project_id)
+                }
+                (Some(org_name), None) => {
+                    let org_id = OrgId(org_name.to_string());
+                    store.list_vpcs_by_org(&org_id)
+                }
+                _ => store.list_vpcs(),
+            };
+            match result {
+                Ok(vpcs) => OrgResponse::VpcList(vpcs),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::VpcDelete { name } => match store.delete_vpc(&name) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::VpcAttach { vpc, project } => match store.attach_vpc(&vpc, &project) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::VpcDetach { vpc, project } => match store.detach_vpc(&vpc, &project) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::VpcPeer { from, to } => match store.create_peering(&from, &to) {
+            Ok(_peering) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::VpcUnpeer { from, to } => match store.delete_peering(&from, &to) {
+            Ok(()) => OrgResponse::Ok,
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::VpcPeeringsList { vpc } => {
+            let result = match vpc.as_deref() {
+                Some(name) => store.list_peerings_for_vpc(name),
+                None => store.list_peerings().map(|all| {
+                    all.into_iter()
+                        .filter(|p| p.status == PeeringStatus::Active)
+                        .collect()
+                }),
+            };
+            match result {
+                Ok(peerings) => {
+                    // Resolve VPC names in the peering list for display
+                    let enriched: Vec<VpcPeering> = peerings
+                        .into_iter()
+                        .map(|mut p| {
+                            p.vpc_a = store.resolve_vpc_name(&p.vpc_a);
+                            p.vpc_b = store.resolve_vpc_name(&p.vpc_b);
+                            p
+                        })
+                        .collect();
+                    OrgResponse::PeeringList(enriched)
+                }
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+
+        // -- Subnet --
+        OrgRequest::SubnetCreate {
+            name,
+            env,
+            project,
+            org,
+            vpc,
+            cidr,
+        } => {
+            // Resolve VPC name
+            let vpc_name = match vpc {
+                Some(v) => v,
+                None => {
+                    // Ensure default VPC exists (same logic as VpcStore::ensure_default_vpc)
+                    let default_name = format!("{org}-{project}-default");
+                    match store.get_vpc(&default_name) {
+                        Ok(Some(_)) => default_name,
+                        Ok(None) => {
+                            let owner = VpcOwner::Project(ProjectId(format!("{org}/{project}")));
+                            match store.create_vpc(
+                                &default_name,
+                                DEFAULT_PROJECT_CIDR,
+                                owner,
+                                false,
+                            ) {
+                                Ok(vpc) => vpc.name,
+                                Err(e) => return OrgResponse::Error(e.to_string()),
+                            }
+                        }
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    }
+                }
+            };
+
+            let env_id = EnvironmentId(format!("{org}/{project}/{env}"));
+            match store.create_subnet(&vpc_name, &env_id, &name, cidr.as_deref()) {
+                Ok(subnet) => OrgResponse::Subnet(subnet),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::SubnetList {
+            env,
+            vpc,
+            project,
+            org,
+        } => {
+            if let Some(vpc_name) = vpc.as_deref() {
+                match store.list_subnets(vpc_name) {
+                    Ok(subnets) => OrgResponse::SubnetList(subnets),
+                    Err(e) => OrgResponse::Error(e.to_string()),
+                }
+            } else if let (Some(env_name), Some(proj), Some(org_name)) =
+                (env.as_deref(), project.as_deref(), org.as_deref())
+            {
+                let env_id = EnvironmentId(format!("{org_name}/{proj}/{env_name}"));
+                match store.list_subnets_by_env(&env_id) {
+                    Ok(subnets) => OrgResponse::SubnetList(subnets),
+                    Err(e) => OrgResponse::Error(e.to_string()),
+                }
+            } else if let (Some(proj), Some(org_name)) = (project.as_deref(), org.as_deref()) {
+                let project_id = ProjectId(format!("{org_name}/{proj}"));
+                let vpcs = match store.list_vpcs_by_project(&project_id) {
+                    Ok(v) => v,
+                    Err(e) => return OrgResponse::Error(e.to_string()),
+                };
+                let mut all_subnets = Vec::new();
+                for v in &vpcs {
+                    match store.list_subnets(&v.name) {
+                        Ok(mut subs) => all_subnets.append(&mut subs),
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    }
+                }
+                OrgResponse::SubnetList(all_subnets)
+            } else {
+                OrgResponse::Error(
+                    "specify --vpc or --env/--project/--org to list subnets".to_string(),
+                )
+            }
+        }
+        OrgRequest::SubnetDelete { name, vpc } => {
+            let vpc_name = match vpc {
+                Some(v) => v,
+                None => {
+                    let matches = match store.find_subnets_by_name(&name) {
+                        Ok(m) => m,
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    };
+                    match matches.len() {
+                        0 => return OrgResponse::Error(format!("subnet '{name}' not found")),
+                        1 => matches.into_iter().next().unwrap().0,
+                        _ => {
+                            let vpc_names: Vec<String> =
+                                matches.into_iter().map(|(v, _)| v).collect();
+                            return OrgResponse::Error(format!(
+                                "subnet '{name}' exists in multiple VPCs: {}. Specify --vpc",
+                                vpc_names.join(", ")
+                            ));
+                        }
+                    }
+                }
+            };
+            match store.delete_subnet(&vpc_name, &name) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+
+        // -- Subnet resolution (for compute layer) --
+        OrgRequest::SubnetResolve {
+            subnet_name,
+            env,
+            project,
+            org,
+        } => {
+            let (env_name, project_name, org_name) = match (&env, &project, &org) {
+                (Some(e), Some(p), Some(o)) => (e.as_str(), p.as_str(), o.as_str()),
+                (None, None, None) => {
+                    if subnet_name.is_some() {
+                        return OrgResponse::Error(
+                            "--subnet requires --env, --project, and --org".to_string(),
+                        );
+                    }
+                    return OrgResponse::SubnetResolved(None);
+                }
+                _ => {
+                    return OrgResponse::Error(
+                        "--env, --project, and --org must all be specified together".to_string(),
+                    );
+                }
+            };
+
+            let env_id = EnvironmentId(format!("{org_name}/{project_name}/{env_name}"));
+            let subnets = match store.list_subnets_by_env(&env_id) {
+                Ok(s) => s,
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+
+            match subnet_name {
+                Some(name) => {
+                    let subnet = subnets.into_iter().find(|s| s.name == name);
+                    match subnet {
+                        Some(s) => OrgResponse::SubnetResolved(Some(ResolvedSubnet {
+                            name: s.name,
+                            cidr: s.cidr,
+                            gateway: s.gateway,
+                            vpc_id: s.vpc_id.0,
+                            env_id: s.env_id.0,
+                        })),
+                        None => OrgResponse::Error(format!(
+                            "subnet '{name}' not found in environment '{env_name}'"
+                        )),
+                    }
+                }
+                None => match subnets.len() {
+                    0 => {
+                        OrgResponse::Error(format!("no subnet found for environment '{env_name}'"))
+                    }
+                    1 => {
+                        let s = subnets.into_iter().next().unwrap();
+                        OrgResponse::SubnetResolved(Some(ResolvedSubnet {
+                            name: s.name,
+                            cidr: s.cidr,
+                            gateway: s.gateway,
+                            vpc_id: s.vpc_id.0,
+                            env_id: s.env_id.0,
+                        }))
+                    }
+                    _ => {
+                        let names: Vec<&str> = subnets.iter().map(|s| s.name.as_str()).collect();
+                        OrgResponse::Error(format!(
+                            "environment '{env_name}' has multiple subnets: {}. Specify --subnet",
+                            names.join(", ")
+                        ))
+                    }
+                },
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client-side helper — send an org request to the daemon
+// ---------------------------------------------------------------------------
+
+/// Send an org request to the daemon via the Unix control socket.
+pub async fn send_org_request(
+    socket_path: &Path,
+    req: &OrgRequest,
+) -> Result<OrgResponse, Box<dyn std::error::Error>> {
+    let payload = serde_json::to_vec(req)?;
+    let envelope = LayerRequest::Org(payload);
+
+    let mut stream = UnixStream::connect(socket_path).await?;
+    syfrah_api::transport::write_message(&mut stream, &envelope).await?;
+    let resp: LayerResponse = syfrah_api::transport::read_message(&mut stream).await?;
+
+    match resp {
+        LayerResponse::Org(data) => {
+            let org_resp: OrgResponse = serde_json::from_slice(&data)?;
+            Ok(org_resp)
+        }
+        LayerResponse::UnknownLayer(name) => Err(format!("unknown layer: {name}").into()),
+        other => Err(format!("unexpected response variant: {other:?}").into()),
     }
 }
 
@@ -18,12 +603,38 @@ impl LayerHandler for OrgHandler {
 mod tests {
     use super::*;
 
+    fn temp_store() -> (tempfile::TempDir, Arc<OrgStore>) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = syfrah_state::LayerDb::open_at(&dir.path().join("org.redb")).unwrap();
+        (dir, Arc::new(OrgStore::new(db)))
+    }
+
     #[tokio::test]
-    async fn handler_returns_not_implemented() {
-        let handler = OrgHandler;
-        let resp = handler.handle(vec![], None).await;
-        let body: serde_json::Value = serde_json::from_slice(&resp).unwrap();
-        assert_eq!(body["error"], "not implemented");
-        assert_eq!(body["layer"], "org");
+    async fn handler_returns_error_for_invalid_request() {
+        let (_dir, store) = temp_store();
+        let handler = OrgLayerHandler::new(store);
+        let resp_bytes = handler.handle(b"not valid json".to_vec(), None).await;
+        let resp: OrgResponse = serde_json::from_slice(&resp_bytes).unwrap();
+        match resp {
+            OrgResponse::Error(msg) => assert!(msg.contains("invalid org request")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn org_create_via_handler() {
+        let (_dir, store) = temp_store();
+        let handler = OrgLayerHandler::new(store);
+
+        let req = OrgRequest::OrgCreate {
+            name: "acme".to_string(),
+        };
+        let payload = serde_json::to_vec(&req).unwrap();
+        let resp_bytes = handler.handle(payload, None).await;
+        let resp: OrgResponse = serde_json::from_slice(&resp_bytes).unwrap();
+        match resp {
+            OrgResponse::Org(org) => assert_eq!(org.name, "acme"),
+            other => panic!("expected Org, got {other:?}"),
+        }
     }
 }

--- a/layers/org/src/cli/env.rs
+++ b/layers/org/src/cli/env.rs
@@ -1,11 +1,28 @@
 //! Implementation of `syfrah env` subcommands.
+//!
+//! All operations go through the daemon's control socket.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 
-use anyhow::{bail, Context};
-use syfrah_state::LayerDb;
+use anyhow::bail;
 
-use crate::store::OrgStore;
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
+}
+
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
 
 // ── Duration parsing ────────────────────────────────────────────────
 
@@ -24,7 +41,7 @@ pub fn parse_duration(s: &str) -> anyhow::Result<u64> {
     if s.chars().all(|c| c.is_ascii_digit()) {
         let value: u64 = s
             .parse()
-            .with_context(|| format!("invalid duration: '{s}'"))?;
+            .map_err(|_| anyhow::anyhow!("invalid duration: '{s}'"))?;
         if value == 0 {
             bail!("duration must be greater than zero");
         }
@@ -32,8 +49,8 @@ pub fn parse_duration(s: &str) -> anyhow::Result<u64> {
     }
 
     let (digits, suffix) = s.split_at(s.len() - 1);
-    let value: u64 = digits.parse().with_context(|| {
-        format!("invalid duration: '{s}' (expected a number followed by s, m, h, or d)")
+    let value: u64 = digits.parse().map_err(|_| {
+        anyhow::anyhow!("invalid duration: '{s}' (expected a number followed by s, m, h, or d)")
     })?;
 
     if value == 0 {
@@ -55,7 +72,7 @@ pub fn parse_duration(s: &str) -> anyhow::Result<u64> {
 fn parse_label(s: &str) -> anyhow::Result<(String, String)> {
     let (key, value) = s
         .split_once('=')
-        .with_context(|| format!("invalid label '{s}': expected KEY=VALUE format"))?;
+        .ok_or_else(|| anyhow::anyhow!("invalid label '{s}': expected KEY=VALUE format"))?;
     if key.is_empty() {
         bail!("label key cannot be empty in '{s}'");
     }
@@ -63,11 +80,6 @@ fn parse_label(s: &str) -> anyhow::Result<(String, String)> {
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-fn open_store() -> anyhow::Result<OrgStore> {
-    let db = LayerDb::open("org").context("failed to open org database")?;
-    Ok(OrgStore::new(db))
-}
 
 fn format_ttl(seconds: Option<u64>) -> String {
     match seconds {
@@ -89,17 +101,12 @@ fn format_labels(labels: &HashMap<String, String>) -> String {
 }
 
 fn format_timestamp(epoch_secs: u64) -> String {
-    // Simple human-readable UTC timestamp.
     let secs = epoch_secs;
-    // Break into date components manually (avoid chrono dependency).
-    // For a CLI display, we show seconds-since-epoch if we don't have
-    // a lightweight formatter. Let's do a basic calculation.
     let days_since_epoch = secs / 86400;
     let time_of_day = secs % 86400;
     let hours = time_of_day / 3600;
     let minutes = (time_of_day % 3600) / 60;
 
-    // Compute year/month/day from days since epoch (1970-01-01).
     let (year, month, day) = days_to_ymd(days_since_epoch);
     format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02} UTC")
 }
@@ -149,7 +156,7 @@ fn is_leap(y: u64) -> bool {
 
 // ── Commands ────────────────────────────────────────────────────────
 
-pub fn run_create(
+pub async fn run_create(
     name: &str,
     project: &str,
     org: &str,
@@ -168,31 +175,42 @@ pub fn run_create(
         labels.insert(k, v);
     }
 
-    let store = open_store()?;
-    let env = store
-        .create_env(org, project, name, ttl_seconds, deletion_protection, labels)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let req = OrgRequest::EnvCreate {
+        name: name.to_string(),
+        project: project.to_string(),
+        org: org.to_string(),
+        ttl: ttl_seconds,
+        deletion_protection,
+        labels,
+    };
 
-    println!("Environment created: {}", env.name);
-    println!("  Project:    {project}");
-    println!("  Org:        {org}");
-    if let Some(ttl) = env.ttl {
-        println!("  TTL:        {}", format_ttl(Some(ttl)));
-    }
-    if env.deletion_protection {
-        println!("  Protected:  yes");
-    }
-    if !env.labels.is_empty() {
-        println!("  Labels:     {}", format_labels(&env.labels));
-    }
-    println!("  Created:    {}", format_timestamp(env.created_at));
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    Ok(())
+    match resp {
+        OrgResponse::Env(env) => {
+            println!("Environment created: {}", env.name);
+            println!("  Project:    {project}");
+            println!("  Org:        {org}");
+            if let Some(ttl) = env.ttl {
+                println!("  TTL:        {}", format_ttl(Some(ttl)));
+            }
+            if env.deletion_protection {
+                println!("  Protected:  yes");
+            }
+            if !env.labels.is_empty() {
+                println!("  Labels:     {}", format_labels(&env.labels));
+            }
+            println!("  Created:    {}", format_timestamp(env.created_at));
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
-pub fn run_list(project: Option<&str>, org: Option<&str>, json: bool) -> anyhow::Result<()> {
-    let store = open_store()?;
-
+pub async fn run_list(project: Option<&str>, org: Option<&str>, json: bool) -> anyhow::Result<()> {
     let (org_name, project_name) = match (org, project) {
         (Some(o), Some(p)) => (o, p),
         (None, None) => {
@@ -206,47 +224,56 @@ pub fn run_list(project: Option<&str>, org: Option<&str>, json: bool) -> anyhow:
         }
     };
 
-    let envs = store
-        .list_envs(org_name, project_name)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let req = OrgRequest::EnvList {
+        project: Some(project_name.to_string()),
+        org: Some(org_name.to_string()),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&envs)?);
-        return Ok(());
+    match resp {
+        OrgResponse::EnvList(envs) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&envs)?);
+                return Ok(());
+            }
+
+            if envs.is_empty() {
+                println!("No environments found in project '{project_name}' (org: {org_name}).");
+                println!(
+                    "\nCreate one with: syfrah env create <name> --project {project_name} --org {org_name}"
+                );
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<15} {:<8} {:<10} {:<30} CREATED",
+                "NAME", "PROJECT", "TTL", "PROTECTED", "LABELS"
+            );
+            println!("{}", "-".repeat(100));
+
+            for env in &envs {
+                let protected = if env.deletion_protection { "yes" } else { "no" };
+                println!(
+                    "{:<20} {:<15} {:<8} {:<10} {:<30} {}",
+                    env.name,
+                    project_name,
+                    format_ttl(env.ttl),
+                    protected,
+                    format_labels(&env.labels),
+                    format_timestamp(env.created_at),
+                );
+            }
+
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    if envs.is_empty() {
-        println!("No environments found in project '{project_name}' (org: {org_name}).");
-        println!(
-            "\nCreate one with: syfrah env create <name> --project {project_name} --org {org_name}"
-        );
-        return Ok(());
-    }
-
-    // Table output: NAME, PROJECT, TTL, PROTECTED, LABELS, CREATED
-    println!(
-        "{:<20} {:<15} {:<8} {:<10} {:<30} CREATED",
-        "NAME", "PROJECT", "TTL", "PROTECTED", "LABELS"
-    );
-    println!("{}", "-".repeat(100));
-
-    for env in &envs {
-        let protected = if env.deletion_protection { "yes" } else { "no" };
-        println!(
-            "{:<20} {:<15} {:<8} {:<10} {:<30} {}",
-            env.name,
-            project_name,
-            format_ttl(env.ttl),
-            protected,
-            format_labels(&env.labels),
-            format_timestamp(env.created_at),
-        );
-    }
-
-    Ok(())
 }
 
-pub fn run_destroy(name: &str, project: &str, org: &str, yes: bool) -> anyhow::Result<()> {
+pub async fn run_destroy(name: &str, project: &str, org: &str, yes: bool) -> anyhow::Result<()> {
     if !yes {
         eprintln!(
             "This will permanently destroy environment '{name}' in project '{project}' (org: {org})."
@@ -255,64 +282,97 @@ pub fn run_destroy(name: &str, project: &str, org: &str, yes: bool) -> anyhow::R
         std::process::exit(1);
     }
 
-    let store = open_store()?;
-    store
-        .delete_env(org, project, name)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let req = OrgRequest::EnvDestroy {
+        name: name.to_string(),
+        project: project.to_string(),
+        org: org.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    println!("Environment destroyed: {name}");
-    Ok(())
+    match resp {
+        OrgResponse::Ok => {
+            println!("Environment destroyed: {name}");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
-pub fn run_extend(name: &str, project: &str, org: &str, ttl_str: &str) -> anyhow::Result<()> {
+pub async fn run_extend(name: &str, project: &str, org: &str, ttl_str: &str) -> anyhow::Result<()> {
     let ttl_seconds = parse_duration(ttl_str)?;
 
-    let store = open_store()?;
-    let env = store
-        .extend_env(org, project, name, ttl_seconds)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let req = OrgRequest::EnvExtend {
+        name: name.to_string(),
+        project: project.to_string(),
+        org: org.to_string(),
+        ttl_seconds,
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    println!("Environment extended: {name}");
-    println!("  New TTL:    {}", format_ttl(env.ttl));
-    if let Some(expires) = env.expires_at {
-        println!("  Expires:    {}", format_timestamp(expires));
+    match resp {
+        OrgResponse::Env(env) => {
+            println!("Environment extended: {name}");
+            println!("  New TTL:    {}", format_ttl(env.ttl));
+            if let Some(expires) = env.expires_at {
+                println!("  Expires:    {}", format_timestamp(expires));
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    Ok(())
 }
 
-pub fn run_update(
+pub async fn run_update(
     name: &str,
     project: &str,
     org: &str,
     deletion_protection: bool,
     no_deletion_protection: bool,
 ) -> anyhow::Result<()> {
-    let store = open_store()?;
-
-    if deletion_protection {
-        let env = store
-            .update_env_protection(org, project, name, true)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        println!(
-            "Deletion protection enabled for environment '{}'.",
-            env.name
-        );
+    let dp = if deletion_protection {
+        Some(true)
     } else if no_deletion_protection {
-        let env = store
-            .update_env_protection(org, project, name, false)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        println!(
-            "Deletion protection disabled for environment '{}'.",
-            env.name
-        );
+        Some(false)
     } else {
         anyhow::bail!(
             "specify --deletion-protection or --no-deletion-protection to update the environment"
         );
-    }
+    };
 
-    Ok(())
+    let req = OrgRequest::EnvUpdate {
+        name: name.to_string(),
+        project: project.to_string(),
+        org: org.to_string(),
+        deletion_protection: dp,
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Env(env) => {
+            if deletion_protection {
+                println!(
+                    "Deletion protection enabled for environment '{}'.",
+                    env.name
+                );
+            } else {
+                println!(
+                    "Deletion protection disabled for environment '{}'.",
+                    env.name
+                );
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -348,8 +408,6 @@ mod tests {
 
     #[test]
     fn env_destroy_parse() {
-        // With --yes the command should proceed; without it, it exits.
-        // We test the flag parsing via clap derive.
         use clap::Parser;
 
         #[derive(Parser)]
@@ -358,7 +416,6 @@ mod tests {
             cmd: crate::cli::EnvCommand,
         }
 
-        // Parse with --yes
         let cli = TestCli::parse_from([
             "test",
             "destroy",
@@ -385,7 +442,6 @@ mod tests {
             _ => panic!("expected Destroy command"),
         }
 
-        // Parse without --yes
         let cli = TestCli::parse_from([
             "test",
             "destroy",
@@ -437,7 +493,6 @@ mod tests {
                 assert_eq!(project, "backend");
                 assert_eq!(org, "acme");
                 assert_eq!(ttl, "24h");
-                // Verify the duration parses correctly
                 assert_eq!(parse_duration(&ttl).unwrap(), 86400);
             }
             _ => panic!("expected Extend command"),

--- a/layers/org/src/cli/mod.rs
+++ b/layers/org/src/cli/mod.rs
@@ -321,25 +321,25 @@ pub enum SubnetCommand {
 }
 
 /// Execute an org CLI command.
-pub fn run(cmd: OrgCommand) -> anyhow::Result<()> {
+pub async fn run(cmd: OrgCommand) -> anyhow::Result<()> {
     match cmd {
-        OrgCommand::Create { name } => org::run_create(name),
-        OrgCommand::List { json } => org::run_list(json),
-        OrgCommand::Delete { name, yes } => org::run_delete(name, yes),
+        OrgCommand::Create { name } => org::run_create(name).await,
+        OrgCommand::List { json } => org::run_list(json).await,
+        OrgCommand::Delete { name, yes } => org::run_delete(name, yes).await,
     }
 }
 
 /// Execute a project CLI command.
-pub fn run_project(cmd: ProjectCommand) -> anyhow::Result<()> {
+pub async fn run_project(cmd: ProjectCommand) -> anyhow::Result<()> {
     match cmd {
-        ProjectCommand::Create { name, org } => project::create(&name, &org),
-        ProjectCommand::List { org, json } => project::list(org.as_deref(), json),
-        ProjectCommand::Delete { name, org, yes } => project::delete(&name, &org, yes),
+        ProjectCommand::Create { name, org } => project::create(&name, &org).await,
+        ProjectCommand::List { org, json } => project::list(org.as_deref(), json).await,
+        ProjectCommand::Delete { name, org, yes } => project::delete(&name, &org, yes).await,
     }
 }
 
 /// Execute an env CLI command.
-pub fn run_env(cmd: EnvCommand) -> anyhow::Result<()> {
+pub async fn run_env(cmd: EnvCommand) -> anyhow::Result<()> {
     match cmd {
         EnvCommand::Create {
             name,
@@ -348,47 +348,53 @@ pub fn run_env(cmd: EnvCommand) -> anyhow::Result<()> {
             ttl,
             deletion_protection,
             labels,
-        } => env::run_create(
-            &name,
-            &project,
-            &org,
-            ttl.as_deref(),
-            deletion_protection,
-            &labels,
-        ),
+        } => {
+            env::run_create(
+                &name,
+                &project,
+                &org,
+                ttl.as_deref(),
+                deletion_protection,
+                &labels,
+            )
+            .await
+        }
         EnvCommand::List { project, org, json } => {
-            env::run_list(project.as_deref(), org.as_deref(), json)
+            env::run_list(project.as_deref(), org.as_deref(), json).await
         }
         EnvCommand::Destroy {
             name,
             project,
             org,
             yes,
-        } => env::run_destroy(&name, &project, &org, yes),
+        } => env::run_destroy(&name, &project, &org, yes).await,
         EnvCommand::Extend {
             name,
             project,
             org,
             ttl,
-        } => env::run_extend(&name, &project, &org, &ttl),
+        } => env::run_extend(&name, &project, &org, &ttl).await,
         EnvCommand::Update {
             name,
             project,
             org,
             deletion_protection,
             no_deletion_protection,
-        } => env::run_update(
-            &name,
-            &project,
-            &org,
-            deletion_protection,
-            no_deletion_protection,
-        ),
+        } => {
+            env::run_update(
+                &name,
+                &project,
+                &org,
+                deletion_protection,
+                no_deletion_protection,
+            )
+            .await
+        }
     }
 }
 
 /// Execute a VPC CLI command.
-pub fn run_vpc(cmd: VpcCommand) -> anyhow::Result<()> {
+pub async fn run_vpc(cmd: VpcCommand) -> anyhow::Result<()> {
     match cmd {
         VpcCommand::Create {
             name,
@@ -396,21 +402,21 @@ pub fn run_vpc(cmd: VpcCommand) -> anyhow::Result<()> {
             project,
             shared,
             cidr,
-        } => vpc::run_create(&name, &org, project.as_deref(), shared, cidr.as_deref()),
+        } => vpc::run_create(&name, &org, project.as_deref(), shared, cidr.as_deref()).await,
         VpcCommand::List { project, org, json } => {
-            vpc::run_list(org.as_deref(), project.as_deref(), json)
+            vpc::run_list(org.as_deref(), project.as_deref(), json).await
         }
-        VpcCommand::Delete { name, org, yes } => vpc::run_delete(&name, &org, yes),
-        VpcCommand::Attach { vpc: v, project } => vpc::run_attach(&v, &project),
-        VpcCommand::Detach { vpc: v, project } => vpc::run_detach(&v, &project),
-        VpcCommand::Peer { from, to } => vpc::run_peer(&from, &to),
-        VpcCommand::Unpeer { from, to } => vpc::run_unpeer(&from, &to),
-        VpcCommand::Peerings { vpc, json } => vpc::run_peerings(vpc.as_deref(), json),
+        VpcCommand::Delete { name, org, yes } => vpc::run_delete(&name, &org, yes).await,
+        VpcCommand::Attach { vpc: v, project } => vpc::run_attach(&v, &project).await,
+        VpcCommand::Detach { vpc: v, project } => vpc::run_detach(&v, &project).await,
+        VpcCommand::Peer { from, to } => vpc::run_peer(&from, &to).await,
+        VpcCommand::Unpeer { from, to } => vpc::run_unpeer(&from, &to).await,
+        VpcCommand::Peerings { vpc, json } => vpc::run_peerings(vpc.as_deref(), json).await,
     }
 }
 
 /// Execute a subnet CLI command.
-pub fn run_subnet(cmd: SubnetCommand) -> anyhow::Result<()> {
+pub async fn run_subnet(cmd: SubnetCommand) -> anyhow::Result<()> {
     match cmd {
         SubnetCommand::Create {
             name,
@@ -419,20 +425,25 @@ pub fn run_subnet(cmd: SubnetCommand) -> anyhow::Result<()> {
             org,
             vpc,
             cidr,
-        } => subnet::run_create(&name, &env, &project, &org, vpc.as_deref(), cidr.as_deref()),
+        } => subnet::run_create(&name, &env, &project, &org, vpc.as_deref(), cidr.as_deref()).await,
         SubnetCommand::List {
             env,
             vpc,
             project,
             org,
             json,
-        } => subnet::run_list(
-            env.as_deref(),
-            vpc.as_deref(),
-            project.as_deref(),
-            org.as_deref(),
-            json,
-        ),
-        SubnetCommand::Delete { name, vpc, yes } => subnet::run_delete(&name, vpc.as_deref(), yes),
+        } => {
+            subnet::run_list(
+                env.as_deref(),
+                vpc.as_deref(),
+                project.as_deref(),
+                org.as_deref(),
+                json,
+            )
+            .await
+        }
+        SubnetCommand::Delete { name, vpc, yes } => {
+            subnet::run_delete(&name, vpc.as_deref(), yes).await
+        }
     }
 }

--- a/layers/org/src/cli/org.rs
+++ b/layers/org/src/cli/org.rs
@@ -1,87 +1,93 @@
 //! Org subcommand handlers.
 //!
-//! All operations are local (redb), no daemon needed.
+//! All operations go through the daemon's control socket to avoid redb lock
+//! contention (the daemon holds the exclusive lock on org.redb).
 
-use crate::store::OrgStore;
-use crate::validation::validate_name;
+use std::path::PathBuf;
+
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
+}
 
 /// Create a new organization.
-pub fn run_create(name: String) -> anyhow::Result<()> {
-    if let Err(e) = validate_name(&name, "org") {
-        anyhow::bail!("{e}");
-    }
+pub async fn run_create(name: String) -> anyhow::Result<()> {
+    let req = OrgRequest::OrgCreate { name: name.clone() };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "cannot reach the syfrah daemon — is it running?\n\
+                 Start it with: syfrah fabric init ...\n\n\
+                 Error: {e}"
+            )
+        })?;
 
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
-
-    match store.create(&name) {
-        Ok(org) => {
+    match resp {
+        OrgResponse::Org(org) => {
             println!("Organization '{}' created.", org.name);
             Ok(())
         }
-        Err(crate::error::OrgError::AlreadyExists(_)) => {
-            anyhow::bail!("org '{name}' already exists");
-        }
-        Err(e) => {
-            anyhow::bail!("failed to create org: {e}");
-        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
 }
 
 /// List all organizations.
-pub fn run_list(json: bool) -> anyhow::Result<()> {
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
+pub async fn run_list(json: bool) -> anyhow::Result<()> {
+    let req = OrgRequest::OrgList;
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "cannot reach the syfrah daemon — is it running?\n\
+                 Start it with: syfrah fabric init ...\n\n\
+                 Error: {e}"
+            )
+        })?;
 
-    let orgs = store
-        .list()
-        .map_err(|e| anyhow::anyhow!("failed to list orgs: {e}"))?;
+    match resp {
+        OrgResponse::OrgList(orgs) => {
+            if json {
+                let json_str = serde_json::to_string_pretty(&orgs)?;
+                println!("{json_str}");
+                return Ok(());
+            }
 
-    if json {
-        let json_str = serde_json::to_string_pretty(&orgs)?;
-        println!("{json_str}");
-        return Ok(());
+            if orgs.is_empty() {
+                println!("(no organizations)");
+                return Ok(());
+            }
+
+            let tw = term_width();
+            let header = format!("{:<30} {:<20}", "NAME", "CREATED");
+            if console::Term::stdout().is_term() {
+                let truncated = &header[..header.len().min(tw)];
+                println!("{}", console::Style::new().bold().apply_to(truncated));
+            } else {
+                println!("{}", &header[..header.len().min(tw)]);
+            }
+            println!("{}", "-".repeat(50.min(tw)));
+
+            for org in &orgs {
+                let created = format_timestamp(org.created_at);
+                let row = format!("{:<30} {:<20}", org.name, created);
+                println!("{}", &row[..row.len().min(tw)]);
+            }
+
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    if orgs.is_empty() {
-        println!("(no organizations)");
-        return Ok(());
-    }
-
-    let tw = term_width();
-    let header = format!("{:<30} {:<20}", "NAME", "CREATED");
-    if console::Term::stdout().is_term() {
-        let truncated = &header[..header.len().min(tw)];
-        println!("{}", console::Style::new().bold().apply_to(truncated));
-    } else {
-        println!("{}", &header[..header.len().min(tw)]);
-    }
-    println!("{}", "-".repeat(50.min(tw)));
-
-    for org in &orgs {
-        let created = format_timestamp(org.created_at);
-        let row = format!("{:<30} {:<20}", org.name, created);
-        println!("{}", &row[..row.len().min(tw)]);
-    }
-
-    Ok(())
 }
 
 /// Delete an organization.
-pub fn run_delete(name: String, yes: bool) -> anyhow::Result<()> {
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
-
-    // Check it exists before prompting
-    match store.get(&name) {
-        Ok(Some(_)) => {}
-        Ok(None) => anyhow::bail!("org '{name}' not found"),
-        Err(e) => anyhow::bail!("failed to look up org: {e}"),
-    }
-
+pub async fn run_delete(name: String, yes: bool) -> anyhow::Result<()> {
     if !yes {
         eprint!("Delete organization '{name}'? This cannot be undone. [y/N] ");
         let mut answer = String::new();
@@ -93,17 +99,23 @@ pub fn run_delete(name: String, yes: bool) -> anyhow::Result<()> {
         }
     }
 
-    match store.delete(&name) {
-        Ok(()) => {
+    let req = OrgRequest::OrgDelete { name: name.clone() };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "cannot reach the syfrah daemon — is it running?\n\n\
+                 Error: {e}"
+            )
+        })?;
+
+    match resp {
+        OrgResponse::Ok => {
             println!("Organization '{name}' deleted.");
             Ok(())
         }
-        Err(crate::error::OrgError::NotFound(_)) => {
-            anyhow::bail!("org '{name}' not found");
-        }
-        Err(e) => {
-            anyhow::bail!("failed to delete org: {e}");
-        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
 }
 

--- a/layers/org/src/cli/project.rs
+++ b/layers/org/src/cli/project.rs
@@ -1,68 +1,91 @@
 //! `syfrah project create|list|delete` handlers.
+//!
+//! All operations go through the daemon's control socket.
+
+use std::path::PathBuf;
 
 use anyhow::Result;
 
-use crate::store::OrgStore;
-use crate::validation::validate_name;
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
 
-pub fn create(name: &str, org: &str) -> Result<()> {
-    validate_name(name, "project")?;
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
-    let project = store.create_project(org, name)?;
-    println!(
-        "Project '{}' created in organization '{}'.",
-        project.name, project.org_id
-    );
-    Ok(())
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
 }
 
-pub fn list(org: Option<&str>, json: bool) -> Result<()> {
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
 
-    let projects = match org {
-        Some(org_name) => store.list_projects(org_name)?,
-        None => {
-            // List all projects across all orgs
-            let orgs = store.list()?;
-            let mut all = Vec::new();
-            for o in &orgs {
-                all.extend(store.list_projects(&o.name)?);
-            }
-            all
-        }
+pub async fn create(name: &str, org: &str) -> Result<()> {
+    let req = OrgRequest::ProjectCreate {
+        name: name.to_string(),
+        org: org.to_string(),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&projects)?);
-        return Ok(());
-    }
-
-    if projects.is_empty() {
-        if let Some(org_name) = org {
+    match resp {
+        OrgResponse::Project(project) => {
             println!(
-                "No projects found in org '{org_name}'. Create one with: syfrah project create <name> --org {org_name}"
+                "Project '{}' created in organization '{}'.",
+                project.name, project.org_id
             );
-        } else {
-            println!(
-                "No projects found. Create one with: syfrah project create <name> --org <org>"
-            );
+            Ok(())
         }
-        return Ok(());
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    println!("{:<30} {:<20} {:<20}", "NAME", "ORG", "CREATED");
-    for p in &projects {
-        let created = format_timestamp(p.created_at);
-        println!("{:<30} {:<20} {:<20}", p.name, p.org_id, created);
-    }
-    Ok(())
 }
 
-pub fn delete(name: &str, org: &str, yes: bool) -> Result<()> {
+pub async fn list(org: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::ProjectList {
+        org: org.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::ProjectList(projects) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&projects)?);
+                return Ok(());
+            }
+
+            if projects.is_empty() {
+                if let Some(org_name) = org {
+                    println!(
+                        "No projects found in org '{org_name}'. Create one with: syfrah project create <name> --org {org_name}"
+                    );
+                } else {
+                    println!(
+                        "No projects found. Create one with: syfrah project create <name> --org <org>"
+                    );
+                }
+                return Ok(());
+            }
+
+            println!("{:<30} {:<20} {:<20}", "NAME", "ORG", "CREATED");
+            for p in &projects {
+                let created = format_timestamp(p.created_at);
+                println!("{:<30} {:<20} {:<20}", p.name, p.org_id, created);
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn delete(name: &str, org: &str, yes: bool) -> Result<()> {
     if !yes {
         eprint!("Delete project '{name}' from org '{org}'? This cannot be undone. [y/N] ");
         let mut input = String::new();
@@ -72,12 +95,23 @@ pub fn delete(name: &str, org: &str, yes: bool) -> Result<()> {
             return Ok(());
         }
     }
-    let db = syfrah_state::LayerDb::open("org")
-        .map_err(|e| anyhow::anyhow!("failed to open org store: {e}"))?;
-    let store = OrgStore::new(db);
-    store.delete_project(org, name)?;
-    println!("Project '{name}' deleted from org '{org}'.");
-    Ok(())
+
+    let req = OrgRequest::ProjectDelete {
+        name: name.to_string(),
+        org: org.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("Project '{name}' deleted from org '{org}'.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
 fn format_timestamp(ts: u64) -> String {

--- a/layers/org/src/cli/subnet.rs
+++ b/layers/org/src/cli/subnet.rs
@@ -1,23 +1,29 @@
 //! `syfrah subnet create|list|delete` handlers.
+//!
+//! All operations go through the daemon's control socket.
 
-use anyhow::{Context, Result};
-use syfrah_state::LayerDb;
+use std::path::PathBuf;
 
-use crate::store::OrgStore;
-use crate::types::{EnvironmentId, ProjectId};
-use crate::vpc::VpcStore;
+use anyhow::Result;
 
-fn open_store() -> Result<OrgStore> {
-    let db = LayerDb::open("org").context("failed to open org database")?;
-    Ok(OrgStore::new(db))
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
 }
 
-fn open_vpc_store() -> Result<VpcStore> {
-    let db = LayerDb::open("org").context("failed to open org database")?;
-    Ok(VpcStore::new(db))
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
 }
 
-pub fn run_create(
+pub async fn run_create(
     name: &str,
     env: &str,
     project: &str,
@@ -25,155 +31,99 @@ pub fn run_create(
     vpc: Option<&str>,
     cidr: Option<&str>,
 ) -> Result<()> {
-    // Resolve VPC name: explicit or default for project.
-    // We must ensure the default VPC exists before creating the subnet.
-    // Since redb holds a file lock, we must close VpcStore before opening OrgStore.
-    let vpc_name = match vpc {
-        Some(v) => v.to_string(),
-        None => {
-            let vpc_store = open_vpc_store()?;
-            let default_vpc = vpc_store
-                .ensure_default_vpc(org, project)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            let name = default_vpc.name.clone();
-            drop(vpc_store);
-            name
-        }
+    let req = OrgRequest::SubnetCreate {
+        name: name.to_string(),
+        env: env.to_string(),
+        project: project.to_string(),
+        org: org.to_string(),
+        vpc: vpc.map(String::from),
+        cidr: cidr.map(String::from),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    // Build environment ID
-    let env_id = EnvironmentId(format!("{org}/{project}/{env}"));
-
-    let store = open_store()?;
-    let subnet = store
-        .create_subnet(&vpc_name, &env_id, name, cidr)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    // Resolve VPC name for display
-    let display_vpc = store
-        .get_vpc_by_id(&subnet.vpc_id)
-        .ok()
-        .flatten()
-        .map(|v| v.name)
-        .unwrap_or_else(|| vpc_name.clone());
-
-    println!("Subnet created: {}", subnet.name);
-    println!("  VPC:      {display_vpc}");
-    println!("  Env:      {env}");
-    println!("  CIDR:     {}", subnet.cidr);
-    println!("  Gateway:  {}", subnet.gateway);
-    println!("  Created:  {}", format_timestamp(subnet.created_at));
-
-    Ok(())
+    match resp {
+        OrgResponse::Subnet(subnet) => {
+            println!("Subnet created: {}", subnet.name);
+            println!("  VPC:      {}", subnet.vpc_id);
+            println!("  Env:      {env}");
+            println!("  CIDR:     {}", subnet.cidr);
+            println!("  Gateway:  {}", subnet.gateway);
+            println!("  Created:  {}", format_timestamp(subnet.created_at));
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
-pub fn run_list(
+pub async fn run_list(
     env: Option<&str>,
     vpc: Option<&str>,
     project: Option<&str>,
     org: Option<&str>,
     json: bool,
 ) -> Result<()> {
-    let store = open_store()?;
-
-    let subnets = if let Some(vpc_name) = vpc {
-        store
-            .list_subnets(vpc_name)
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-    } else if let (Some(env_name), Some(proj), Some(org_name)) = (env, project, org) {
-        let env_id = EnvironmentId(format!("{org_name}/{proj}/{env_name}"));
-        store
-            .list_subnets_by_env(&env_id)
-            .map_err(|e| anyhow::anyhow!("{e}"))?
-    } else if let (Some(proj), Some(org_name)) = (project, org) {
-        let project_id = ProjectId(format!("{org_name}/{proj}"));
-        let vpcs = store
-            .list_vpcs_by_project(&project_id)
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
-        let mut all_subnets = Vec::new();
-        for vpc in &vpcs {
-            let mut subs = store
-                .list_subnets(&vpc.name)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            all_subnets.append(&mut subs);
-        }
-        all_subnets
-    } else {
-        anyhow::bail!("specify --vpc or --env/--project/--org to list subnets");
+    let req = OrgRequest::SubnetList {
+        env: env.map(String::from),
+        vpc: vpc.map(String::from),
+        project: project.map(String::from),
+        org: org.map(String::from),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&subnets)?);
-        return Ok(());
+    match resp {
+        OrgResponse::SubnetList(subnets) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&subnets)?);
+                return Ok(());
+            }
+
+            if subnets.is_empty() {
+                println!("No subnets found.");
+                println!("\nCreate one with: syfrah subnet create <name> --env <env> --project <project> --org <org>");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<25} {:<15} {:<18} {:<16} CREATED",
+                "NAME", "VPC", "ENV", "CIDR", "GATEWAY"
+            );
+            println!("{}", "-".repeat(110));
+
+            for subnet in &subnets {
+                let env_name = subnet
+                    .env_id
+                    .0
+                    .split('/')
+                    .nth(2)
+                    .unwrap_or(&subnet.env_id.0);
+
+                println!(
+                    "{:<20} {:<25} {:<15} {:<18} {:<16} {}",
+                    subnet.name,
+                    subnet.vpc_id,
+                    env_name,
+                    subnet.cidr,
+                    subnet.gateway,
+                    format_timestamp(subnet.created_at),
+                );
+            }
+
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    if subnets.is_empty() {
-        println!("No subnets found.");
-        println!("\nCreate one with: syfrah subnet create <name> --env <env> --project <project> --org <org>");
-        return Ok(());
-    }
-
-    println!(
-        "{:<20} {:<25} {:<15} {:<18} {:<16} CREATED",
-        "NAME", "VPC", "ENV", "CIDR", "GATEWAY"
-    );
-    println!("{}", "-".repeat(110));
-
-    for subnet in &subnets {
-        let vpc_name = store
-            .get_vpc_by_id(&subnet.vpc_id)
-            .ok()
-            .flatten()
-            .map(|v| v.name)
-            .unwrap_or_else(|| subnet.vpc_id.0.clone());
-
-        let env_name = subnet
-            .env_id
-            .0
-            .split('/')
-            .nth(2)
-            .unwrap_or(&subnet.env_id.0);
-
-        println!(
-            "{:<20} {:<25} {:<15} {:<18} {:<16} {}",
-            subnet.name,
-            vpc_name,
-            env_name,
-            subnet.cidr,
-            subnet.gateway,
-            format_timestamp(subnet.created_at),
-        );
-    }
-
-    Ok(())
 }
 
-pub fn run_delete(name: &str, vpc: Option<&str>, yes: bool) -> Result<()> {
-    let store = open_store()?;
-
-    // Resolve VPC: if provided use it directly, otherwise search all VPCs.
-    let vpc_name = match vpc {
-        Some(v) => v.to_string(),
-        None => {
-            let matches = store
-                .find_subnets_by_name(name)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            match matches.len() {
-                0 => anyhow::bail!("subnet '{name}' not found"),
-                1 => matches.into_iter().next().unwrap().0,
-                _ => {
-                    let vpc_names: Vec<String> = matches.into_iter().map(|(v, _)| v).collect();
-                    anyhow::bail!(
-                        "subnet '{name}' exists in multiple VPCs: {}. Specify --vpc",
-                        vpc_names.join(", ")
-                    );
-                }
-            }
-        }
-    };
-
+pub async fn run_delete(name: &str, vpc: Option<&str>, yes: bool) -> Result<()> {
     if !yes {
-        eprint!("Delete subnet '{name}' from VPC '{vpc_name}'? This cannot be undone. [y/N] ");
+        let vpc_display = vpc.unwrap_or("(auto-detect)");
+        eprint!("Delete subnet '{name}' from VPC '{vpc_display}'? This cannot be undone. [y/N] ");
         let mut answer = String::new();
         std::io::stdin().read_line(&mut answer)?;
         let answer = answer.trim();
@@ -183,12 +133,22 @@ pub fn run_delete(name: &str, vpc: Option<&str>, yes: bool) -> Result<()> {
         }
     }
 
-    store
-        .delete_subnet(&vpc_name, name)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let req = OrgRequest::SubnetDelete {
+        name: name.to_string(),
+        vpc: vpc.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    println!("Subnet '{name}' deleted from VPC '{vpc_name}'.");
-    Ok(())
+    match resp {
+        OrgResponse::Ok => {
+            println!("Subnet '{name}' deleted.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
 fn format_timestamp(ts: u64) -> String {
@@ -237,7 +197,6 @@ mod tests {
 
     #[test]
     fn subnet_create_parse() {
-        // All flags
         let cmd = parse(&[
             "create",
             "frontend",
@@ -271,7 +230,6 @@ mod tests {
             other => panic!("expected Create, got {other:?}"),
         }
 
-        // Without optional flags (vpc and cidr omitted)
         let cmd = parse(&[
             "create",
             "database",
@@ -304,7 +262,6 @@ mod tests {
 
     #[test]
     fn subnet_list_parse() {
-        // With all filters
         let cmd = parse(&[
             "list",
             "--env",
@@ -334,7 +291,6 @@ mod tests {
             other => panic!("expected List, got {other:?}"),
         }
 
-        // No filters
         let cmd = parse(&["list"]);
         match cmd {
             SubnetCommand::List {
@@ -353,7 +309,6 @@ mod tests {
             other => panic!("expected List, got {other:?}"),
         }
 
-        // Partial filters
         let cmd = parse(&["list", "--env", "staging"]);
         match cmd {
             SubnetCommand::List { env, vpc, .. } => {
@@ -366,7 +321,6 @@ mod tests {
 
     #[test]
     fn subnet_delete_parse() {
-        // With --vpc and --yes
         let cmd = parse(&["delete", "frontend", "--vpc", "my-vpc", "--yes"]);
         match cmd {
             SubnetCommand::Delete { name, vpc, yes } => {
@@ -377,7 +331,6 @@ mod tests {
             other => panic!("expected Delete, got {other:?}"),
         }
 
-        // Without --yes
         let cmd = parse(&["delete", "frontend", "--vpc", "my-vpc"]);
         match cmd {
             SubnetCommand::Delete { name, vpc, yes } => {
@@ -388,7 +341,6 @@ mod tests {
             other => panic!("expected Delete, got {other:?}"),
         }
 
-        // Short -y flag
         let cmd = parse(&["delete", "-y", "frontend", "--vpc", "my-vpc"]);
         match cmd {
             SubnetCommand::Delete { name, vpc, yes } => {
@@ -399,7 +351,6 @@ mod tests {
             other => panic!("expected Delete, got {other:?}"),
         }
 
-        // Without --vpc (auto-resolve mode)
         let cmd = parse(&["delete", "frontend", "--yes"]);
         match cmd {
             SubnetCommand::Delete { name, vpc, yes } => {

--- a/layers/org/src/cli/vpc.rs
+++ b/layers/org/src/cli/vpc.rs
@@ -1,20 +1,30 @@
-//! `syfrah vpc create|list|delete` handlers.
+//! `syfrah vpc create|list|delete|attach|detach|peer|unpeer|peerings` handlers.
+//!
+//! All operations go through the daemon's control socket.
 
-use anyhow::{bail, Context, Result};
-use syfrah_state::LayerDb;
+use std::path::PathBuf;
 
-use crate::store::OrgStore;
-use crate::types::{OrgId, ProjectId, VpcOwner};
+use anyhow::{bail, Result};
 
-const DEFAULT_PROJECT_CIDR: &str = "10.1.0.0/16";
-const DEFAULT_SHARED_CIDR: &str = "10.100.0.0/16";
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+use crate::types::VpcOwner;
 
-fn open_store() -> Result<OrgStore> {
-    let db = LayerDb::open("org").context("failed to open org database")?;
-    Ok(OrgStore::new(db))
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
 }
 
-pub fn run_create(
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
+
+pub async fn run_create(
     name: &str,
     org: &str,
     project: Option<&str>,
@@ -30,113 +40,99 @@ pub fn run_create(
         );
     }
 
-    let store = open_store()?;
-
-    let (owner, cidr_str) = if shared {
-        let owner = VpcOwner::Org(OrgId(org.to_string()));
-        let cidr_str = cidr.unwrap_or(DEFAULT_SHARED_CIDR);
-        (owner, cidr_str)
-    } else {
-        let project = project.unwrap();
-        let owner = VpcOwner::Project(ProjectId(format!("{org}/{project}")));
-        let cidr_str = cidr.unwrap_or(DEFAULT_PROJECT_CIDR);
-        (owner, cidr_str)
+    let req = OrgRequest::VpcCreate {
+        name: name.to_string(),
+        org: org.to_string(),
+        project: project.map(String::from),
+        shared,
+        cidr: cidr.map(String::from),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    let vpc = store
-        .create_vpc(name, cidr_str, owner, shared)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    println!("VPC created: {}", vpc.name);
-    match &vpc.owner {
-        VpcOwner::Org(org_id) => {
-            println!("  Org:      {}", org_id.0);
-            println!("  Shared:   yes");
-        }
-        VpcOwner::Project(proj_id) => {
-            println!("  Org:      {org}");
-            if let Some(p) = proj_id.0.split('/').nth(1) {
-                println!("  Project:  {p}");
+    match resp {
+        OrgResponse::Vpc(vpc) => {
+            println!("VPC created: {}", vpc.name);
+            match &vpc.owner {
+                VpcOwner::Org(org_id) => {
+                    println!("  Org:      {}", org_id.0);
+                    println!("  Shared:   yes");
+                }
+                VpcOwner::Project(proj_id) => {
+                    println!("  Org:      {org}");
+                    if let Some(p) = proj_id.0.split('/').nth(1) {
+                        println!("  Project:  {p}");
+                    }
+                }
             }
+            println!("  CIDR:     {}", vpc.cidr);
+            println!("  VNI:      {}", vpc.vni);
+            println!("  Created:  {}", format_timestamp(vpc.created_at));
+            Ok(())
         }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-    println!("  CIDR:     {}", vpc.cidr);
-    println!("  VNI:      {}", vpc.vni);
-    println!("  Created:  {}", format_timestamp(vpc.created_at));
-
-    Ok(())
 }
 
-pub fn run_list(org: Option<&str>, project: Option<&str>, json: bool) -> Result<()> {
-    let store = open_store()?;
-
-    let vpcs = match (org, project) {
-        (Some(org_name), Some(proj_name)) => {
-            let project_id = ProjectId(format!("{org_name}/{proj_name}"));
-            store
-                .list_vpcs_by_project(&project_id)
-                .map_err(|e| anyhow::anyhow!("{e}"))?
-        }
-        (Some(org_name), None) => {
-            let org_id = OrgId(org_name.to_string());
-            store
-                .list_vpcs_by_org(&org_id)
-                .map_err(|e| anyhow::anyhow!("{e}"))?
-        }
-        _ => store.list_vpcs().map_err(|e| anyhow::anyhow!("{e}"))?,
+pub async fn run_list(org: Option<&str>, project: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::VpcList {
+        org: org.map(String::from),
+        project: project.map(String::from),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&vpcs)?);
-        return Ok(());
-    }
+    match resp {
+        OrgResponse::VpcList(vpcs) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&vpcs)?);
+                return Ok(());
+            }
 
-    if vpcs.is_empty() {
-        println!("No VPCs found.");
-        if let Some(org_name) = org {
+            if vpcs.is_empty() {
+                println!("No VPCs found.");
+                if let Some(org_name) = org {
+                    println!(
+                        "\nCreate one with: syfrah vpc create <name> --project <project> --org {org_name}"
+                    );
+                }
+                return Ok(());
+            }
+
             println!(
-                "\nCreate one with: syfrah vpc create <name> --project <project> --org {org_name}"
+                "{:<20} {:<18} {:<6} {:<25} {:<8} CREATED",
+                "NAME", "CIDR", "VNI", "OWNER", "SHARED"
             );
+            println!("{}", "-".repeat(95));
+
+            for vpc in &vpcs {
+                let owner = match &vpc.owner {
+                    VpcOwner::Project(pid) => pid.0.clone(),
+                    VpcOwner::Org(oid) => oid.0.clone(),
+                };
+                let shared = if vpc.shared { "yes" } else { "no" };
+                println!(
+                    "{:<20} {:<18} {:<6} {:<25} {:<8} {}",
+                    vpc.name,
+                    vpc.cidr,
+                    vpc.vni,
+                    owner,
+                    shared,
+                    format_timestamp(vpc.created_at),
+                );
+            }
+
+            Ok(())
         }
-        return Ok(());
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
-
-    println!(
-        "{:<20} {:<18} {:<6} {:<25} {:<8} CREATED",
-        "NAME", "CIDR", "VNI", "OWNER", "SHARED"
-    );
-    println!("{}", "-".repeat(95));
-
-    for vpc in &vpcs {
-        let owner = match &vpc.owner {
-            VpcOwner::Project(pid) => pid.0.clone(),
-            VpcOwner::Org(oid) => oid.0.clone(),
-        };
-        let shared = if vpc.shared { "yes" } else { "no" };
-        println!(
-            "{:<20} {:<18} {:<6} {:<25} {:<8} {}",
-            vpc.name,
-            vpc.cidr,
-            vpc.vni,
-            owner,
-            shared,
-            format_timestamp(vpc.created_at),
-        );
-    }
-
-    Ok(())
 }
 
-pub fn run_delete(name: &str, _org: &str, yes: bool) -> Result<()> {
-    let store = open_store()?;
-
-    // Check it exists first
-    match store.get_vpc(name) {
-        Ok(Some(_)) => {}
-        Ok(None) => bail!("vpc '{name}' not found"),
-        Err(e) => bail!("failed to look up vpc: {e}"),
-    }
-
+pub async fn run_delete(name: &str, _org: &str, yes: bool) -> Result<()> {
     if !yes {
         eprint!("Delete VPC '{name}'? This cannot be undone. [y/N] ");
         let mut answer = String::new();
@@ -148,91 +144,140 @@ pub fn run_delete(name: &str, _org: &str, yes: bool) -> Result<()> {
         }
     }
 
-    store.delete_vpc(name).map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("VPC '{name}' deleted.");
-    Ok(())
-}
-
-pub fn run_attach(vpc_name: &str, project: &str) -> Result<()> {
-    let store = open_store()?;
-    store
-        .attach_vpc(vpc_name, project)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("Project '{project}' attached to VPC '{vpc_name}'.");
-    Ok(())
-}
-
-pub fn run_detach(vpc_name: &str, project: &str) -> Result<()> {
-    let store = open_store()?;
-    store
-        .detach_vpc(vpc_name, project)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("Project '{project}' detached from VPC '{vpc_name}'.");
-    Ok(())
-}
-
-pub fn run_peer(from: &str, to: &str) -> Result<()> {
-    let store = open_store()?;
-    store
-        .create_peering(from, to)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("VPCs peered: {from} <-> {to}");
-    Ok(())
-}
-
-pub fn run_unpeer(from: &str, to: &str) -> Result<()> {
-    let store = open_store()?;
-    store
-        .delete_peering(from, to)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
-    println!("VPCs unpeered: {from} <-> {to}");
-    Ok(())
-}
-
-pub fn run_peerings(vpc: Option<&str>, json: bool) -> Result<()> {
-    let store = open_store()?;
-
-    let peerings = match vpc {
-        Some(name) => store
-            .list_peerings_for_vpc(name)
-            .map_err(|e| anyhow::anyhow!("{e}"))?,
-        None => {
-            let all = store.list_peerings().map_err(|e| anyhow::anyhow!("{e}"))?;
-            all.into_iter()
-                .filter(|p| p.status == crate::types::PeeringStatus::Active)
-                .collect()
-        }
+    let req = OrgRequest::VpcDelete {
+        name: name.to_string(),
     };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    if json {
-        println!("{}", serde_json::to_string_pretty(&peerings)?);
-        return Ok(());
-    }
-
-    if peerings.is_empty() {
-        println!("No peerings found.");
-        if vpc.is_some() {
-            println!("\nCreate one with: syfrah vpc peer --from <vpc-a> --to <vpc-b>");
+    match resp {
+        OrgResponse::Ok => {
+            println!("VPC '{name}' deleted.");
+            Ok(())
         }
-        return Ok(());
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
+}
 
-    println!("{:<20} {:<20} {:<10} CREATED", "VPC_A", "VPC_B", "STATUS");
-    println!("{}", "-".repeat(70));
+pub async fn run_attach(vpc_name: &str, project: &str) -> Result<()> {
+    let req = OrgRequest::VpcAttach {
+        vpc: vpc_name.to_string(),
+        project: project.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
 
-    for p in &peerings {
-        let vpc_a_name = store.resolve_vpc_name(&p.vpc_a);
-        let vpc_b_name = store.resolve_vpc_name(&p.vpc_b);
-        println!(
-            "{:<20} {:<20} {:<10} {}",
-            vpc_a_name,
-            vpc_b_name,
-            p.status,
-            format_timestamp(p.created_at),
-        );
+    match resp {
+        OrgResponse::Ok => {
+            println!("Project '{project}' attached to VPC '{vpc_name}'.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
     }
+}
 
-    Ok(())
+pub async fn run_detach(vpc_name: &str, project: &str) -> Result<()> {
+    let req = OrgRequest::VpcDetach {
+        vpc: vpc_name.to_string(),
+        project: project.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("Project '{project}' detached from VPC '{vpc_name}'.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_peer(from: &str, to: &str) -> Result<()> {
+    let req = OrgRequest::VpcPeer {
+        from: from.to_string(),
+        to: to.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("VPCs peered: {from} <-> {to}");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_unpeer(from: &str, to: &str) -> Result<()> {
+    let req = OrgRequest::VpcUnpeer {
+        from: from.to_string(),
+        to: to.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("VPCs unpeered: {from} <-> {to}");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_peerings(vpc: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::VpcPeeringsList {
+        vpc: vpc.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::PeeringList(peerings) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&peerings)?);
+                return Ok(());
+            }
+
+            if peerings.is_empty() {
+                println!("No peerings found.");
+                if vpc.is_some() {
+                    println!("\nCreate one with: syfrah vpc peer --from <vpc-a> --to <vpc-b>");
+                }
+                return Ok(());
+            }
+
+            println!("{:<20} {:<20} {:<10} CREATED", "VPC_A", "VPC_B", "STATUS");
+            println!("{}", "-".repeat(70));
+
+            for p in &peerings {
+                println!(
+                    "{:<20} {:<20} {:<10} {}",
+                    p.vpc_a,
+                    p.vpc_b,
+                    p.status,
+                    format_timestamp(p.created_at),
+                );
+            }
+
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
 }
 
 fn format_timestamp(ts: u64) -> String {
@@ -281,7 +326,6 @@ mod tests {
 
     #[test]
     fn vpc_create_parse() {
-        // Project-scoped VPC with all flags
         let cmd = parse(&[
             "create",
             "my-vpc",
@@ -309,7 +353,6 @@ mod tests {
             other => panic!("expected Create, got {other:?}"),
         }
 
-        // Shared VPC
         let cmd = parse(&[
             "create",
             "shared-net",
@@ -336,7 +379,6 @@ mod tests {
             other => panic!("expected Create, got {other:?}"),
         }
 
-        // Project-scoped without explicit CIDR
         let cmd = parse(&[
             "create",
             "default-vpc",
@@ -421,7 +463,6 @@ mod tests {
 
     #[test]
     fn vpc_peerings_parse() {
-        // With --vpc filter and --json
         let cmd = parse(&["peerings", "--vpc", "hub-vpc", "--json"]);
         match cmd {
             VpcCommand::Peerings { vpc, json } => {
@@ -431,7 +472,6 @@ mod tests {
             other => panic!("expected Peerings, got {other:?}"),
         }
 
-        // Without filters
         let cmd = parse(&["peerings"]);
         match cmd {
             VpcCommand::Peerings { vpc, json } => {
@@ -441,7 +481,6 @@ mod tests {
             other => panic!("expected Peerings, got {other:?}"),
         }
 
-        // With only --vpc
         let cmd = parse(&["peerings", "--vpc", "my-vpc"]);
         match cmd {
             VpcCommand::Peerings { vpc, json } => {

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -10,7 +10,7 @@ pub mod types;
 pub mod validation;
 pub mod vpc;
 
-pub use api::OrgHandler;
+pub use api::{send_org_request, OrgLayerHandler, OrgRequest, OrgResponse, ResolvedSubnet};
 pub use cli::{EnvCommand, OrgCommand, ProjectCommand, SubnetCommand, VpcCommand};
 pub use error::OrgError;
 pub use ipam::{AllocationState, IpAllocation, IpamStore, SubnetBitmap};


### PR DESCRIPTION
## Summary

- Routes all org/project/env/vpc/subnet CLI commands through the daemon's Unix control socket instead of opening redb databases directly
- Adds `Org` variant to `LayerRequest`/`LayerResponse` and implements full `OrgRequest`/`OrgResponse` protocol
- Shares the org store between the org handler and compute layer in the daemon, eliminating duplicate DB opens
- Fixes `resolve_subnet()` in compute CLI to use control socket instead of opening `org.redb` directly

## Root cause

The daemon opens `org.redb`, `ipam.redb`, and `placement.redb` at startup and holds exclusive locks. CLI commands that tried to open these same files would fail because redb uses file-level locking.

## Fix

Follow the same pattern already used by compute commands: CLI sends requests through the daemon's Unix control socket, and the daemon processes them using its already-opened database handles.

## Test plan

- [ ] `syfrah fabric init` starts daemon
- [ ] `syfrah org create acme` works while daemon is running
- [ ] `syfrah project create p --org acme` works
- [ ] `syfrah env create e --project p --org acme` works
- [ ] `syfrah subnet create s --env e --project p --org acme` works
- [ ] `syfrah compute vm create --name vm1 --image alpine-3.20 --vcpus 1 --memory 512 --subnet s --project p --org acme --ssh-key ~/.ssh/id_ed25519.pub` works
- [ ] All existing tests pass (`cargo test -p syfrah-org -p syfrah-compute -p syfrah-fabric -p syfrah-bin -p syfrah-api`: 189 passed)

Closes #850