### PR TITLE
Fix interface names exceeding Linux 15-char limit

### DIFF
--- a/layers/compute/src/network.rs
+++ b/layers/compute/src/network.rs
@@ -21,7 +21,7 @@ use syfrah_overlay::NetworkBackend;
 /// This stores everything needed to tear down the VM's network on delete.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInfo {
-    /// VPC ID (used for bridge/VXLAN naming: syfbr-{vpc_id}, syfvx-{vpc_id}).
+    /// VPC ID (used for bridge/VXLAN naming via the `syfrah_overlay::naming` module).
     pub vpc_id: String,
     /// Subnet ID (used for IPAM release).
     pub subnet_id: String,
@@ -31,7 +31,7 @@ pub struct NetworkInfo {
     pub ip: String,
     /// Derived MAC address (e.g., "02:00:0a:00:01:03").
     pub mac: String,
-    /// TAP device name (e.g., "syftap-web-1").
+    /// TAP device name (hash-based, e.g., "syft-a1b2c3d4").
     pub tap_name: String,
     /// Hosting node fabric address (for FDB removal).
     pub hosting_node: String,
@@ -76,8 +76,8 @@ impl<B: NetworkBackend + ?Sized> NetworkCleanup<B> {
         ipam_release: Option<Box<dyn FnOnce() -> Result<(), String> + Send>>,
     ) -> CleanupResult {
         let mut result = CleanupResult::default();
-        let bridge = format!("syfbr-{}", info.vpc_id);
-        let vxlan = format!("syfvx-{}", info.vpc_id);
+        let bridge = syfrah_overlay::naming::bridge_name(&info.vpc_id);
+        let vxlan = syfrah_overlay::naming::vxlan_name(&info.vpc_id);
 
         // 1. Remove FDB entry
         if let Err(e) = self.backend.remove_fdb_entry(&bridge, &info.mac).await {
@@ -232,7 +232,7 @@ mod tests {
             subnet_cidr: "10.0.1.0/24".to_string(),
             ip: "10.0.1.3".to_string(),
             mac: "02:00:0a:00:01:03".to_string(),
-            tap_name: "syftap-web-1".to_string(),
+            tap_name: syfrah_overlay::naming::tap_name("web-1"),
             hosting_node: "fd00::1".to_string(),
         }
     }
@@ -266,7 +266,7 @@ mod tests {
 
         let calls = backend.calls();
         assert!(
-            calls.iter().any(|c| c == "delete_tap(syftap-web-1)"),
+            calls.iter().any(|c| c == &format!("delete_tap({})", syfrah_overlay::naming::tap_name("web-1"))),
             "delete_tap should have been called"
         );
     }
@@ -282,9 +282,10 @@ mod tests {
 
         let calls = backend.calls();
         assert!(
-            calls
-                .iter()
-                .any(|c| c.starts_with("remove_fdb_entry(syfbr-100")),
+            calls.iter().any(|c| c.starts_with(&format!(
+                "remove_fdb_entry({}",
+                syfrah_overlay::naming::bridge_name("100")
+            ))),
             "remove_fdb_entry should have been called"
         );
     }
@@ -303,18 +304,20 @@ mod tests {
         );
 
         let calls = backend.calls();
+        let br = syfrah_overlay::naming::bridge_name("100");
+        let vx = syfrah_overlay::naming::vxlan_name("100");
         assert!(
-            calls.iter().any(|c| c == "delete_bridge(syfbr-100)"),
+            calls.iter().any(|c| c == &format!("delete_bridge({br})")),
             "delete_bridge should have been called"
         );
         assert!(
-            calls.iter().any(|c| c == "delete_vxlan(syfvx-100)"),
+            calls.iter().any(|c| c == &format!("delete_vxlan({vx})")),
             "delete_vxlan should have been called"
         );
         assert!(
             calls
                 .iter()
-                .any(|c| c == "remove_nat(syfbr-100, 10.0.1.0/24)"),
+                .any(|c| c == &format!("remove_nat({br}, 10.0.1.0/24)")),
             "remove_nat should have been called"
         );
     }

--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -178,9 +178,9 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         ip: &str,
         mac: &str,
     ) -> Result<NetworkSetupResult, ComputeError> {
-        let bridge_name = format!("syfbr-{vpc_id}");
-        let vxlan_name = format!("syfvx-{vpc_id}");
-        let tap_name = format!("syftap-{vm_id}");
+        let bridge_name = syfrah_overlay::naming::bridge_name(vpc_id);
+        let vxlan_name = syfrah_overlay::naming::vxlan_name(vpc_id);
+        let tap_name = syfrah_overlay::naming::tap_name(vm_id);
 
         // Parse prefix length from CIDR.
         let prefix_len = parse_prefix_len(subnet_cidr)?;
@@ -345,7 +345,7 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         ip: &str,
         tap_name: &str,
     ) -> Result<(), ComputeError> {
-        let _bridge_name = format!("syfbr-{vpc_id}");
+        let _bridge_name = syfrah_overlay::naming::bridge_name(vpc_id);
 
         // Remove nftables rules (best-effort).
         if let Err(e) = self.backend.remove_vm_rules(tap_name).await {
@@ -542,14 +542,17 @@ mod tests {
 
         let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
 
-        assert_eq!(result.tap_name, "syftap-web-1");
+        let expected_tap = syfrah_overlay::naming::tap_name("web-1");
+        assert_eq!(result.tap_name, expected_tap);
 
         // Verify TAP was created and attached to bridge
         let calls = h.backend.calls();
-        assert!(calls.iter().any(|c| c == "create_tap(syftap-web-1)"));
         assert!(calls
             .iter()
-            .any(|c| c.starts_with("attach_to_bridge(syftap-web-1")));
+            .any(|c| c == &format!("create_tap({expected_tap})")));
+        assert!(calls
+            .iter()
+            .any(|c| c.starts_with(&format!("attach_to_bridge({expected_tap}"))));
     }
 
     #[tokio::test]
@@ -562,7 +565,10 @@ mod tests {
         let calls = h.backend.calls();
         // Bridge should be created with the VPC ID
         assert!(
-            calls.iter().any(|c| c.starts_with("create_bridge(syfbr-")),
+            calls.iter().any(|c| c.starts_with(&format!(
+                "create_bridge({}",
+                syfrah_overlay::naming::BRIDGE_PREFIX
+            ))),
             "bridge must be created"
         );
     }

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -79,7 +79,7 @@ pub trait NetworkBackend: Send + Sync {
     /// List kernel network interfaces matching a given prefix.
     ///
     /// Used by the reconciliation loop and daemon restart recovery to
-    /// discover existing `syfbr-*`, `syfvx-*`, `syftap-*`, and
-    /// `syfpeer-*` interfaces.
+    /// discover existing `syfb-*`, `syfx-*`, `syft-*`, and
+    /// `syfp*` interfaces.
     async fn list_interfaces(&self, prefix: &str) -> Result<Vec<String>>;
 }

--- a/layers/overlay/src/bridge_tests.rs
+++ b/layers/overlay/src/bridge_tests.rs
@@ -2,58 +2,58 @@
 mod tests {
     use crate::backend::NetworkBackend;
     use crate::mock::MockBackend;
+    use crate::naming;
 
     #[tokio::test]
     async fn create_bridge() {
         let backend = MockBackend::new();
-        backend.create_bridge("syfbr-100").await.unwrap();
+        let br = naming::bridge_name("100");
+        backend.create_bridge(&br).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], "create_bridge(syfbr-100)");
+        assert_eq!(calls[0], format!("create_bridge({br})"));
     }
 
     #[tokio::test]
     async fn add_gateway_ip() {
         let backend = MockBackend::new();
-        backend
-            .add_bridge_ip("syfbr-100", "10.1.1.1", 24)
-            .await
-            .unwrap();
+        let br = naming::bridge_name("100");
+        backend.add_bridge_ip(&br, "10.1.1.1", 24).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], "add_bridge_ip(syfbr-100, 10.1.1.1, 24)");
+        assert_eq!(calls[0], format!("add_bridge_ip({br}, 10.1.1.1, 24)"));
     }
 
     #[tokio::test]
     async fn remove_gateway_ip() {
         let backend = MockBackend::new();
-        backend
-            .remove_bridge_ip("syfbr-100", "10.1.1.1")
-            .await
-            .unwrap();
+        let br = naming::bridge_name("100");
+        backend.remove_bridge_ip(&br, "10.1.1.1").await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], "remove_bridge_ip(syfbr-100, 10.1.1.1)");
+        assert_eq!(calls[0], format!("remove_bridge_ip({br}, 10.1.1.1)"));
     }
 
     #[tokio::test]
     async fn delete_bridge() {
         let backend = MockBackend::new();
-        backend.delete_bridge("syfbr-100").await.unwrap();
+        let br = naming::bridge_name("100");
+        backend.delete_bridge(&br).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], "delete_bridge(syfbr-100)");
+        assert_eq!(calls[0], format!("delete_bridge({br})"));
     }
 
     #[tokio::test]
     async fn idempotent_create() {
         let backend = MockBackend::new();
-        backend.create_bridge("syfbr-200").await.unwrap();
-        backend.create_bridge("syfbr-200").await.unwrap();
+        let br = naming::bridge_name("200");
+        backend.create_bridge(&br).await.unwrap();
+        backend.create_bridge(&br).await.unwrap();
 
         // MockBackend records both calls — the real LinuxBackend would
         // skip the second via interface_exists check.  What matters is
@@ -66,14 +66,20 @@ mod tests {
     #[tokio::test]
     async fn multi_subnet_gateways() {
         let backend = MockBackend::new();
-        let bridge = "syfbr-100";
+        let bridge = naming::bridge_name("100");
 
-        backend.add_bridge_ip(bridge, "10.1.1.1", 24).await.unwrap();
-        backend.add_bridge_ip(bridge, "10.1.2.1", 24).await.unwrap();
+        backend
+            .add_bridge_ip(&bridge, "10.1.1.1", 24)
+            .await
+            .unwrap();
+        backend
+            .add_bridge_ip(&bridge, "10.1.2.1", 24)
+            .await
+            .unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], "add_bridge_ip(syfbr-100, 10.1.1.1, 24)");
-        assert_eq!(calls[1], "add_bridge_ip(syfbr-100, 10.1.2.1, 24)");
+        assert_eq!(calls[0], format!("add_bridge_ip({bridge}, 10.1.1.1, 24)"));
+        assert_eq!(calls[1], format!("add_bridge_ip({bridge}, 10.1.2.1, 24)"));
     }
 }

--- a/layers/overlay/src/fdb.rs
+++ b/layers/overlay/src/fdb.rs
@@ -8,6 +8,7 @@ use tracing::{info, warn};
 
 use crate::backend::NetworkBackend;
 use crate::error::{OverlayError, Result};
+use crate::naming;
 
 /// Action carried by a VM placement announcement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,8 +63,8 @@ pub async fn rebuild_fdb(
             continue;
         }
 
-        let bridge = format!("syfbr-{}", p.vpc_id);
-        let vxlan = format!("syfvx-{}", p.vpc_id);
+        let bridge = naming::bridge_name(&p.vpc_id);
+        let vxlan = naming::vxlan_name(&p.vpc_id);
 
         match add_fdb_entry(backend, &bridge, &p.vm_mac, &p.hosting_node).await {
             Ok(()) => {}
@@ -104,12 +105,12 @@ pub async fn rebuild_fdb(
 
 /// Naming convention: VXLAN interface for a given bridge.
 ///
-/// Bridge name: `syfbr-{vpc_id}` -> VXLAN name: `syfvx-{vpc_id}`.
+/// Bridge name: `syfb-{hash}` -> VXLAN name: `syfx-{hash}`.
 fn vxlan_name_from_bridge(bridge: &str) -> Result<String> {
     let suffix = bridge
-        .strip_prefix("syfbr-")
+        .strip_prefix(naming::BRIDGE_PREFIX)
         .ok_or_else(|| OverlayError::InterfaceNotFound(bridge.to_string()))?;
-    Ok(format!("syfvx-{suffix}"))
+    Ok(format!("{}{suffix}", naming::VXLAN_PREFIX))
 }
 
 /// Add a static FDB entry for a remote VM.
@@ -176,8 +177,8 @@ pub async fn sync_placement(
         return Ok(());
     }
 
-    let bridge = format!("syfbr-{}", placement.vpc_id);
-    let vxlan = format!("syfvx-{}", placement.vpc_id);
+    let bridge = naming::bridge_name(&placement.vpc_id);
+    let vxlan = naming::vxlan_name(&placement.vpc_id);
 
     match placement.action {
         PlacementAction::Add => {
@@ -198,8 +199,12 @@ mod tests {
     use super::*;
     use crate::mock::MockBackend;
 
-    const BRIDGE: &str = "syfbr-100";
-    const VXLAN: &str = "syfvx-100";
+    fn bridge_100() -> String {
+        naming::bridge_name("100")
+    }
+    fn vxlan_100() -> String {
+        naming::vxlan_name("100")
+    }
     const MAC: &str = "02:00:0a:00:01:05";
     const IP: &str = "10.0.1.5";
     const VTEP: &str = "fd12:3456:7800::2";
@@ -207,11 +212,12 @@ mod tests {
     #[tokio::test]
     async fn add_fdb_entry_correct_mac_and_vtep() {
         let backend = MockBackend::new();
-        add_fdb_entry(&backend, BRIDGE, MAC, VTEP).await.unwrap();
+        let bridge = bridge_100();
+        add_fdb_entry(&backend, &bridge, MAC, VTEP).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], format!("add_fdb_entry({BRIDGE}, {MAC}, {VTEP})"));
+        assert_eq!(calls[0], format!("add_fdb_entry({bridge}, {MAC}, {VTEP})"));
     }
 
     #[tokio::test]
@@ -225,28 +231,32 @@ mod tests {
     #[tokio::test]
     async fn remove_fdb_entry_cleanup() {
         let backend = MockBackend::new();
-        add_fdb_entry(&backend, BRIDGE, MAC, VTEP).await.unwrap();
-        remove_fdb_entry(&backend, BRIDGE, MAC).await.unwrap();
+        let bridge = bridge_100();
+        add_fdb_entry(&backend, &bridge, MAC, VTEP).await.unwrap();
+        remove_fdb_entry(&backend, &bridge, MAC).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[1], format!("remove_fdb_entry({BRIDGE}, {MAC})"));
+        assert_eq!(calls[1], format!("remove_fdb_entry({bridge}, {MAC})"));
     }
 
     #[tokio::test]
     async fn add_arp_proxy_entry() {
         let backend = MockBackend::new();
-        add_arp_proxy(&backend, VXLAN, IP, MAC).await.unwrap();
+        let vxlan = vxlan_100();
+        add_arp_proxy(&backend, &vxlan, IP, MAC).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], format!("add_arp_proxy({VXLAN}, {IP}, {MAC})"));
+        assert_eq!(calls[0], format!("add_arp_proxy({vxlan}, {IP}, {MAC})"));
     }
 
     #[tokio::test]
     async fn register_remote_vm_adds_fdb_and_arp() {
         let backend = MockBackend::new();
-        register_remote_vm(&backend, BRIDGE, VXLAN, MAC, IP, VTEP)
+        let bridge = bridge_100();
+        let vxlan = vxlan_100();
+        register_remote_vm(&backend, &bridge, &vxlan, MAC, IP, VTEP)
             .await
             .unwrap();
 
@@ -277,9 +287,11 @@ mod tests {
             .unwrap();
 
         let calls = backend.calls();
+        let bridge = bridge_100();
+        let vxlan = vxlan_100();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], format!("add_fdb_entry(syfbr-100, {MAC}, {VTEP})"));
-        assert_eq!(calls[1], format!("add_arp_proxy(syfvx-100, {IP}, {MAC})"));
+        assert_eq!(calls[0], format!("add_fdb_entry({bridge}, {MAC}, {VTEP})"));
+        assert_eq!(calls[1], format!("add_arp_proxy({vxlan}, {IP}, {MAC})"));
     }
 
     #[tokio::test]
@@ -292,8 +304,10 @@ mod tests {
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], format!("remove_fdb_entry(syfbr-100, {MAC})"));
-        assert_eq!(calls[1], format!("remove_arp_proxy(syfvx-100, {IP})"));
+        let bridge = bridge_100();
+        let vxlan = vxlan_100();
+        assert_eq!(calls[0], format!("remove_fdb_entry({bridge}, {MAC})"));
+        assert_eq!(calls[1], format!("remove_arp_proxy({vxlan}, {IP})"));
     }
 
     #[tokio::test]
@@ -360,8 +374,10 @@ mod tests {
         let calls = backend.calls();
         // 3 remote placements x 2 calls each (FDB + ARP)
         assert_eq!(calls.len(), 6);
-        assert!(calls[0].contains("add_fdb_entry(syfbr-100"));
-        assert!(calls[1].contains("add_arp_proxy(syfvx-100"));
+        let bridge = bridge_100();
+        let vxlan = vxlan_100();
+        assert!(calls[0].contains(&format!("add_fdb_entry({bridge}")));
+        assert!(calls[1].contains(&format!("add_arp_proxy({vxlan}")));
     }
 
     #[tokio::test]

--- a/layers/overlay/src/lib.rs
+++ b/layers/overlay/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod fdb;
 pub mod linux;
 pub mod mock;
+pub mod naming;
 pub mod nft;
 pub mod reconcile;
 pub mod recovery;

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -170,13 +170,13 @@ impl NetworkBackend for LinuxBackend {
     }
 
     async fn add_fdb_entry(&self, bridge: &str, mac: &str, vtep: &str) -> Result<()> {
-        let vxlan = bridge.replace("syfbr-", "syfvx-");
+        let vxlan = bridge.replace(crate::naming::BRIDGE_PREFIX, crate::naming::VXLAN_PREFIX);
         Self::run("bridge", &["fdb", "add", mac, "dev", &vxlan, "dst", vtep]).await?;
         Ok(())
     }
 
     async fn remove_fdb_entry(&self, bridge: &str, mac: &str) -> Result<()> {
-        let vxlan = bridge.replace("syfbr-", "syfvx-");
+        let vxlan = bridge.replace(crate::naming::BRIDGE_PREFIX, crate::naming::VXLAN_PREFIX);
         Self::run("bridge", &["fdb", "del", mac, "dev", &vxlan]).await?;
         Ok(())
     }
@@ -344,7 +344,7 @@ impl NetworkBackend for LinuxBackend {
             if !trimmed.contains(tap) {
                 continue;
             }
-            // Lines look like: "iif "syftap-xxx" ... # handle 42"
+            // Lines look like: "iif "syft-xxx" ... # handle 42"
             if let Some(handle_pos) = trimmed.rfind("# handle ") {
                 let handle = trimmed[handle_pos + 9..].trim();
                 Self::run(

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -221,55 +221,58 @@ mod tests {
     #[tokio::test]
     async fn mock_backend_records_calls() {
         let backend = MockBackend::new();
-        backend.create_bridge("syfbr-100").await.unwrap();
+        let br = crate::naming::bridge_name("100");
+        backend.create_bridge(&br).await.unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], "create_bridge(syfbr-100)");
+        assert_eq!(calls[0], format!("create_bridge({br})"));
     }
 
     #[tokio::test]
     async fn trait_method_coverage() {
         let b = MockBackend::new();
+        let br100 = crate::naming::bridge_name("100");
+        let br200 = crate::naming::bridge_name("200");
+        let vx100 = crate::naming::vxlan_name("100");
+        let tap = crate::naming::tap_name("vm1");
+        let vh = crate::naming::veth_host_name("a");
+        let vc = crate::naming::veth_container_name("b");
 
-        b.create_vxlan("syfvx-100", 100, "fd00::1", 4789)
+        b.create_vxlan(&vx100, 100, "fd00::1", 4789).await.unwrap();
+        b.delete_vxlan(&vx100).await.unwrap();
+        b.add_fdb_entry(&br100, "02:00:0a:01:01:03", "fd00::2")
             .await
             .unwrap();
-        b.delete_vxlan("syfvx-100").await.unwrap();
-        b.add_fdb_entry("syfbr-100", "02:00:0a:01:01:03", "fd00::2")
+        b.remove_fdb_entry(&br100, "02:00:0a:01:01:03")
             .await
             .unwrap();
-        b.remove_fdb_entry("syfbr-100", "02:00:0a:01:01:03")
+        b.add_arp_proxy(&vx100, "10.1.1.3", "02:00:0a:01:01:03")
             .await
             .unwrap();
-        b.add_arp_proxy("syfvx-100", "10.1.1.3", "02:00:0a:01:01:03")
-            .await
-            .unwrap();
-        b.remove_arp_proxy("syfvx-100", "10.1.1.3").await.unwrap();
+        b.remove_arp_proxy(&vx100, "10.1.1.3").await.unwrap();
 
-        b.create_bridge("syfbr-100").await.unwrap();
-        b.add_bridge_ip("syfbr-100", "10.1.1.1", 24).await.unwrap();
-        b.remove_bridge_ip("syfbr-100", "10.1.1.1").await.unwrap();
-        b.delete_bridge("syfbr-100").await.unwrap();
-        b.attach_to_bridge("syfvx-100", "syfbr-100").await.unwrap();
+        b.create_bridge(&br100).await.unwrap();
+        b.add_bridge_ip(&br100, "10.1.1.1", 24).await.unwrap();
+        b.remove_bridge_ip(&br100, "10.1.1.1").await.unwrap();
+        b.delete_bridge(&br100).await.unwrap();
+        b.attach_to_bridge(&vx100, &br100).await.unwrap();
 
-        b.create_tap("syftap-vm1").await.unwrap();
-        b.delete_tap("syftap-vm1").await.unwrap();
-        b.create_veth_pair("syfve-a", "syfve-b").await.unwrap();
+        b.create_tap(&tap).await.unwrap();
+        b.delete_tap(&tap).await.unwrap();
+        b.create_veth_pair(&vh, &vc).await.unwrap();
 
-        b.apply_vm_rules("syftap-vm1", "02:00:0a:01:01:03", "10.1.1.3")
+        b.apply_vm_rules(&tap, "02:00:0a:01:01:03", "10.1.1.3")
             .await
             .unwrap();
-        b.remove_vm_rules("syftap-vm1").await.unwrap();
-        b.apply_nat("syfbr-100", "10.1.1.0/24").await.unwrap();
-        b.remove_nat("syfbr-100", "10.1.1.0/24").await.unwrap();
-        b.apply_peering_rules("syfbr-100", "syfbr-200")
+        b.remove_vm_rules(&tap).await.unwrap();
+        b.apply_nat(&br100, "10.1.1.0/24").await.unwrap();
+        b.remove_nat(&br100, "10.1.1.0/24").await.unwrap();
+        b.apply_peering_rules(&br100, &br200).await.unwrap();
+        b.remove_peering_rules(&br100, &br200).await.unwrap();
+        b.list_interfaces(crate::naming::BRIDGE_PREFIX)
             .await
             .unwrap();
-        b.remove_peering_rules("syfbr-100", "syfbr-200")
-            .await
-            .unwrap();
-        b.list_interfaces("syfbr-").await.unwrap();
 
         let calls = b.calls();
         assert_eq!(calls.len(), 21, "expected one call per trait method");

--- a/layers/overlay/src/naming.rs
+++ b/layers/overlay/src/naming.rs
@@ -1,0 +1,204 @@
+//! Deterministic interface naming that respects the Linux 15-character limit.
+//!
+//! Linux network interfaces (bridges, VXLANs, TAPs, veths) must have names
+//! no longer than 15 characters (`IFNAMSIZ - 1`). VPC/VM identifiers can be
+//! arbitrarily long, so we hash the input to a fixed 8-hex-digit suffix.
+//!
+//! Naming conventions:
+//! - Bridge:         `syfb-{hash}`   (13 chars)
+//! - VXLAN:          `syfx-{hash}`   (13 chars)
+//! - TAP:            `syft-{hash}`   (13 chars)
+//! - veth host:      `syfvh{hash}`   (13 chars)
+//! - veth container: `syfvc{hash}`   (13 chars)
+//! - peer veth A:    `syfpa{hash}`   (13 chars)
+//! - peer veth B:    `syfpb{hash}`   (13 chars)
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// Linux interface name length limit (`IFNAMSIZ - 1`).
+pub const IFNAMSIZ_MAX: usize = 15;
+
+fn short_hash(input: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    input.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() & 0xFFFF_FFFF)
+}
+
+/// Bridge interface name for a VPC: `syfb-{hash}`.
+pub fn bridge_name(vpc_id: &str) -> String {
+    format!("syfb-{}", short_hash(vpc_id))
+}
+
+/// VXLAN interface name for a VPC: `syfx-{hash}`.
+pub fn vxlan_name(vpc_id: &str) -> String {
+    format!("syfx-{}", short_hash(vpc_id))
+}
+
+/// TAP interface name for a VM: `syft-{hash}`.
+pub fn tap_name(vm_id: &str) -> String {
+    format!("syft-{}", short_hash(vm_id))
+}
+
+/// Veth host-side name for a container: `syfvh{hash}`.
+pub fn veth_host_name(vm_id: &str) -> String {
+    format!("syfvh{}", short_hash(vm_id))
+}
+
+/// Veth container-side name: `syfvc{hash}`.
+pub fn veth_container_name(vm_id: &str) -> String {
+    format!("syfvc{}", short_hash(vm_id))
+}
+
+/// Peering veth end A: `syfpa{hash}`.
+pub fn peer_name_a(peering_id: &str) -> String {
+    format!("syfpa{}", short_hash(peering_id))
+}
+
+/// Peering veth end B: `syfpb{hash}`.
+pub fn peer_name_b(peering_id: &str) -> String {
+    format!("syfpb{}", short_hash(peering_id))
+}
+
+/// Prefix used for bridge interface names (for `list_interfaces`).
+pub const BRIDGE_PREFIX: &str = "syfb-";
+
+/// Prefix used for VXLAN interface names.
+pub const VXLAN_PREFIX: &str = "syfx-";
+
+/// Prefix used for TAP interface names.
+pub const TAP_PREFIX: &str = "syft-";
+
+/// Prefix used for peering veth interfaces.
+pub const PEER_PREFIX: &str = "syfp";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bridge_name_within_limit() {
+        let name = bridge_name("acme-backend-default-very-long-vpc-name");
+        assert!(
+            name.len() <= IFNAMSIZ_MAX,
+            "bridge name '{}' is {} chars, exceeds {}",
+            name,
+            name.len(),
+            IFNAMSIZ_MAX
+        );
+        assert!(name.starts_with(BRIDGE_PREFIX));
+    }
+
+    #[test]
+    fn vxlan_name_within_limit() {
+        let name = vxlan_name("acme-backend-default-very-long-vpc-name");
+        assert!(
+            name.len() <= IFNAMSIZ_MAX,
+            "vxlan name '{}' is {} chars, exceeds {}",
+            name,
+            name.len(),
+            IFNAMSIZ_MAX
+        );
+        assert!(name.starts_with(VXLAN_PREFIX));
+    }
+
+    #[test]
+    fn tap_name_within_limit() {
+        let name = tap_name("my-super-long-vm-identifier-12345");
+        assert!(
+            name.len() <= IFNAMSIZ_MAX,
+            "tap name '{}' is {} chars, exceeds {}",
+            name,
+            name.len(),
+            IFNAMSIZ_MAX
+        );
+        assert!(name.starts_with(TAP_PREFIX));
+    }
+
+    #[test]
+    fn veth_host_name_within_limit() {
+        let name = veth_host_name("my-super-long-vm-identifier-12345");
+        assert!(
+            name.len() <= IFNAMSIZ_MAX,
+            "veth host name '{}' is {} chars, exceeds {}",
+            name,
+            name.len(),
+            IFNAMSIZ_MAX
+        );
+    }
+
+    #[test]
+    fn veth_container_name_within_limit() {
+        let name = veth_container_name("my-super-long-vm-identifier-12345");
+        assert!(
+            name.len() <= IFNAMSIZ_MAX,
+            "veth container name '{}' is {} chars, exceeds {}",
+            name,
+            name.len(),
+            IFNAMSIZ_MAX
+        );
+    }
+
+    #[test]
+    fn peer_names_within_limit() {
+        let a = peer_name_a("very-long-peering-identifier-abc-123");
+        let b = peer_name_b("very-long-peering-identifier-abc-123");
+        assert!(
+            a.len() <= IFNAMSIZ_MAX,
+            "peer_a name '{}' is {} chars, exceeds {}",
+            a,
+            a.len(),
+            IFNAMSIZ_MAX
+        );
+        assert!(
+            b.len() <= IFNAMSIZ_MAX,
+            "peer_b name '{}' is {} chars, exceeds {}",
+            b,
+            b.len(),
+            IFNAMSIZ_MAX
+        );
+    }
+
+    #[test]
+    fn deterministic_hashing() {
+        // Same input always produces the same output.
+        assert_eq!(bridge_name("vpc-100"), bridge_name("vpc-100"));
+        assert_eq!(tap_name("vm-1"), tap_name("vm-1"));
+    }
+
+    #[test]
+    fn different_inputs_different_hashes() {
+        assert_ne!(bridge_name("vpc-100"), bridge_name("vpc-200"));
+        assert_ne!(tap_name("vm-1"), tap_name("vm-2"));
+    }
+
+    #[test]
+    fn all_names_at_most_13_chars() {
+        // With a 4-char prefix + dash + 8 hex chars = 13, or 5-char prefix + 8 = 13.
+        let inputs = [
+            "a",
+            "short",
+            "medium-length-id",
+            "a-very-long-identifier-that-would-blow-up-the-old-format",
+        ];
+        for input in &inputs {
+            for name in [
+                bridge_name(input),
+                vxlan_name(input),
+                tap_name(input),
+                veth_host_name(input),
+                veth_container_name(input),
+                peer_name_a(input),
+                peer_name_b(input),
+            ] {
+                assert!(
+                    name.len() <= 13,
+                    "name '{}' for input '{}' is {} chars",
+                    name,
+                    input,
+                    name.len()
+                );
+            }
+        }
+    }
+}

--- a/layers/overlay/src/nft.rs
+++ b/layers/overlay/src/nft.rs
@@ -232,49 +232,55 @@ pub fn generate_remove_peering_rules(bridge_a: &str, bridge_b: &str) -> String {
 mod tests {
     use super::*;
 
-    const TAP: &str = "syftap-vm1";
+    fn tap() -> String {
+        crate::naming::tap_name("vm1")
+    }
     const MAC: &str = "02:00:0a:00:01:05";
     const IP: Ipv4Addr = Ipv4Addr::new(10, 0, 1, 5);
 
     fn rules() -> String {
-        generate_vm_rules(TAP, MAC, IP)
+        generate_vm_rules(&tap(), MAC, IP)
     }
 
     #[test]
     fn anti_spoof_rules_generated() {
         let r = rules();
-        assert!(r.contains(&format!("iif {TAP} ether saddr != {MAC} drop")));
-        assert!(r.contains(&format!("iif {TAP} ip saddr != {IP} drop")));
+        let t = tap();
+        assert!(r.contains(&format!("iif {t} ether saddr != {MAC} drop")));
+        assert!(r.contains(&format!("iif {t} ip saddr != {IP} drop")));
     }
 
     #[test]
     fn default_deny_ingress() {
         let r = rules();
-        assert!(r.contains(&format!("oif {TAP} drop")));
+        assert!(r.contains(&format!("oif {} drop", tap())));
     }
 
     #[test]
     fn ssh_allowed() {
         let r = rules();
-        assert!(r.contains(&format!("oif {TAP} tcp dport 22 accept")));
+        assert!(r.contains(&format!("oif {} tcp dport 22 accept", tap())));
     }
 
     #[test]
     fn icmp_allowed() {
         let r = rules();
-        assert!(r.contains(&format!("oif {TAP} icmp type echo-request accept")));
+        assert!(r.contains(&format!("oif {} icmp type echo-request accept", tap())));
     }
 
     #[test]
     fn egress_allowed() {
         let r = rules();
-        assert!(r.contains(&format!("iif {TAP} accept")));
+        assert!(r.contains(&format!("iif {} accept", tap())));
     }
 
     #[test]
     fn conntrack_established() {
         let r = rules();
-        assert!(r.contains(&format!("oif {TAP} ct state established,related accept")));
+        assert!(r.contains(&format!(
+            "oif {} ct state established,related accept",
+            tap()
+        )));
     }
 
     #[test]
@@ -289,8 +295,9 @@ mod tests {
         let r = rules();
         let mac_spoof_pos = r.find("ether saddr !=").expect("MAC spoof rule");
         let ip_spoof_pos = r.find("ip saddr !=").expect("IP spoof rule");
-        let egress_pos = r.find(&format!("iif {TAP} accept")).expect("egress rule");
-        let deny_pos = r.find(&format!("oif {TAP} drop")).expect("deny rule");
+        let t = tap();
+        let egress_pos = r.find(&format!("iif {t} accept")).expect("egress rule");
+        let deny_pos = r.find(&format!("oif {t} drop")).expect("deny rule");
         let ssh_pos = r.find("tcp dport 22 accept").expect("SSH rule");
         assert!(mac_spoof_pos < ip_spoof_pos);
         assert!(ip_spoof_pos < egress_pos);
@@ -299,16 +306,19 @@ mod tests {
 
     #[test]
     fn subnet_isolation_blocks_both_directions() {
-        let rules = generate_subnet_isolation("syfbr-100", "10.1.1.0/24", "10.1.2.0/24");
+        let br = crate::naming::bridge_name("100");
+        let rules = generate_subnet_isolation(&br, "10.1.1.0/24", "10.1.2.0/24");
         assert!(rules.contains("ip saddr 10.1.1.0/24 ip daddr 10.1.2.0/24 drop"));
         assert!(rules.contains("ip saddr 10.1.2.0/24 ip daddr 10.1.1.0/24 drop"));
     }
 
     #[test]
     fn vpc_isolation_blocks_both_directions() {
-        let rules = generate_vpc_isolation("syfbr-100", "syfbr-200");
-        assert!(rules.contains("iif syfbr-100 oif syfbr-200 drop"));
-        assert!(rules.contains("iif syfbr-200 oif syfbr-100 drop"));
+        let br_a = crate::naming::bridge_name("100");
+        let br_b = crate::naming::bridge_name("200");
+        let rules = generate_vpc_isolation(&br_a, &br_b);
+        assert!(rules.contains(&format!("iif {br_a} oif {br_b} drop")));
+        assert!(rules.contains(&format!("iif {br_b} oif {br_a} drop")));
     }
 
     #[test]
@@ -318,38 +328,48 @@ mod tests {
 
     #[test]
     fn subnet_isolation_uses_bridge_name() {
-        let rules = generate_subnet_isolation("syfbr-vpc42", "10.0.1.0/24", "10.0.2.0/24");
-        assert!(rules.contains("iif syfbr-vpc42 oif syfbr-vpc42"));
+        let br = crate::naming::bridge_name("vpc42");
+        let rules = generate_subnet_isolation(&br, "10.0.1.0/24", "10.0.2.0/24");
+        assert!(rules.contains(&format!("iif {br} oif {br}")));
     }
 
     // ── SNAT tests ──────────────────────────────────────────────────
 
     #[test]
     fn snat_rule_generated() {
-        let rules = generate_nat_rules("syfbr-100", "10.1.1.0/24");
+        let br = crate::naming::bridge_name("100");
+        let rules = generate_nat_rules(&br, "10.1.1.0/24");
         assert!(rules.contains("masquerade"));
         assert!(rules.contains("10.1.1.0/24"));
-        assert!(rules.contains("syfbr-100"));
+        assert!(rules.contains(&br));
     }
 
     #[test]
     fn masquerade_per_bridge() {
-        let expr = masquerade_rule_expr("syfbr-200", "10.2.0.0/16");
-        assert_eq!(expr, "oif != \"syfbr-200\" ip saddr 10.2.0.0/16 masquerade");
+        let br = crate::naming::bridge_name("200");
+        let expr = masquerade_rule_expr(&br, "10.2.0.0/16");
+        assert_eq!(
+            expr,
+            format!("oif != \"{br}\" ip saddr 10.2.0.0/16 masquerade")
+        );
     }
 
     // ── Peering tests ───────────────────────────────────────────────
 
     #[test]
     fn peering_forward_rules() {
-        let rules = generate_peering_rules("syfbr-100", "syfbr-200");
-        assert!(rules.contains("iif syfbr-100 oif syfbr-200 accept"));
-        assert!(rules.contains("iif syfbr-200 oif syfbr-100 accept"));
+        let br_a = crate::naming::bridge_name("100");
+        let br_b = crate::naming::bridge_name("200");
+        let rules = generate_peering_rules(&br_a, &br_b);
+        assert!(rules.contains(&format!("iif {br_a} oif {br_b} accept")));
+        assert!(rules.contains(&format!("iif {br_b} oif {br_a} accept")));
     }
 
     #[test]
     fn peering_rules_removed() {
-        let rules = generate_remove_peering_rules("syfbr-100", "syfbr-200");
-        assert!(rules.contains("remove peering rules syfbr-100 <-> syfbr-200"));
+        let br_a = crate::naming::bridge_name("100");
+        let br_b = crate::naming::bridge_name("200");
+        let rules = generate_remove_peering_rules(&br_a, &br_b);
+        assert!(rules.contains(&format!("remove peering rules {br_a} <-> {br_b}")));
     }
 }

--- a/layers/overlay/src/reconcile.rs
+++ b/layers/overlay/src/reconcile.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 
 use crate::backend::NetworkBackend;
+use crate::naming;
 
 // ── Expected state (from redb) ─────────────────────────────────────────
 
@@ -155,7 +156,8 @@ async fn check_bridges(
     state: &NetworkState,
     report: &mut ReconcileReport,
 ) {
-    let kernel_bridges: HashSet<String> = match backend.list_interfaces("syfbr-").await {
+    let kernel_bridges: HashSet<String> = match backend.list_interfaces(naming::BRIDGE_PREFIX).await
+    {
         Ok(list) => list.into_iter().collect(),
         Err(e) => {
             report.warnings.push(format!("failed to list bridges: {e}"));
@@ -187,7 +189,7 @@ async fn check_taps(
     state: &NetworkState,
     report: &mut ReconcileReport,
 ) {
-    let kernel_taps: HashSet<String> = match backend.list_interfaces("syftap-").await {
+    let kernel_taps: HashSet<String> = match backend.list_interfaces(naming::TAP_PREFIX).await {
         Ok(list) => list.into_iter().collect(),
         Err(e) => {
             report.warnings.push(format!("failed to list TAPs: {e}"));
@@ -276,7 +278,7 @@ async fn detect_orphaned_interfaces(
     let expected_taps: HashSet<&str> = state.vms.iter().map(|vm| vm.tap_name.as_str()).collect();
 
     // Check kernel bridges
-    if let Ok(kernel_bridges) = backend.list_interfaces("syfbr-").await {
+    if let Ok(kernel_bridges) = backend.list_interfaces(naming::BRIDGE_PREFIX).await {
         for name in &kernel_bridges {
             if !expected_bridges.contains(name.as_str()) {
                 let msg = format!("orphaned bridge in kernel: {name}");
@@ -287,7 +289,7 @@ async fn detect_orphaned_interfaces(
     }
 
     // Build a map of expected TAP names by prefix to avoid re-listing
-    if let Ok(kernel_taps) = backend.list_interfaces("syftap-").await {
+    if let Ok(kernel_taps) = backend.list_interfaces(naming::TAP_PREFIX).await {
         for name in &kernel_taps {
             if !expected_taps.contains(name.as_str()) {
                 let msg = format!("orphaned TAP in kernel: {name}");
@@ -337,14 +339,14 @@ mod tests {
     async fn orphaned_tap_detected() {
         let backend = MockBackend::new();
         // Kernel has a TAP that IS in expected state, but also has one that is NOT
-        backend.add_interface("syftap-vm1");
-        backend.add_interface("syftap-orphan");
+        backend.add_interface(&naming::tap_name("vm1"));
+        backend.add_interface(&naming::tap_name("orphan"));
 
         let mut state = make_state();
         state.vms.push(ExpectedVm {
             vm_id: "vm1".into(),
             vpc_id: "100".into(),
-            tap_name: "syftap-vm1".into(),
+            tap_name: naming::tap_name("vm1"),
             mac: "02:00:0a:01:01:03".into(),
             ip: "10.1.1.3".into(),
         });
@@ -353,10 +355,10 @@ mod tests {
 
         // The orphaned TAP should trigger a warning
         assert!(
-            report
-                .warnings
-                .iter()
-                .any(|w| w.contains("orphaned TAP in kernel: syftap-orphan")),
+            report.warnings.iter().any(|w| w.contains(&format!(
+                "orphaned TAP in kernel: {}",
+                naming::tap_name("orphan")
+            ))),
             "expected orphaned TAP warning, got: {:?}",
             report.warnings
         );
@@ -369,7 +371,7 @@ mod tests {
 
         let mut state = make_state();
         state.bridges.push(ExpectedBridge {
-            name: "syfbr-100".into(),
+            name: naming::bridge_name("100"),
             vpc_id: "100".into(),
         });
 
@@ -379,7 +381,9 @@ mod tests {
         // Verify the backend was called to create the bridge
         let calls = backend.calls();
         assert!(
-            calls.iter().any(|c| c == "create_bridge(syfbr-100)"),
+            calls
+                .iter()
+                .any(|c| c == &format!("create_bridge({})", naming::bridge_name("100"))),
             "expected create_bridge call, got: {:?}",
             calls
         );
@@ -388,11 +392,11 @@ mod tests {
     #[tokio::test]
     async fn existing_bridge_not_recreated() {
         let backend = MockBackend::new();
-        backend.add_interface("syfbr-100");
+        backend.add_interface(&naming::bridge_name("100"));
 
         let mut state = make_state();
         state.bridges.push(ExpectedBridge {
-            name: "syfbr-100".into(),
+            name: naming::bridge_name("100"),
             vpc_id: "100".into(),
         });
 
@@ -411,16 +415,14 @@ mod tests {
         let backend = MockBackend::new();
 
         let mut state = make_state();
-        state.vm_rules.push((
-            "syftap-vm1".into(),
-            "02:00:0a:01:01:03".into(),
-            "10.1.1.3".into(),
-        ));
-        state.vm_rules.push((
-            "syftap-vm2".into(),
-            "02:00:0a:01:01:04".into(),
-            "10.1.1.4".into(),
-        ));
+        let tap1 = naming::tap_name("vm1");
+        let tap2 = naming::tap_name("vm2");
+        state
+            .vm_rules
+            .push((tap1.clone(), "02:00:0a:01:01:03".into(), "10.1.1.3".into()));
+        state
+            .vm_rules
+            .push((tap2.clone(), "02:00:0a:01:01:04".into(), "10.1.1.4".into()));
 
         let report = reconcile_network(&backend, &state).await;
 
@@ -428,10 +430,10 @@ mod tests {
         let calls = backend.calls();
         assert!(calls
             .iter()
-            .any(|c| c == "apply_vm_rules(syftap-vm1, 02:00:0a:01:01:03, 10.1.1.3)"));
+            .any(|c| c == &format!("apply_vm_rules({tap1}, 02:00:0a:01:01:03, 10.1.1.3)")));
         assert!(calls
             .iter()
-            .any(|c| c == "apply_vm_rules(syftap-vm2, 02:00:0a:01:01:04, 10.1.1.4)"));
+            .any(|c| c == &format!("apply_vm_rules({tap2}, 02:00:0a:01:01:04, 10.1.1.4)")));
     }
 
     #[tokio::test]
@@ -491,7 +493,7 @@ mod tests {
         state.vms.push(ExpectedVm {
             vm_id: "vm1".into(),
             vpc_id: "100".into(),
-            tap_name: "syftap-vm1".into(),
+            tap_name: naming::tap_name("vm1"),
             mac: "02:00:0a:01:01:03".into(),
             ip: "10.1.1.3".into(),
         });
@@ -499,7 +501,10 @@ mod tests {
         let report = reconcile_network(&backend, &state).await;
 
         assert!(
-            report.warnings.iter().any(|w| w.contains("syftap-vm1")),
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains(&naming::tap_name("vm1"))),
             "should warn about missing TAP"
         );
         // Bridges fixed should be 0 — we only warn for TAPs
@@ -509,7 +514,8 @@ mod tests {
     #[tokio::test]
     async fn orphaned_bridge_detected() {
         let backend = MockBackend::new();
-        backend.add_interface("syfbr-orphan");
+        let orphan_bridge = naming::bridge_name("orphan");
+        backend.add_interface(&orphan_bridge);
 
         let state = make_state();
         // No expected bridges
@@ -520,7 +526,7 @@ mod tests {
             report
                 .warnings
                 .iter()
-                .any(|w| w.contains("orphaned bridge in kernel: syfbr-orphan")),
+                .any(|w| w.contains(&format!("orphaned bridge in kernel: {orphan_bridge}"))),
             "expected orphaned bridge warning"
         );
     }
@@ -528,18 +534,18 @@ mod tests {
     #[tokio::test]
     async fn clean_state_no_actions() {
         let backend = MockBackend::new();
-        backend.add_interface("syfbr-100");
-        backend.add_interface("syftap-vm1");
+        backend.add_interface(&naming::bridge_name("100"));
+        backend.add_interface(&naming::tap_name("vm1"));
 
         let mut state = make_state();
         state.bridges.push(ExpectedBridge {
-            name: "syfbr-100".into(),
+            name: naming::bridge_name("100"),
             vpc_id: "100".into(),
         });
         state.vms.push(ExpectedVm {
             vm_id: "vm1".into(),
             vpc_id: "100".into(),
-            tap_name: "syftap-vm1".into(),
+            tap_name: naming::tap_name("vm1"),
             mac: "02:00:0a:01:01:03".into(),
             ip: "10.1.1.3".into(),
         });
@@ -557,33 +563,35 @@ mod tests {
         let backend = MockBackend::new();
         // Kernel: has bridge 100, missing bridge 200, orphaned bridge 999
         // Kernel: has tap vm1, orphaned tap ghost
-        backend.add_interface("syfbr-100");
-        backend.add_interface("syfbr-999");
-        backend.add_interface("syftap-vm1");
-        backend.add_interface("syftap-ghost");
+        let br_999 = naming::bridge_name("999");
+        let tap_ghost = naming::tap_name("ghost");
+        backend.add_interface(&naming::bridge_name("100"));
+        backend.add_interface(&br_999);
+        backend.add_interface(&naming::tap_name("vm1"));
+        backend.add_interface(&tap_ghost);
 
         let mut state = make_state();
         state.now = 1_000_000;
 
         state.bridges.push(ExpectedBridge {
-            name: "syfbr-100".into(),
+            name: naming::bridge_name("100"),
             vpc_id: "100".into(),
         });
         state.bridges.push(ExpectedBridge {
-            name: "syfbr-200".into(),
+            name: naming::bridge_name("200"),
             vpc_id: "200".into(),
         });
 
         state.vms.push(ExpectedVm {
             vm_id: "vm1".into(),
             vpc_id: "100".into(),
-            tap_name: "syftap-vm1".into(),
+            tap_name: naming::tap_name("vm1"),
             mac: "02:00:0a:01:01:03".into(),
             ip: "10.1.1.3".into(),
         });
 
         state.vm_rules.push((
-            "syftap-vm1".into(),
+            naming::tap_name("vm1"),
             "02:00:0a:01:01:03".into(),
             "10.1.1.3".into(),
         ));
@@ -606,7 +614,7 @@ mod tests {
         assert_eq!(report.orphans_reclaimed, 1, "one orphaned IP reclaimed");
 
         // Warnings: orphaned bridge 999, orphaned TAP ghost
-        assert!(report.warnings.iter().any(|w| w.contains("syfbr-999")));
-        assert!(report.warnings.iter().any(|w| w.contains("syftap-ghost")));
+        assert!(report.warnings.iter().any(|w| w.contains(&br_999)));
+        assert!(report.warnings.iter().any(|w| w.contains(&tap_ghost)));
     }
 }

--- a/layers/overlay/src/recovery.rs
+++ b/layers/overlay/src/recovery.rs
@@ -17,13 +17,14 @@ use tracing::{info, warn};
 
 use crate::backend::NetworkBackend;
 use crate::fdb::{add_arp_proxy, add_fdb_entry};
+use crate::naming;
 use crate::vxlan::VXLAN_PORT;
 
 /// A VPC descriptor used during recovery. Mirrors the essential fields
 /// from `syfrah_org::Vpc` without creating a crate dependency.
 #[derive(Debug, Clone)]
 pub struct RecoveryVpc {
-    /// VPC identifier (used in bridge/VXLAN naming: `syfbr-{id}`, `syfvx-{id}`).
+    /// VPC identifier (used in bridge/VXLAN naming via the `naming` module).
     pub id: String,
     /// VXLAN Network Identifier.
     pub vni: u32,
@@ -88,11 +89,20 @@ pub async fn recover_network(
     let mut report = RecoveryReport::default();
 
     // ── 1. Discover kernel interfaces ─────────────────────────────────
-    let kernel_bridges = backend.list_interfaces("syfbr-").await.unwrap_or_default();
-    let kernel_vxlans = backend.list_interfaces("syfvx-").await.unwrap_or_default();
-    let kernel_taps = backend.list_interfaces("syftap-").await.unwrap_or_default();
+    let kernel_bridges = backend
+        .list_interfaces(naming::BRIDGE_PREFIX)
+        .await
+        .unwrap_or_default();
+    let kernel_vxlans = backend
+        .list_interfaces(naming::VXLAN_PREFIX)
+        .await
+        .unwrap_or_default();
+    let kernel_taps = backend
+        .list_interfaces(naming::TAP_PREFIX)
+        .await
+        .unwrap_or_default();
     let kernel_peers = backend
-        .list_interfaces("syfpeer-")
+        .list_interfaces(naming::PEER_PREFIX)
         .await
         .unwrap_or_default();
 
@@ -110,24 +120,24 @@ pub async fn recover_network(
 
     let expected_bridges: HashSet<String> = local_vpc_ids
         .iter()
-        .map(|id| format!("syfbr-{id}"))
+        .map(|id| naming::bridge_name(id))
         .collect();
 
     let expected_vxlans: HashSet<String> = local_vpc_ids
         .iter()
-        .map(|id| format!("syfvx-{id}"))
+        .map(|id| naming::vxlan_name(id))
         .collect();
 
-    // Expected TAPs: local placements -> syftap-{vm_id}
+    // Expected TAPs: local placements -> naming::tap_name(vm_id)
     let expected_taps: HashSet<String> = placements
         .iter()
         .filter(|p| p.hosting_node == local_node)
-        .map(|p| format!("syftap-{}", p.vm_id))
+        .map(|p| naming::tap_name(&p.vm_id))
         .collect();
 
     // ── 3. Re-create missing bridges ──────────────────────────────────
     for vpc in vpcs {
-        let bridge = format!("syfbr-{}", vpc.id);
+        let bridge = naming::bridge_name(&vpc.id);
         if !expected_bridges.contains(&bridge) {
             continue;
         }
@@ -166,8 +176,8 @@ pub async fn recover_network(
 
     // ── 4. Re-create missing VXLANs ───────────────────────────────────
     for vpc in vpcs {
-        let vxlan = format!("syfvx-{}", vpc.id);
-        let bridge = format!("syfbr-{}", vpc.id);
+        let vxlan = naming::vxlan_name(&vpc.id);
+        let bridge = naming::bridge_name(&vpc.id);
 
         if !expected_vxlans.contains(&vxlan) {
             continue;
@@ -198,7 +208,7 @@ pub async fn recover_network(
     // ── 5. Re-apply nftables rules ────────────────────────────────────
     // nftables rules do not survive reboot — re-apply for every local VM.
     for p in placements.iter().filter(|p| p.hosting_node == local_node) {
-        let tap = format!("syftap-{}", p.vm_id);
+        let tap = naming::tap_name(&p.vm_id);
 
         if let Err(e) = backend.apply_vm_rules(&tap, &p.vm_mac, &p.vm_ip).await {
             warn!(
@@ -214,7 +224,7 @@ pub async fn recover_network(
     // Re-apply NAT for subnets that have local VMs.
     for subnet in subnets {
         if local_vpc_ids.contains(subnet.vpc_id.as_str()) {
-            let bridge = format!("syfbr-{}", subnet.vpc_id);
+            let bridge = naming::bridge_name(&subnet.vpc_id);
             if let Err(e) = backend.apply_nat(&bridge, &subnet.cidr).await {
                 warn!(
                     bridge = %bridge, subnet = %subnet.cidr,
@@ -226,8 +236,8 @@ pub async fn recover_network(
 
     // ── 6. Re-populate FDB from placements ────────────────────────────
     for p in placements.iter().filter(|p| p.hosting_node != local_node) {
-        let bridge = format!("syfbr-{}", p.vpc_id);
-        let vxlan = format!("syfvx-{}", p.vpc_id);
+        let bridge = naming::bridge_name(&p.vpc_id);
+        let vxlan = naming::vxlan_name(&p.vpc_id);
 
         // Only rebuild FDB for VPCs where we have local VMs too.
         if !local_vpc_ids.contains(p.vpc_id.as_str()) {
@@ -354,7 +364,7 @@ mod tests {
     async fn bridges_survive_restart() {
         let backend = MockBackend::new();
         // Bridge already exists in the kernel.
-        backend.set_interfaces(vec!["syfbr-100".to_string(), "syfvx-100".to_string()]);
+        backend.set_interfaces(vec![naming::bridge_name("100"), naming::vxlan_name("100")]);
 
         let vpcs = vec![vpc("100", 100)];
         let subnets = vec![subnet("100", "10.1.1.0/24", "10.1.1.1")];
@@ -387,9 +397,9 @@ mod tests {
     async fn taps_survive_restart() {
         let backend = MockBackend::new();
         backend.set_interfaces(vec![
-            "syfbr-100".to_string(),
-            "syfvx-100".to_string(),
-            "syftap-vm-1".to_string(),
+            naming::bridge_name("100"),
+            naming::vxlan_name("100"),
+            naming::tap_name("vm-1"),
         ]);
 
         let vpcs = vec![vpc("100", 100)];
@@ -410,7 +420,9 @@ mod tests {
 
         let calls = backend.calls();
         assert!(
-            !calls.iter().any(|c| c == "delete_tap(syftap-vm-1)"),
+            !calls
+                .iter()
+                .any(|c| c == &format!("delete_tap({})", naming::tap_name("vm-1"))),
             "TAP should not be deleted"
         );
     }
@@ -422,10 +434,10 @@ mod tests {
     async fn nftables_reapplied() {
         let backend = MockBackend::new();
         backend.set_interfaces(vec![
-            "syfbr-100".to_string(),
-            "syfvx-100".to_string(),
-            "syftap-vm-1".to_string(),
-            "syftap-vm-2".to_string(),
+            naming::bridge_name("100"),
+            naming::vxlan_name("100"),
+            naming::tap_name("vm-1"),
+            naming::tap_name("vm-2"),
         ]);
 
         let vpcs = vec![vpc("100", 100)];
@@ -446,8 +458,8 @@ mod tests {
             .filter(|c| c.starts_with("apply_vm_rules("))
             .collect();
         assert_eq!(apply_calls.len(), 2);
-        assert!(apply_calls[0].contains("syftap-vm-1"));
-        assert!(apply_calls[1].contains("syftap-vm-2"));
+        assert!(apply_calls[0].contains(&naming::tap_name("vm-1")));
+        assert!(apply_calls[1].contains(&naming::tap_name("vm-2")));
     }
 
     // ── fdb_repopulated ───────────────────────────────────────────────
@@ -457,9 +469,9 @@ mod tests {
     async fn fdb_repopulated() {
         let backend = MockBackend::new();
         backend.set_interfaces(vec![
-            "syfbr-100".to_string(),
-            "syfvx-100".to_string(),
-            "syftap-vm-local".to_string(),
+            naming::bridge_name("100"),
+            naming::vxlan_name("100"),
+            naming::tap_name("vm-local"),
         ]);
 
         let vpcs = vec![vpc("100", 100)];
@@ -512,9 +524,9 @@ mod tests {
         let backend = MockBackend::new();
         // Kernel has interfaces that are NOT in redb.
         backend.set_interfaces(vec![
-            "syfbr-orphan".to_string(),
-            "syfvx-orphan".to_string(),
-            "syftap-deleted-vm".to_string(),
+            naming::bridge_name("orphan"),
+            naming::vxlan_name("orphan"),
+            naming::tap_name("deleted-vm"),
         ]);
 
         let vpcs: Vec<RecoveryVpc> = vec![];
@@ -527,9 +539,15 @@ mod tests {
         assert_eq!(report.orphans_cleaned, 3);
 
         let calls = backend.calls();
-        assert!(calls.iter().any(|c| c == "delete_bridge(syfbr-orphan)"));
-        assert!(calls.iter().any(|c| c == "delete_vxlan(syfvx-orphan)"));
-        assert!(calls.iter().any(|c| c == "delete_tap(syftap-deleted-vm)"));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("delete_bridge({})", naming::bridge_name("orphan"))));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("delete_vxlan({})", naming::vxlan_name("orphan"))));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("delete_tap({})", naming::tap_name("deleted-vm"))));
     }
 
     // ── missing bridge is re-created ──────────────────────────────────
@@ -557,16 +575,20 @@ mod tests {
         assert_eq!(report.vxlans_recovered, 1);
 
         let calls = backend.calls();
-        assert!(calls.iter().any(|c| c == "create_bridge(syfbr-200)"));
+        let br200 = naming::bridge_name("200");
+        let vx200 = naming::vxlan_name("200");
         assert!(calls
             .iter()
-            .any(|c| c == "add_bridge_ip(syfbr-200, 10.2.1.1, 24)"));
+            .any(|c| c == &format!("create_bridge({br200})")));
         assert!(calls
             .iter()
-            .any(|c| c.starts_with("create_vxlan(syfvx-200")));
+            .any(|c| c == &format!("add_bridge_ip({br200}, 10.2.1.1, 24)")));
         assert!(calls
             .iter()
-            .any(|c| c == "attach_to_bridge(syfvx-200, syfbr-200)"));
+            .any(|c| c.starts_with(&format!("create_vxlan({vx200}"))));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("attach_to_bridge({vx200}, {br200})")));
     }
 
     // ── NAT rules re-applied for local subnets ────────────────────────
@@ -574,7 +596,7 @@ mod tests {
     #[tokio::test]
     async fn nat_reapplied() {
         let backend = MockBackend::new();
-        backend.set_interfaces(vec!["syfbr-100".to_string(), "syfvx-100".to_string()]);
+        backend.set_interfaces(vec![naming::bridge_name("100"), naming::vxlan_name("100")]);
 
         let vpcs = vec![vpc("100", 100)];
         let subnets = vec![

--- a/layers/overlay/src/rollback.rs
+++ b/layers/overlay/src/rollback.rs
@@ -151,11 +151,13 @@ mod tests {
         rb.set_ip_allocated("subnet-1", "10.1.1.3");
 
         // Step 2: Bridge creation succeeds
-        backend.create_bridge("syfbr-100").await.unwrap();
-        rb.set_bridge_created("syfbr-100");
+        let br = crate::naming::bridge_name("100");
+        let tap = crate::naming::tap_name("vm1");
+        backend.create_bridge(&br).await.unwrap();
+        rb.set_bridge_created(&br);
 
         // Step 3: TAP creation fails
-        let tap_result = backend.create_tap("syftap-vm1").await;
+        let tap_result = backend.create_tap(&tap).await;
         assert!(tap_result.is_err(), "create_tap should have failed");
 
         // Rollback
@@ -170,7 +172,7 @@ mod tests {
         // Verify: bridge was deleted
         let calls = backend.calls();
         assert!(
-            calls.iter().any(|c| c == "delete_bridge(syfbr-100)"),
+            calls.iter().any(|c| c == &format!("delete_bridge({br})")),
             "bridge should be rolled back, got: {calls:?}"
         );
 
@@ -196,7 +198,7 @@ mod tests {
         rb.set_ip_allocated("subnet-1", "10.1.1.5");
 
         // TAP fails
-        let tap_result = backend.create_tap("syftap-vm2").await;
+        let tap_result = backend.create_tap(&crate::naming::tap_name("vm2")).await;
         assert!(tap_result.is_err());
 
         let release_cb: IpReleaseCallback = Box::new(move |_subnet, _ip| {
@@ -218,18 +220,19 @@ mod tests {
         rb.set_ip_allocated("subnet-1", "10.1.1.3");
 
         // Bridge created for this VM (first VM in VPC on this node)
-        backend.create_bridge("syfbr-200").await.unwrap();
-        rb.set_bridge_created("syfbr-200");
+        let br = crate::naming::bridge_name("200");
+        backend.create_bridge(&br).await.unwrap();
+        rb.set_bridge_created(&br);
 
         // TAP fails
-        let tap_result = backend.create_tap("syftap-vm3").await;
+        let tap_result = backend.create_tap(&crate::naming::tap_name("vm3")).await;
         assert!(tap_result.is_err());
 
         rb.rollback(&backend, None).await;
 
         let calls = backend.calls();
         assert!(
-            calls.iter().any(|c| c == "delete_bridge(syfbr-200)"),
+            calls.iter().any(|c| c == &format!("delete_bridge({br})")),
             "bridge must be deleted on rollback, got: {calls:?}"
         );
 
@@ -248,10 +251,12 @@ mod tests {
 
         let mut rb = NetworkRollback::new();
         rb.set_ip_allocated("subnet-1", "10.1.1.3");
-        rb.set_bridge_created("syfbr-100");
-        rb.set_tap_created("syftap-vm1");
-        rb.set_nft_applied("syftap-vm1");
-        rb.set_nat_applied("syfbr-100", "10.1.1.0/24");
+        let br = crate::naming::bridge_name("100");
+        let tap = crate::naming::tap_name("vm1");
+        rb.set_bridge_created(&br);
+        rb.set_tap_created(&tap);
+        rb.set_nft_applied(&tap);
+        rb.set_nat_applied(&br, "10.1.1.0/24");
         rb.set_placement_stored("100", "vm1");
 
         let released = Arc::new(Mutex::new(false));
@@ -289,8 +294,8 @@ mod tests {
 
         let mut rb = NetworkRollback::new();
         rb.set_ip_allocated("subnet-1", "10.1.1.3");
-        rb.set_tap_created("syftap-vm1");
-        rb.set_bridge_created("syfbr-100");
+        rb.set_tap_created(&crate::naming::tap_name("vm1"));
+        rb.set_bridge_created(&crate::naming::bridge_name("100"));
 
         let released = Arc::new(Mutex::new(false));
         let released_clone = Arc::clone(&released);

--- a/layers/overlay/src/tap.rs
+++ b/layers/overlay/src/tap.rs
@@ -1,30 +1,30 @@
 //! TAP and veth management for VM and container networking.
 //!
-//! - **TAP** interfaces (`syftap-{vm_id}`) connect Cloud Hypervisor VMs to the
-//!   VPC bridge.
-//! - **veth pairs** (`syfve-{vm_id}-h` / `syfve-{vm_id}-c`) connect crun
-//!   containers — the host side is attached to the bridge and the container
-//!   side is moved into the container network namespace.
+//! - **TAP** interfaces connect Cloud Hypervisor VMs to the VPC bridge.
+//! - **veth pairs** connect crun containers — the host side is attached to
+//!   the bridge and the container side is moved into the container network
+//!   namespace.
 //!
 //! All operations are idempotent: creating an interface that already exists is
 //! a no-op rather than an error.
 
 use crate::backend::NetworkBackend;
 use crate::error::Result;
+use crate::naming;
 
 /// Canonical TAP name for a given VM.
 pub fn tap_name(vm_id: &str) -> String {
-    format!("syftap-{vm_id}")
+    naming::tap_name(vm_id)
 }
 
 /// Canonical veth host-side name for a given VM.
 pub fn veth_host_name(vm_id: &str) -> String {
-    format!("syfve-{vm_id}-h")
+    naming::veth_host_name(vm_id)
 }
 
 /// Canonical veth container-side name for a given VM.
 pub fn veth_container_name(vm_id: &str) -> String {
-    format!("syfve-{vm_id}-c")
+    naming::veth_container_name(vm_id)
 }
 
 /// Create a TAP device and bring it up.
@@ -77,35 +77,41 @@ mod tests {
     async fn create_tap_correct_name() {
         let backend = MockBackend::new();
         let name = create_tap(&backend, "abc123").await.unwrap();
-        assert_eq!(name, "syftap-abc123");
+        assert_eq!(name, naming::tap_name("abc123"));
 
         let calls = backend.calls();
-        assert!(calls.iter().any(|c| c == "create_tap(syftap-abc123)"));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("create_tap({})", naming::tap_name("abc123"))));
     }
 
     #[tokio::test]
     async fn create_veth_pair_both_ends() {
         let backend = MockBackend::new();
         let (host, container) = create_veth_pair(&backend, "ctr42").await.unwrap();
-        assert_eq!(host, "syfve-ctr42-h");
-        assert_eq!(container, "syfve-ctr42-c");
+        assert_eq!(host, naming::veth_host_name("ctr42"));
+        assert_eq!(container, naming::veth_container_name("ctr42"));
 
         let calls = backend.calls();
-        assert!(calls
-            .iter()
-            .any(|c| c == "create_veth_pair(syfve-ctr42-h, syfve-ctr42-c)"));
+        assert!(calls.iter().any(|c| c
+            == &format!(
+                "create_veth_pair({}, {})",
+                naming::veth_host_name("ctr42"),
+                naming::veth_container_name("ctr42")
+            )));
     }
 
     #[tokio::test]
     async fn attach_to_bridge_host_side() {
         let backend = MockBackend::new();
         let tap = create_tap(&backend, "vm1").await.unwrap();
-        attach_to_bridge(&backend, &tap, "syfbr-100").await.unwrap();
+        let bridge = naming::bridge_name("100");
+        attach_to_bridge(&backend, &tap, &bridge).await.unwrap();
 
         let calls = backend.calls();
         assert!(calls
             .iter()
-            .any(|c| c == "attach_to_bridge(syftap-vm1, syfbr-100)"));
+            .any(|c| c == &format!("attach_to_bridge({}, {})", naming::tap_name("vm1"), bridge)));
     }
 
     #[tokio::test]
@@ -115,6 +121,8 @@ mod tests {
         delete_tap(&backend, "vm1").await.unwrap();
 
         let calls = backend.calls();
-        assert!(calls.iter().any(|c| c == "delete_tap(syftap-vm1)"));
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("delete_tap({})", naming::tap_name("vm1"))));
     }
 }

--- a/layers/overlay/src/veth_peer.rs
+++ b/layers/overlay/src/veth_peer.rs
@@ -2,17 +2,16 @@
 //!
 //! Creates a veth pair that connects two VPC bridges, enabling cross-VPC
 //! communication for peered VPCs.
-//!
-//! Naming convention: `syfpeer-{peering_id}-a` and `syfpeer-{peering_id}-b`.
 
 use crate::backend::NetworkBackend;
 use crate::error::Result;
+use crate::naming;
 
 /// Create a veth peer connection between two VPC bridges.
 ///
 /// Steps:
-/// 1. Create veth pair `syfpeer-{peering_id}-a` / `syfpeer-{peering_id}-b`
-/// 2. Attach `-a` to `bridge_a`, `-b` to `bridge_b`
+/// 1. Create veth pair for the peering
+/// 2. Attach end A to `bridge_a`, end B to `bridge_b`
 /// 3. Apply nftables peering rules to allow forwarding between bridges
 pub async fn create_veth_peer(
     backend: &dyn NetworkBackend,
@@ -20,8 +19,8 @@ pub async fn create_veth_peer(
     bridge_a: &str,
     bridge_b: &str,
 ) -> Result<()> {
-    let name_a = format!("syfpeer-{peering_id}-a");
-    let name_b = format!("syfpeer-{peering_id}-b");
+    let name_a = naming::peer_name_a(peering_id);
+    let name_b = naming::peer_name_b(peering_id);
 
     // 1. Create veth pair.
     backend.create_veth_pair(&name_a, &name_b).await?;
@@ -45,7 +44,7 @@ pub async fn delete_veth_peer(
     bridge_a: &str,
     bridge_b: &str,
 ) -> Result<()> {
-    let name_a = format!("syfpeer-{peering_id}-a");
+    let name_a = naming::peer_name_a(peering_id);
 
     // 1. Remove peering forwarding rules.
     backend.remove_peering_rules(bridge_a, bridge_b).await?;
@@ -65,52 +64,62 @@ mod tests {
     #[tokio::test]
     async fn create_veth_peer_creates_and_attaches_both_ends() {
         let backend = MockBackend::new();
+        let br_a = naming::bridge_name("100");
+        let br_b = naming::bridge_name("200");
 
-        create_veth_peer(&backend, "peer1", "syfbr-100", "syfbr-200")
+        create_veth_peer(&backend, "peer1", &br_a, &br_b)
             .await
             .unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 4);
-        assert_eq!(
-            calls[0],
-            "create_veth_pair(syfpeer-peer1-a, syfpeer-peer1-b)"
-        );
-        assert_eq!(calls[1], "attach_to_bridge(syfpeer-peer1-a, syfbr-100)");
-        assert_eq!(calls[2], "attach_to_bridge(syfpeer-peer1-b, syfbr-200)");
-        assert_eq!(calls[3], "apply_peering_rules(syfbr-100, syfbr-200)");
+        let pa = naming::peer_name_a("peer1");
+        let pb = naming::peer_name_b("peer1");
+        assert_eq!(calls[0], format!("create_veth_pair({pa}, {pb})"));
+        assert_eq!(calls[1], format!("attach_to_bridge({pa}, {br_a})"));
+        assert_eq!(calls[2], format!("attach_to_bridge({pb}, {br_b})"));
+        assert_eq!(calls[3], format!("apply_peering_rules({br_a}, {br_b})"));
     }
 
     #[tokio::test]
     async fn delete_peer_cleans_up() {
         let backend = MockBackend::new();
+        let br_a = naming::bridge_name("500");
+        let br_b = naming::bridge_name("600");
 
-        create_veth_peer(&backend, "peer3", "syfbr-500", "syfbr-600")
+        create_veth_peer(&backend, "peer3", &br_a, &br_b)
             .await
             .unwrap();
 
         backend.reset();
 
-        delete_veth_peer(&backend, "peer3", "syfbr-500", "syfbr-600")
+        delete_veth_peer(&backend, "peer3", &br_a, &br_b)
             .await
             .unwrap();
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], "remove_peering_rules(syfbr-500, syfbr-600)");
-        assert_eq!(calls[1], "delete_tap(syfpeer-peer3-a)");
+        assert_eq!(calls[0], format!("remove_peering_rules({br_a}, {br_b})"));
+        assert_eq!(
+            calls[1],
+            format!("delete_tap({})", naming::peer_name_a("peer3"))
+        );
     }
 
     #[tokio::test]
     async fn peering_id_in_names() {
         let backend = MockBackend::new();
+        let br_a = naming::bridge_name("1");
+        let br_b = naming::bridge_name("2");
 
-        create_veth_peer(&backend, "abc123", "syfbr-1", "syfbr-2")
+        create_veth_peer(&backend, "abc123", &br_a, &br_b)
             .await
             .unwrap();
 
         let calls = backend.calls();
-        assert!(calls[0].contains("syfpeer-abc123-a"));
-        assert!(calls[0].contains("syfpeer-abc123-b"));
+        let pa = naming::peer_name_a("abc123");
+        let pb = naming::peer_name_b("abc123");
+        assert!(calls[0].contains(&pa));
+        assert!(calls[0].contains(&pb));
     }
 }

--- a/layers/overlay/src/vxlan.rs
+++ b/layers/overlay/src/vxlan.rs
@@ -1,22 +1,23 @@
 //! VXLAN interface management.
 //!
-//! One VXLAN interface per VPC per node: `syfvx-{vpc_id}`.
+//! One VXLAN interface per VPC per node.
 //! Created on-demand when the first VM in a VPC lands on this node.
 
 use crate::backend::NetworkBackend;
 use crate::error::Result;
+use crate::naming;
 
 /// Default VXLAN UDP destination port.
 pub const VXLAN_PORT: u16 = 4789;
 
 /// Derive the VXLAN interface name from a VPC ID.
 pub fn vxlan_name(vpc_id: &str) -> String {
-    format!("syfvx-{vpc_id}")
+    naming::vxlan_name(vpc_id)
 }
 
 /// Derive the bridge name from a VPC ID.
 pub fn bridge_name(vpc_id: &str) -> String {
-    format!("syfbr-{vpc_id}")
+    naming::bridge_name(vpc_id)
 }
 
 /// Create a VXLAN interface for the given VPC and attach it to the VPC bridge.
@@ -25,7 +26,7 @@ pub fn bridge_name(vpc_id: &str) -> String {
 ///
 /// Steps:
 /// 1. Create with `nolearning` + `proxy` flags, bring up.
-/// 2. Attach to `syfbr-{vpc_id}`.
+/// 2. Attach to VPC bridge.
 pub async fn ensure_vxlan(
     backend: &dyn NetworkBackend,
     vpc_id: &str,
@@ -72,8 +73,16 @@ mod tests {
 
         let calls = backend.calls();
         assert_eq!(calls.len(), 2);
-        assert_eq!(calls[0], "create_vxlan(syfvx-vpc-100, 100, fd00::1, 4789)");
-        assert_eq!(calls[1], "attach_to_bridge(syfvx-vpc-100, syfbr-vpc-100)");
+        let expected_vxlan = naming::vxlan_name("vpc-100");
+        let expected_bridge = naming::bridge_name("vpc-100");
+        assert_eq!(
+            calls[0],
+            format!("create_vxlan({expected_vxlan}, 100, fd00::1, 4789)")
+        );
+        assert_eq!(
+            calls[1],
+            format!("attach_to_bridge({expected_vxlan}, {expected_bridge})")
+        );
     }
 
     #[tokio::test]
@@ -102,9 +111,11 @@ mod tests {
             .filter(|c| c.starts_with("attach_to_bridge("))
             .collect();
         assert_eq!(attach_calls.len(), 1);
+        let expected_vxlan = naming::vxlan_name("vpc-200");
+        let expected_bridge = naming::bridge_name("vpc-200");
         assert_eq!(
             attach_calls[0],
-            "attach_to_bridge(syfvx-vpc-200, syfbr-vpc-200)"
+            format!("attach_to_bridge({expected_vxlan}, {expected_bridge})")
         );
     }
 
@@ -123,6 +134,9 @@ mod tests {
             .filter(|c| c.starts_with("delete_vxlan("))
             .collect();
         assert_eq!(delete_calls.len(), 1);
-        assert_eq!(delete_calls[0], "delete_vxlan(syfvx-vpc-300)");
+        assert_eq!(
+            delete_calls[0],
+            format!("delete_vxlan({})", naming::vxlan_name("vpc-300"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `layers/overlay/src/naming.rs` module that hashes identifiers to 8 hex digits, producing interface names of at most 13 characters (well within the Linux 15-char `IFNAMSIZ` limit)
- Replace all hardcoded `format!("syfbr-{id}")` / `format!("syfvx-{id}")` / `format!("syftap-{id}")` patterns across overlay and compute crates with calls to the new naming module
- Update all tests (80 pass) to use deterministic hash-based names

## Naming convention

| Type | Old format | New format | Max len |
|------|-----------|-----------|---------|
| Bridge | `syfbr-{vpc_id}` | `syfb-{hash}` | 13 |
| VXLAN | `syfvx-{vpc_id}` | `syfx-{hash}` | 13 |
| TAP | `syftap-{vm_id}` | `syft-{hash}` | 13 |
| veth host | `syfve-{id}-h` | `syfvh{hash}` | 13 |
| veth container | `syfve-{id}-c` | `syfvc{hash}` | 13 |
| peer-a | `syfpeer-{id}-a` | `syfpa{hash}` | 13 |
| peer-b | `syfpeer-{id}-b` | `syfpb{hash}` | 13 |

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` clean
- [x] `cargo test -p syfrah-overlay -p syfrah-compute` — all 80 tests pass
- [x] Unit tests in `naming.rs` verify all names <= 15 chars with long inputs
- [x] Deterministic hashing verified (same input = same output)

Closes #854