### PR TITLE
feat(compute): container networking via veth pairs

### DIFF
--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -488,7 +488,8 @@ impl VmManager {
                     Arc::clone(backend),
                     local_node.clone(),
                 );
-                match ns.setup(&vm_id_str, &subnet_name).await {
+                let is_container = self.runtime.name().starts_with("container");
+                match ns.setup(&vm_id_str, &subnet_name, is_container).await {
                     Ok(result) => {
                         info!(
                             vm_id = %vm_id_str,
@@ -779,6 +780,49 @@ impl VmManager {
                 return Err(e);
             }
         };
+
+        // -- Container networking: move veth into container netns ----------------
+        // After crun creates the container (PID is known), move the container-
+        // side veth into its network namespace and configure IP/routes.
+        if let Some(ref nr) = network_result {
+            if let Some(ref container_veth) = nr.container_veth {
+                if let Some(ref backend) = self.network_backend {
+                    info!(
+                        vm_id = %vm_id_str,
+                        pid = handle.pid,
+                        veth = %container_veth,
+                        "moving veth into container network namespace"
+                    );
+                    backend
+                        .move_to_netns(container_veth, handle.pid)
+                        .await
+                        .map_err(|e| {
+                            ComputeError::NetworkSetup(format!(
+                                "failed to move veth into container netns: {e}"
+                            ))
+                        })?;
+                    backend
+                        .configure_netns(
+                            handle.pid,
+                            container_veth,
+                            &nr.ip,
+                            nr.prefix_len,
+                            &nr.gateway,
+                        )
+                        .await
+                        .map_err(|e| {
+                            ComputeError::NetworkSetup(format!(
+                                "failed to configure container netns: {e}"
+                            ))
+                        })?;
+                    info!(
+                        vm_id = %vm_id_str,
+                        ip = %nr.ip,
+                        "container network namespace configured"
+                    );
+                }
+            }
+        }
 
         // -- Build VmRuntimeState from the RuntimeHandle ----------------------
         let now = now_unix();

--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -35,8 +35,10 @@ const DNS_SERVERS: &[&str] = &["8.8.8.8", "1.1.1.1"];
 /// Everything the caller needs after network setup succeeds.
 #[derive(Debug)]
 pub struct NetworkSetupResult {
-    /// TAP device name for the VM (pass to runtime).
+    /// TAP device name for the VM, or host-side veth name for containers.
     pub tap_name: String,
+    /// Container-side veth name (only set for containers, moved into netns).
+    pub container_veth: Option<String>,
     /// MAC address assigned by IPAM.
     pub mac: String,
     /// Allocated IP address.
@@ -45,6 +47,8 @@ pub struct NetworkSetupResult {
     pub subnet_cidr: String,
     /// Gateway IP.
     pub gateway: String,
+    /// Prefix length parsed from the subnet CIDR.
+    pub prefix_len: u8,
     /// Network config for Cloud Hypervisor.
     pub network_config: NetworkConfig,
     /// Cloud-init network config for the config-drive.
@@ -104,6 +108,7 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         &self,
         vm_id: &str,
         subnet_name: &str,
+        is_container: bool,
     ) -> Result<NetworkSetupResult, ComputeError> {
         // -- 1. Resolve subnet ------------------------------------------------
         let (subnet, vpc) = self.resolve_subnet(subnet_name)?;
@@ -143,6 +148,7 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
                 &gateway,
                 &ip,
                 &mac,
+                is_container,
             )
             .await
         {
@@ -177,10 +183,10 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         gateway: &str,
         ip: &str,
         mac: &str,
+        is_container: bool,
     ) -> Result<NetworkSetupResult, ComputeError> {
         let bridge_name = syfrah_overlay::naming::bridge_name(vpc_id);
         let vxlan_name = syfrah_overlay::naming::vxlan_name(vpc_id);
-        let tap_name = syfrah_overlay::naming::tap_name(vm_id);
 
         // Parse prefix length from CIDR.
         let prefix_len = parse_prefix_len(subnet_cidr)?;
@@ -209,20 +215,42 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
             .await
             .map_err(|e| ComputeError::NetworkSetup(format!("add bridge IP failed: {e}")))?;
 
-        // -- 5. Create TAP, attach to bridge ----------------------------------
-        self.backend
-            .create_tap(&tap_name)
-            .await
-            .map_err(|e| ComputeError::NetworkSetup(format!("TAP creation failed: {e}")))?;
+        // -- 5. Create host-side interface and attach to bridge ----------------
+        // For VMs: create a TAP device.
+        // For containers: create a veth pair (host end attaches to bridge,
+        //   container end will be moved into the netns after crun creates it).
+        let (host_iface, container_veth) = if is_container {
+            let host_veth = syfrah_overlay::naming::veth_host_name(vm_id);
+            let cont_veth = syfrah_overlay::naming::veth_container_name(vm_id);
+            self.backend
+                .create_veth_pair(&host_veth, &cont_veth)
+                .await
+                .map_err(|e| {
+                    ComputeError::NetworkSetup(format!("veth pair creation failed: {e}"))
+                })?;
+            (host_veth, Some(cont_veth))
+        } else {
+            let tap_name = syfrah_overlay::naming::tap_name(vm_id);
+            self.backend
+                .create_tap(&tap_name)
+                .await
+                .map_err(|e| ComputeError::NetworkSetup(format!("TAP creation failed: {e}")))?;
+            (tap_name, None)
+        };
 
         self.backend
-            .attach_to_bridge(&tap_name, &bridge_name)
+            .attach_to_bridge(&host_iface, &bridge_name)
             .await
-            .map_err(|e| ComputeError::NetworkSetup(format!("attach TAP to bridge failed: {e}")))?;
+            .map_err(|e| {
+                ComputeError::NetworkSetup(format!(
+                    "attach {} to bridge failed: {e}",
+                    if is_container { "veth" } else { "TAP" }
+                ))
+            })?;
 
         // -- 6. Apply nftables rules ------------------------------------------
         self.backend
-            .apply_vm_rules(&tap_name, mac, ip)
+            .apply_vm_rules(&host_iface, mac, ip)
             .await
             .map_err(|e| ComputeError::NetworkSetup(format!("nftables rules failed: {e}")))?;
 
@@ -256,14 +284,15 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         info!(
             vm_id,
             %ip, %mac,
-            tap = %tap_name,
+            iface = %host_iface,
             bridge = %bridge_name,
+            is_container,
             "network setup complete"
         );
 
         // Build result
         let network_config = NetworkConfig {
-            tap_name: tap_name.clone(),
+            tap_name: host_iface.clone(),
             mac: Some(mac.to_string()),
         };
 
@@ -276,11 +305,13 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         };
 
         Ok(NetworkSetupResult {
-            tap_name,
+            tap_name: host_iface,
+            container_veth,
             mac: mac.to_string(),
             ip: ip.to_string(),
             subnet_cidr: subnet_cidr.to_string(),
             gateway: gateway.to_string(),
+            prefix_len,
             network_config,
             cloud_init_network,
             placement,
@@ -481,7 +512,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         // Verify IP and MAC assigned
         assert_eq!(result.ip, "10.0.1.3");
@@ -522,7 +553,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         // Verify IPAM was called — IP is the first allocatable (.3)
         assert_eq!(result.ip, "10.0.1.3");
@@ -540,7 +571,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         let expected_tap = syfrah_overlay::naming::tap_name("web-1");
         assert_eq!(result.tap_name, expected_tap);
@@ -560,7 +591,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let _result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let _result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         let calls = h.backend.calls();
         // Bridge should be created with the VPC ID
@@ -578,7 +609,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         // Verify placement was stored
         let stored = h
@@ -600,7 +631,7 @@ mod tests {
         h.backend.set_fail("create_tap");
 
         let ns = h.network_setup();
-        let result = ns.setup("web-1", SUBNET_NAME).await;
+        let result = ns.setup("web-1", SUBNET_NAME, false).await;
 
         assert!(result.is_err(), "setup must fail when TAP creation fails");
 
@@ -620,7 +651,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         // Verify cloud-init network config
         assert_eq!(result.cloud_init_network.ip, "10.0.1.3");
@@ -635,7 +666,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", "nonexistent").await;
+        let result = ns.setup("web-1", "nonexistent", false).await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -649,7 +680,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
 
         // Mark as assigned (happens after successful boot)
         ns.mark_assigned(&result.placement.subnet_id, &result.ip, "web-1")
@@ -670,7 +701,7 @@ mod tests {
         let h = TestHarness::new();
         let ns = h.network_setup();
 
-        let result = ns.setup("web-1", SUBNET_NAME).await.unwrap();
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
         h.backend.reset();
 
         // Teardown
@@ -698,6 +729,71 @@ mod tests {
         assert!(
             alloc.is_none(),
             "IP allocation must be removed after teardown"
+        );
+    }
+
+    #[tokio::test]
+    async fn container_creates_veth_pair_not_tap() {
+        let h = TestHarness::new();
+        let ns = h.network_setup();
+
+        let result = ns.setup("web-1", SUBNET_NAME, true).await.unwrap();
+
+        // Container should get a veth pair, not a TAP.
+        let expected_host = syfrah_overlay::naming::veth_host_name("web-1");
+        let expected_cont = syfrah_overlay::naming::veth_container_name("web-1");
+        assert_eq!(result.tap_name, expected_host);
+        assert_eq!(result.container_veth, Some(expected_cont.clone()));
+        assert!(result.prefix_len > 0, "prefix_len must be set");
+
+        let calls = h.backend.calls();
+        let call_names: Vec<&str> = calls.iter().map(|c| c.split('(').next().unwrap()).collect();
+
+        assert!(
+            call_names.contains(&"create_veth_pair"),
+            "veth pair must be created for container"
+        );
+        assert!(
+            !call_names.contains(&"create_tap"),
+            "TAP must NOT be created for container"
+        );
+        assert!(
+            call_names.contains(&"attach_to_bridge"),
+            "host veth must be attached to bridge"
+        );
+        assert!(
+            call_names.contains(&"apply_vm_rules"),
+            "nftables must be applied on host veth"
+        );
+
+        // Verify the veth pair call has the right names
+        assert!(calls
+            .iter()
+            .any(|c| c == &format!("create_veth_pair({expected_host}, {expected_cont})")));
+    }
+
+    #[tokio::test]
+    async fn vm_creates_tap_not_veth() {
+        let h = TestHarness::new();
+        let ns = h.network_setup();
+
+        let result = ns.setup("web-1", SUBNET_NAME, false).await.unwrap();
+
+        // VM should get a TAP, not a veth pair.
+        let expected_tap = syfrah_overlay::naming::tap_name("web-1");
+        assert_eq!(result.tap_name, expected_tap);
+        assert!(result.container_veth.is_none());
+
+        let calls = h.backend.calls();
+        let call_names: Vec<&str> = calls.iter().map(|c| c.split('(').next().unwrap()).collect();
+
+        assert!(
+            call_names.contains(&"create_tap"),
+            "TAP must be created for VM"
+        );
+        assert!(
+            !call_names.contains(&"create_veth_pair"),
+            "veth pair must NOT be created for VM"
         );
     }
 }

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -54,6 +54,22 @@ pub trait NetworkBackend: Send + Sync {
     /// Create a veth pair (used by containers).
     async fn create_veth_pair(&self, name_a: &str, name_b: &str) -> Result<()>;
 
+    /// Move a network interface into a container's network namespace.
+    async fn move_to_netns(&self, iface: &str, pid: u32) -> Result<()>;
+
+    /// Configure networking inside a container's network namespace.
+    ///
+    /// Renames `iface` to `eth0`, assigns the given IP/prefix, brings up
+    /// `eth0` and `lo`, and adds a default route via `gateway`.
+    async fn configure_netns(
+        &self,
+        pid: u32,
+        iface: &str,
+        ip: &str,
+        prefix_len: u8,
+        gateway: &str,
+    ) -> Result<()>;
+
     // ── Firewall ───────────────────────────────────────────────────────
 
     /// Apply anti-spoofing + default ingress/egress rules for a VM.

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -240,6 +240,52 @@ impl NetworkBackend for LinuxBackend {
         Ok(())
     }
 
+    async fn move_to_netns(&self, iface: &str, pid: u32) -> Result<()> {
+        Self::run("ip", &["link", "set", iface, "netns", &pid.to_string()]).await?;
+        Ok(())
+    }
+
+    async fn configure_netns(
+        &self,
+        pid: u32,
+        iface: &str,
+        ip: &str,
+        prefix_len: u8,
+        gateway: &str,
+    ) -> Result<()> {
+        let ns = format!("/proc/{pid}/ns/net");
+        let cidr = format!("{ip}/{prefix_len}");
+
+        // Rename the veth endpoint to eth0 inside the namespace.
+        Self::run(
+            "nsenter",
+            &["--net", &ns, "ip", "link", "set", iface, "name", "eth0"],
+        )
+        .await?;
+        // Assign the allocated IP.
+        Self::run(
+            "nsenter",
+            &["--net", &ns, "ip", "addr", "add", &cidr, "dev", "eth0"],
+        )
+        .await?;
+        // Bring up eth0 and loopback.
+        Self::run(
+            "nsenter",
+            &["--net", &ns, "ip", "link", "set", "eth0", "up"],
+        )
+        .await?;
+        Self::run("nsenter", &["--net", &ns, "ip", "link", "set", "lo", "up"]).await?;
+        // Default route through the bridge gateway.
+        Self::run(
+            "nsenter",
+            &[
+                "--net", &ns, "ip", "route", "add", "default", "via", gateway,
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
     // ── Firewall ───────────────────────────────────────────────────
 
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -168,6 +168,27 @@ impl NetworkBackend for MockBackend {
         Ok(())
     }
 
+    async fn move_to_netns(&self, iface: &str, pid: u32) -> Result<()> {
+        self.should_fail("move_to_netns")?;
+        self.record(format!("move_to_netns({iface}, {pid})"));
+        Ok(())
+    }
+
+    async fn configure_netns(
+        &self,
+        pid: u32,
+        iface: &str,
+        ip: &str,
+        prefix_len: u8,
+        gateway: &str,
+    ) -> Result<()> {
+        self.should_fail("configure_netns")?;
+        self.record(format!(
+            "configure_netns({pid}, {iface}, {ip}, {prefix_len}, {gateway})"
+        ));
+        Ok(())
+    }
+
     // ── Firewall ───────────────────────────────────────────────────────
 
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
@@ -261,6 +282,10 @@ mod tests {
         b.create_tap(&tap).await.unwrap();
         b.delete_tap(&tap).await.unwrap();
         b.create_veth_pair(&vh, &vc).await.unwrap();
+        b.move_to_netns(&vc, 1234).await.unwrap();
+        b.configure_netns(1234, &vc, "10.1.1.3", 24, "10.1.1.1")
+            .await
+            .unwrap();
 
         b.apply_vm_rules(&tap, "02:00:0a:01:01:03", "10.1.1.3")
             .await
@@ -275,7 +300,7 @@ mod tests {
             .unwrap();
 
         let calls = b.calls();
-        assert_eq!(calls.len(), 21, "expected one call per trait method");
+        assert_eq!(calls.len(), 23, "expected one call per trait method");
 
         // Verify each method was recorded
         assert!(calls[0].starts_with("create_vxlan("));
@@ -292,13 +317,15 @@ mod tests {
         assert!(calls[11].starts_with("create_tap("));
         assert!(calls[12].starts_with("delete_tap("));
         assert!(calls[13].starts_with("create_veth_pair("));
-        assert!(calls[14].starts_with("apply_vm_rules("));
-        assert!(calls[15].starts_with("remove_vm_rules("));
-        assert!(calls[16].starts_with("apply_nat("));
-        assert!(calls[17].starts_with("remove_nat("));
-        assert!(calls[18].starts_with("apply_peering_rules("));
-        assert!(calls[19].starts_with("remove_peering_rules("));
-        assert!(calls[20].starts_with("list_interfaces("));
+        assert!(calls[14].starts_with("move_to_netns("));
+        assert!(calls[15].starts_with("configure_netns("));
+        assert!(calls[16].starts_with("apply_vm_rules("));
+        assert!(calls[17].starts_with("remove_vm_rules("));
+        assert!(calls[18].starts_with("apply_nat("));
+        assert!(calls[19].starts_with("remove_nat("));
+        assert!(calls[20].starts_with("apply_peering_rules("));
+        assert!(calls[21].starts_with("remove_peering_rules("));
+        assert!(calls[22].starts_with("list_interfaces("));
 
         // Test reset
         b.reset();


### PR DESCRIPTION
## Summary

Containers need veth pairs (not TAP devices) to connect to the overlay network. This PR implements the full container networking flow:

- **NetworkBackend trait**: adds `move_to_netns()` and `configure_netns()` methods for moving a veth endpoint into a container's network namespace and configuring IP/routes inside it
- **NetworkSetup**: accepts `is_container` flag; creates a veth pair instead of a TAP device for containers; exposes `container_veth` name and `prefix_len` in the result
- **VmManager**: after `crun run -d` returns with the container PID, moves the container-side veth into the netns, renames it to `eth0`, assigns IP/prefix, brings up `eth0` + `lo`, and adds the default route via the bridge gateway

The VM (TAP) path is unchanged. Existing tests updated and two new tests added.

### Files changed

| File | Change |
|------|--------|
| `layers/overlay/src/backend.rs` | Added `move_to_netns` and `configure_netns` to trait |
| `layers/overlay/src/linux.rs` | Implemented via `ip link set netns` and `nsenter` |
| `layers/overlay/src/mock.rs` | Record calls for test assertions |
| `layers/compute/src/network_setup.rs` | Branch on `is_container`: veth pair vs TAP |
| `layers/compute/src/manager.rs` | Post-create netns setup for containers |

Closes #856