### PR TITLE
Set IPAM-derived MAC on container veth

### DIFF
--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -809,6 +809,7 @@ impl VmManager {
                             &nr.ip,
                             nr.prefix_len,
                             &nr.gateway,
+                            &nr.mac,
                         )
                         .await
                         .map_err(|e| {

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -68,6 +68,7 @@ pub trait NetworkBackend: Send + Sync {
         ip: &str,
         prefix_len: u8,
         gateway: &str,
+        mac: &str,
     ) -> Result<()>;
 
     // ── Firewall ───────────────────────────────────────────────────────

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -252,6 +252,7 @@ impl NetworkBackend for LinuxBackend {
         ip: &str,
         prefix_len: u8,
         gateway: &str,
+        mac: &str,
     ) -> Result<()> {
         // Use --net=<path> (not --net <path>) for compatibility with
         // util-linux nsenter which requires the = form.
@@ -262,6 +263,12 @@ impl NetworkBackend for LinuxBackend {
         Self::run(
             "nsenter",
             &[&ns_flag, "ip", "link", "set", iface, "name", "eth0"],
+        )
+        .await?;
+        // Set MAC address to match IPAM-derived MAC (required for anti-spoofing)
+        Self::run(
+            "nsenter",
+            &[&ns_flag, "ip", "link", "set", "eth0", "address", mac],
         )
         .await?;
         // Assign the allocated IP.

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -181,10 +181,11 @@ impl NetworkBackend for MockBackend {
         ip: &str,
         prefix_len: u8,
         gateway: &str,
+        mac: &str,
     ) -> Result<()> {
         self.should_fail("configure_netns")?;
         self.record(format!(
-            "configure_netns({pid}, {iface}, {ip}, {prefix_len}, {gateway})"
+            "configure_netns({pid}, {iface}, {ip}, {prefix_len}, {gateway}, {mac})"
         ));
         Ok(())
     }
@@ -283,7 +284,7 @@ mod tests {
         b.delete_tap(&tap).await.unwrap();
         b.create_veth_pair(&vh, &vc).await.unwrap();
         b.move_to_netns(&vc, 1234).await.unwrap();
-        b.configure_netns(1234, &vc, "10.1.1.3", 24, "10.1.1.1")
+        b.configure_netns(1234, &vc, "10.1.1.3", 24, "10.1.1.1", "02:00:0a:01:01:03")
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

- Add `mac` parameter to `NetworkBackend::configure_netns()` trait method
- Set the MAC address on eth0 inside the container namespace before bringing the interface up
- This ensures the veth MAC matches the IPAM-derived MAC used in nftables anti-spoofing rules

## What was happening

`configure_netns()` renamed the veth to eth0 and brought it up, but never set the MAC. The kernel assigned a random MAC that didn't match the IPAM-derived MAC in the anti-spoofing rules, causing traffic drops.

## Changes

- `layers/overlay/src/backend.rs` — added `mac: &str` parameter to trait
- `layers/overlay/src/linux.rs` — added `ip link set eth0 address <mac>` after rename, before link up
- `layers/overlay/src/mock.rs` — updated mock impl and test to pass MAC
- `layers/compute/src/manager.rs` — pass `nr.mac` to `configure_netns()`

## Testing

- Built and deployed to 65.109.130.108
- Created two containers in the same subnet
- Verified MACs are IPAM-derived (`02:00:0a:01:00:05`, `02:00:0a:01:00:06`)
- Verified ping works in both directions (0% packet loss)
- All cargo tests pass (80/80 in overlay+compute)

Closes #859