### PR TITLE
Add route tables, routes, CLI, and deletion guards

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -72,6 +72,11 @@ enum Commands {
         #[command(subcommand)]
         command: syfrah_org::SgCommand,
     },
+    /// Manage route tables and routes
+    Route {
+        #[command(subcommand)]
+        command: syfrah_org::RouteCommand,
+    },
     /// Inspect and manage layer state databases
     State {
         #[command(subcommand)]
@@ -950,6 +955,7 @@ async fn run() -> Result<()> {
         Commands::Vpc { command } => syfrah_org::cli::run_vpc(command).await,
         Commands::Subnet { command } => syfrah_org::cli::run_subnet(command).await,
         Commands::Sg { command } => syfrah_org::cli::run_sg(command).await,
+        Commands::Route { command } => syfrah_org::cli::run_route(command).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             let mut buf = Vec::new();

--- a/layers/org/src/api.rs
+++ b/layers/org/src/api.rs
@@ -18,8 +18,8 @@ use crate::sg_rules::SgRuleStore;
 use crate::store::OrgStore;
 use crate::types::{
     Direction, Environment, EnvironmentId, NetworkInterface, Org, OrgId, PeeringStatus, PortRange,
-    Project, ProjectId, Protocol, RuleId, RuleSource, SecurityGroup, SecurityGroupRule, Subnet,
-    Vpc, VpcOwner, VpcPeering,
+    Project, ProjectId, Protocol, Route, RouteTable, RouteTarget, RuleId, RuleSource,
+    SecurityGroup, SecurityGroupRule, Subnet, Vpc, VpcOwner, VpcPeering,
 };
 
 // ---------------------------------------------------------------------------
@@ -193,6 +193,44 @@ pub enum OrgRequest {
         source: Option<String>,
     },
 
+    // -- Route Table --
+    RouteTableCreate {
+        name: String,
+        vpc: String,
+    },
+    RouteTableList {
+        vpc: Option<String>,
+    },
+    RouteTableDelete {
+        name: String,
+        vpc: Option<String>,
+    },
+    RouteTableAssociate {
+        table: String,
+        subnet: String,
+    },
+    RouteTableDisassociate {
+        subnet: String,
+    },
+
+    // -- Route --
+    RouteAdd {
+        vpc: String,
+        table: Option<String>,
+        destination: String,
+        target: String,
+        priority: Option<u32>,
+    },
+    RouteDelete {
+        vpc: String,
+        table: Option<String>,
+        destination: String,
+    },
+    RouteList {
+        vpc: Option<String>,
+        table: Option<String>,
+    },
+
     // -- Subnet resolution (used by compute layer) --
     SubnetResolve {
         subnet_name: Option<String>,
@@ -229,6 +267,10 @@ pub enum OrgResponse {
         verdict: String,
         reason: String,
     },
+    RouteTableResp(RouteTable),
+    RouteTableList(Vec<RouteTable>),
+    RouteResp(Route),
+    RouteListResp(Vec<Route>),
     /// Resolved subnet info for VM placement (None = no subnet context).
     SubnetResolved(Option<ResolvedSubnet>),
     Ok,
@@ -866,6 +908,179 @@ fn handle_org_request(
             OrgResponse::SgCheckResult { verdict, reason }
         }
 
+        // -- Route Table --
+        OrgRequest::RouteTableCreate { name, vpc } => {
+            match store.create_route_table_by_vpc_name(&name, &vpc) {
+                Ok(table) => OrgResponse::RouteTableResp(table),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteTableList { vpc } => {
+            match store.list_route_tables_by_vpc_name(vpc.as_deref()) {
+                Ok(tables) => OrgResponse::RouteTableList(tables),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteTableDelete { name, vpc } => {
+            // Resolve VPC: if given, use it; otherwise scan all tables.
+            let result = if let Some(vname) = vpc {
+                store.delete_route_table_by_vpc_name(&vname, &name)
+            } else {
+                // Try to find the table across all VPCs.
+                let tables = match store.list_route_tables() {
+                    Ok(t) => t,
+                    Err(e) => return OrgResponse::Error(e.to_string()),
+                };
+                let matching: Vec<_> = tables.iter().filter(|t| t.name == name).collect();
+                match matching.len() {
+                    0 => Err(crate::error::OrgError::RouteTableNotFound(name.clone())),
+                    1 => store.delete_route_table(&matching[0].vpc_id, &name),
+                    _ => Err(crate::error::OrgError::Ambiguous(format!(
+                        "route table '{name}' exists in multiple VPCs — specify --vpc"
+                    ))),
+                }
+            };
+            match result {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteTableAssociate { table, subnet } => {
+            // Find the subnet, then find the route table in the same VPC.
+            let matches = match store.find_subnets_by_name(&subnet) {
+                Ok(m) => m,
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            let sub = match matches.len() {
+                0 => return OrgResponse::Error(format!("subnet not found: {subnet}")),
+                1 => matches.into_iter().next().unwrap().1,
+                _ => {
+                    return OrgResponse::Error(format!(
+                        "subnet '{subnet}' exists in multiple VPCs — specify --vpc"
+                    ));
+                }
+            };
+            let rt = match store.get_route_table(&sub.vpc_id, &table) {
+                Ok(Some(t)) => t,
+                Ok(None) => {
+                    return OrgResponse::Error(format!("route table not found: {table}"));
+                }
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            match store.associate_subnet_route_table(&sub.id, &rt.id) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteTableDisassociate { subnet } => {
+            let matches = match store.find_subnets_by_name(&subnet) {
+                Ok(m) => m,
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            let sub = match matches.len() {
+                0 => return OrgResponse::Error(format!("subnet not found: {subnet}")),
+                1 => matches.into_iter().next().unwrap().1,
+                _ => {
+                    return OrgResponse::Error(format!(
+                        "subnet '{subnet}' exists in multiple VPCs — specify --vpc"
+                    ));
+                }
+            };
+            match store.disassociate_subnet_route_table(&sub.id) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+
+        // -- Route --
+        OrgRequest::RouteAdd {
+            vpc,
+            table,
+            destination,
+            target,
+            priority,
+        } => {
+            let vpc_obj = match store.get_vpc(&vpc) {
+                Ok(Some(v)) => v,
+                Ok(None) => return OrgResponse::Error(format!("VPC not found: {vpc}")),
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            let table_name = table.as_deref().unwrap_or("default");
+            let rt = match store.get_route_table(&vpc_obj.id, table_name) {
+                Ok(Some(t)) => t,
+                Ok(None) => {
+                    return OrgResponse::Error(format!("route table not found: {table_name}"));
+                }
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            let route_target = match parse_route_target(&target) {
+                Ok(t) => t,
+                Err(e) => return OrgResponse::Error(e),
+            };
+
+            // Validate target resources exist if applicable.
+            if let Err(e) = validate_route_target(store, &route_target) {
+                return OrgResponse::Error(e);
+            }
+
+            match store.add_route(&rt.id, &destination, route_target, priority) {
+                Ok(route) => OrgResponse::RouteResp(route),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteDelete {
+            vpc,
+            table,
+            destination,
+        } => {
+            let vpc_obj = match store.get_vpc(&vpc) {
+                Ok(Some(v)) => v,
+                Ok(None) => return OrgResponse::Error(format!("VPC not found: {vpc}")),
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            let table_name = table.as_deref().unwrap_or("default");
+            let rt = match store.get_route_table(&vpc_obj.id, table_name) {
+                Ok(Some(t)) => t,
+                Ok(None) => {
+                    return OrgResponse::Error(format!("route table not found: {table_name}"));
+                }
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            match store.remove_route(&rt.id, &destination) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::RouteList { vpc, table } => {
+            if let Some(vname) = &vpc {
+                let vpc_obj = match store.get_vpc(vname) {
+                    Ok(Some(v)) => v,
+                    Ok(None) => return OrgResponse::Error(format!("VPC not found: {vname}")),
+                    Err(e) => return OrgResponse::Error(e.to_string()),
+                };
+                if let Some(tname) = &table {
+                    let rt = match store.get_route_table(&vpc_obj.id, tname) {
+                        Ok(Some(t)) => t,
+                        Ok(None) => {
+                            return OrgResponse::Error(format!("route table not found: {tname}"));
+                        }
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    };
+                    match store.list_routes_by_table(&rt.id) {
+                        Ok(routes) => OrgResponse::RouteListResp(routes),
+                        Err(e) => OrgResponse::Error(e.to_string()),
+                    }
+                } else {
+                    match store.list_routes_by_vpc(&vpc_obj.id) {
+                        Ok(routes) => OrgResponse::RouteListResp(routes),
+                        Err(e) => OrgResponse::Error(e.to_string()),
+                    }
+                }
+            } else {
+                OrgResponse::Error("specify --vpc to list routes".to_string())
+            }
+        }
+
         // -- Subnet resolution (for compute layer) --
         OrgRequest::SubnetResolve {
             subnet_name,
@@ -966,6 +1181,69 @@ pub async fn send_org_request(
 }
 
 /// Parse a port range string like "443" or "8000-9000".
+/// Parse a route target string like "local", "blackhole", "nat-gw:foo", "peering:bar".
+fn parse_route_target(s: &str) -> std::result::Result<RouteTarget, String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("local") {
+        Ok(RouteTarget::Local)
+    } else if s.eq_ignore_ascii_case("blackhole") {
+        Ok(RouteTarget::Blackhole)
+    } else if let Some(name) = s.strip_prefix("nat-gw:") {
+        if name.is_empty() {
+            return Err("nat-gw target requires a name".to_string());
+        }
+        Ok(RouteTarget::NatGateway(name.to_string()))
+    } else if let Some(name) = s.strip_prefix("peering:") {
+        if name.is_empty() {
+            return Err("peering target requires a name".to_string());
+        }
+        Ok(RouteTarget::VpcPeering(name.to_string()))
+    } else {
+        Err(format!(
+            "invalid route target: '{s}'. Valid: local, blackhole, nat-gw:<name>, peering:<name>"
+        ))
+    }
+}
+
+/// Validate that a route target's referenced resource exists and is active.
+fn validate_route_target(
+    store: &OrgStore,
+    target: &RouteTarget,
+) -> std::result::Result<(), String> {
+    match target {
+        RouteTarget::Local | RouteTarget::Blackhole => Ok(()),
+        RouteTarget::VpcPeering(name) => {
+            // Check if peering exists and is active.
+            match store.list_peerings() {
+                Ok(peerings) => {
+                    let found = peerings
+                        .iter()
+                        .find(|p| p.vpc_a == *name || p.vpc_b == *name || p.id.0 == *name);
+                    match found {
+                        Some(p) => {
+                            if p.status == crate::types::PeeringStatus::Active {
+                                Ok(())
+                            } else {
+                                Err(format!(
+                                    "target resource '{}' is not active (current state: {})",
+                                    name, p.status
+                                ))
+                            }
+                        }
+                        None => Err(format!("target resource '{name}' not found")),
+                    }
+                }
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        RouteTarget::NatGateway(_name) => {
+            // NAT Gateway is not yet implemented (Phase 3 placeholder).
+            // For now, accept the target — it will be validated when NAT GW is implemented.
+            Ok(())
+        }
+    }
+}
+
 fn parse_port_range(s: &str) -> std::result::Result<PortRange, String> {
     if let Some((from_s, to_s)) = s.split_once('-') {
         let from: u16 = from_s
@@ -1190,7 +1468,7 @@ mod tests {
             priority: 100,
             description: None,
         };
-        let (v1, _) = evaluate_rules(&[rule.clone()], 22, Protocol::Tcp, "10.1.2.3");
+        let (v1, _) = evaluate_rules(std::slice::from_ref(&rule), 22, Protocol::Tcp, "10.1.2.3");
         assert_eq!(v1, "ALLOWED");
         let (v2, _) = evaluate_rules(&[rule], 22, Protocol::Tcp, "192.168.1.1");
         assert_eq!(v2, "DENIED");

--- a/layers/org/src/cli/mod.rs
+++ b/layers/org/src/cli/mod.rs
@@ -1,8 +1,9 @@
-//! CLI commands for `syfrah org ...`, `syfrah project ...`, `syfrah env ...`, `syfrah vpc ...`, and `syfrah subnet ...`.
+//! CLI commands for `syfrah org ...`, `syfrah project ...`, `syfrah env ...`, `syfrah vpc ...`, `syfrah subnet ...`, and `syfrah route ...`.
 
 pub mod env;
 pub mod org;
 pub mod project;
+pub mod route;
 pub mod sg;
 pub mod subnet;
 pub mod vpc;
@@ -318,6 +319,114 @@ pub enum SubnetCommand {
         /// Skip confirmation prompt
         #[arg(long, short)]
         yes: bool,
+    },
+}
+
+/// Top-level route CLI command.
+#[derive(Debug, Subcommand)]
+pub enum RouteCommand {
+    /// Manage route tables
+    Table {
+        #[command(subcommand)]
+        action: RouteTableAction,
+    },
+    /// List routes in a VPC
+    #[command(
+        after_help = "Examples:\n  syfrah route list --vpc my-vpc\n  syfrah route list --vpc my-vpc --table default --json"
+    )]
+    List {
+        /// VPC name
+        #[arg(long)]
+        vpc: Option<String>,
+        /// Route table name (default: all tables in VPC)
+        #[arg(long)]
+        table: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add a route to a route table
+    #[command(
+        after_help = "Examples:\n  syfrah route add --vpc my-vpc --destination 10.99.0.0/24 --target blackhole\n  syfrah route add --vpc my-vpc --destination 0.0.0.0/0 --target nat-gw:my-nat"
+    )]
+    Add {
+        /// VPC name
+        #[arg(long)]
+        vpc: String,
+        /// Destination CIDR
+        #[arg(long)]
+        destination: String,
+        /// Target: local, blackhole, nat-gw:<name>, peering:<name>
+        #[arg(long)]
+        target: String,
+        /// Route table name (default: "default")
+        #[arg(long)]
+        table: Option<String>,
+        /// Priority (lower = evaluated first, default: 100)
+        #[arg(long)]
+        priority: Option<u32>,
+    },
+    /// Delete a route from a route table
+    #[command(
+        after_help = "Examples:\n  syfrah route delete --vpc my-vpc --destination 10.99.0.0/24"
+    )]
+    Delete {
+        /// VPC name
+        #[arg(long)]
+        vpc: String,
+        /// Destination CIDR to remove
+        #[arg(long)]
+        destination: String,
+        /// Route table name (default: "default")
+        #[arg(long)]
+        table: Option<String>,
+    },
+}
+
+/// Route table management subcommands.
+#[derive(Debug, Subcommand)]
+pub enum RouteTableAction {
+    /// Create a new route table
+    Create {
+        /// Route table name
+        name: String,
+        /// VPC the route table belongs to
+        #[arg(long)]
+        vpc: String,
+    },
+    /// List route tables
+    List {
+        /// Filter by VPC name
+        #[arg(long)]
+        vpc: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete a route table
+    Delete {
+        /// Route table name
+        name: String,
+        /// VPC the route table belongs to
+        #[arg(long)]
+        vpc: Option<String>,
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
+    /// Associate a route table with a subnet
+    Associate {
+        /// Route table name
+        table: String,
+        /// Subnet to associate
+        #[arg(long)]
+        subnet: String,
+    },
+    /// Disassociate a subnet from its custom route table (reverts to default)
+    Disassociate {
+        /// Subnet to disassociate
+        #[arg(long)]
+        subnet: String,
     },
 }
 
@@ -678,5 +787,41 @@ pub async fn run_sg(cmd: SgCommand) -> anyhow::Result<()> {
             protocol,
             source,
         } => sg::run_check(&vm, port, &protocol, source.as_deref()).await,
+    }
+}
+
+/// Execute a route CLI command.
+pub async fn run_route(cmd: RouteCommand) -> anyhow::Result<()> {
+    match cmd {
+        RouteCommand::Table { action } => match action {
+            RouteTableAction::Create { name, vpc } => route::run_table_create(&name, &vpc).await,
+            RouteTableAction::List { vpc, json } => {
+                route::run_table_list(vpc.as_deref(), json).await
+            }
+            RouteTableAction::Delete { name, vpc, yes } => {
+                route::run_table_delete(&name, vpc.as_deref(), yes).await
+            }
+            RouteTableAction::Associate { table, subnet } => {
+                route::run_table_associate(&table, &subnet).await
+            }
+            RouteTableAction::Disassociate { subnet } => {
+                route::run_table_disassociate(&subnet).await
+            }
+        },
+        RouteCommand::List { vpc, table, json } => {
+            route::run_list(vpc.as_deref(), table.as_deref(), json).await
+        }
+        RouteCommand::Add {
+            vpc,
+            destination,
+            target,
+            table,
+            priority,
+        } => route::run_add(&vpc, &destination, &target, table.as_deref(), priority).await,
+        RouteCommand::Delete {
+            vpc,
+            destination,
+            table,
+        } => route::run_delete(&vpc, &destination, table.as_deref()).await,
     }
 }

--- a/layers/org/src/cli/route.rs
+++ b/layers/org/src/cli/route.rs
@@ -1,0 +1,274 @@
+//! `syfrah route` handlers.
+//!
+//! All operations go through the daemon's control socket.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
+}
+
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
+
+// ── Route Table ──────────────────────────────────────────────────
+
+pub async fn run_table_create(name: &str, vpc: &str) -> Result<()> {
+    let req = OrgRequest::RouteTableCreate {
+        name: name.to_string(),
+        vpc: vpc.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::RouteTableResp(table) => {
+            println!("Route table created: {}", table.name);
+            println!("  VPC:      {}", table.vpc_id);
+            println!("  Default:  {}", table.is_default);
+            println!("  State:    {}", table.state);
+            println!("  Created:  {}", format_timestamp(table.created_at));
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_table_list(vpc: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::RouteTableList {
+        vpc: vpc.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::RouteTableList(tables) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&tables)?);
+                return Ok(());
+            }
+
+            if tables.is_empty() {
+                println!("No route tables found.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<20} {:<10} {:<10} CREATED",
+                "NAME", "VPC", "DEFAULT", "STATE"
+            );
+            println!("{}", "-".repeat(70));
+            for t in &tables {
+                println!(
+                    "{:<20} {:<20} {:<10} {:<10} {}",
+                    t.name,
+                    t.vpc_id,
+                    if t.is_default { "yes" } else { "no" },
+                    t.state,
+                    format_timestamp(t.created_at),
+                );
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_table_delete(name: &str, vpc: Option<&str>, yes: bool) -> Result<()> {
+    if !yes {
+        eprint!("Delete route table '{name}'? [y/N] ");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let req = OrgRequest::RouteTableDelete {
+        name: name.to_string(),
+        vpc: vpc.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("Route table '{name}' deleted.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_table_associate(table: &str, subnet: &str) -> Result<()> {
+    let req = OrgRequest::RouteTableAssociate {
+        table: table.to_string(),
+        subnet: subnet.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("Subnet '{subnet}' associated with route table '{table}'.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_table_disassociate(subnet: &str) -> Result<()> {
+    let req = OrgRequest::RouteTableDisassociate {
+        subnet: subnet.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!(
+                "Subnet '{subnet}' disassociated from custom route table (using VPC default)."
+            );
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+// ── Route ────────────────────────────────────────────────────────
+
+pub async fn run_list(vpc: Option<&str>, table: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::RouteList {
+        vpc: vpc.map(String::from),
+        table: table.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::RouteListResp(routes) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&routes)?);
+                return Ok(());
+            }
+
+            if routes.is_empty() {
+                println!("No routes found.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<20} {:<12} {:<12} PRIORITY",
+                "DESTINATION", "TARGET", "ORIGIN", "STATUS"
+            );
+            println!("{}", "-".repeat(76));
+            for r in &routes {
+                println!(
+                    "{:<20} {:<20} {:<12} {:<12} {}",
+                    r.destination, r.target, r.origin, r.status, r.priority,
+                );
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_add(
+    vpc: &str,
+    destination: &str,
+    target: &str,
+    table: Option<&str>,
+    priority: Option<u32>,
+) -> Result<()> {
+    let req = OrgRequest::RouteAdd {
+        vpc: vpc.to_string(),
+        table: table.map(String::from),
+        destination: destination.to_string(),
+        target: target.to_string(),
+        priority,
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::RouteResp(route) => {
+            println!("Route added:");
+            println!("  Destination: {}", route.destination);
+            println!("  Target:      {}", route.target);
+            println!("  Origin:      {}", route.origin);
+            println!("  Status:      {}", route.status);
+            println!("  Priority:    {}", route.priority);
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_delete(vpc: &str, destination: &str, table: Option<&str>) -> Result<()> {
+    let req = OrgRequest::RouteDelete {
+        vpc: vpc.to_string(),
+        table: table.map(String::from),
+        destination: destination.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("Route for '{destination}' deleted.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+fn format_timestamp(ts: u64) -> String {
+    if ts == 0 {
+        return "-".to_string();
+    }
+    let secs = ts;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let age = now.saturating_sub(secs);
+    if age < 60 {
+        format!("{age}s ago")
+    } else if age < 3600 {
+        format!("{}m ago", age / 60)
+    } else if age < 86400 {
+        format!("{}h ago", age / 3600)
+    } else {
+        format!("{}d ago", age / 86400)
+    }
+}

--- a/layers/org/src/error.rs
+++ b/layers/org/src/error.rs
@@ -136,6 +136,36 @@ pub enum OrgError {
     #[error("IP already assigned: {ip} in subnet {subnet}")]
     IpAlreadyAssigned { subnet: String, ip: String },
 
+    #[error("route table already exists: {0}")]
+    RouteTableAlreadyExists(String),
+
+    #[error("route table not found: {0}")]
+    RouteTableNotFound(String),
+
+    #[error("cannot delete the default route table")]
+    CannotDeleteDefaultRouteTable,
+
+    #[error("route table '{name}' is associated with {count} subnet(s) — disassociate them first")]
+    RouteTableHasSubnets { name: String, count: usize },
+
+    #[error("route already exists for destination: {0}")]
+    RouteAlreadyExists(String),
+
+    #[error("route not found for destination: {0}")]
+    RouteNotFound(String),
+
+    #[error("cannot delete system-managed route")]
+    CannotDeleteSystemRoute,
+
+    #[error("cannot delete propagated route — remove the peering instead")]
+    CannotDeletePropagatedRoute,
+
+    #[error("target resource '{0}' not found")]
+    RouteTargetNotFound(String),
+
+    #[error("target resource '{name}' is not active (current state: {state})")]
+    RouteTargetNotActive { name: String, state: String },
+
     #[error("security group already exists: {0}")]
     SgAlreadyExists(String),
 

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -13,7 +13,10 @@ pub mod validation;
 pub mod vpc;
 
 pub use api::{send_org_request, OrgLayerHandler, OrgRequest, OrgResponse, ResolvedSubnet};
-pub use cli::{EnvCommand, OrgCommand, ProjectCommand, SgCommand, SubnetCommand, VpcCommand};
+pub use cli::{
+    EnvCommand, OrgCommand, ProjectCommand, RouteCommand, RouteTableAction, SgCommand,
+    SubnetCommand, VpcCommand,
+};
 pub use error::OrgError;
 pub use ipam::{AllocationState, IpAllocation, IpamStore, SubnetBitmap};
 pub use nic::NicStore;
@@ -22,9 +25,10 @@ pub use sg_rules::SgRuleStore;
 pub use store::OrgStore;
 pub use types::{
     Direction, Environment, EnvironmentId, NetworkInterface, NicId, Org, OrgId, PeeringId,
-    PeeringStatus, PlacementAction, PortRange, Project, ProjectId, Protocol, ResourceState, RuleId,
-    RuleSource, SecurityGroup, SecurityGroupId, SecurityGroupRule, Subnet, SubnetId, VmPlacement,
-    Vpc, VpcAttachment, VpcId, VpcOwner, VpcPeering,
+    PeeringStatus, PlacementAction, PortRange, Project, ProjectId, Protocol, ResourceState, Route,
+    RouteId, RouteOrigin, RouteStatus, RouteTable, RouteTableId, RouteTarget, RuleId, RuleSource,
+    SecurityGroup, SecurityGroupId, SecurityGroupRule, Subnet, SubnetId, VmPlacement, Vpc,
+    VpcAttachment, VpcId, VpcOwner, VpcPeering,
 };
 pub use validation::validate_name;
 pub use vpc::{cidrs_overlap, parse_and_validate_cidr, validate_subnet_cidr, VpcStore};

--- a/layers/org/src/store.rs
+++ b/layers/org/src/store.rs
@@ -7,8 +7,9 @@ use syfrah_state::LayerDb;
 use crate::error::{OrgError, Result};
 use crate::types::{
     Environment, EnvironmentId, NetworkInterface, Org, OrgId, PeeringId, PeeringStatus, Project,
-    ProjectId, ResourceState, SecurityGroup, SecurityGroupId, Subnet, SubnetId, Vpc, VpcAttachment,
-    VpcId, VpcOwner, VpcPeering,
+    ProjectId, ResourceState, Route, RouteId, RouteOrigin, RouteStatus, RouteTable, RouteTableId,
+    RouteTarget, SecurityGroup, SecurityGroupId, Subnet, SubnetId, Vpc, VpcAttachment, VpcId,
+    VpcOwner, VpcPeering,
 };
 use crate::validation::validate_name;
 use crate::vpc::{cidrs_overlap, parse_and_validate_cidr};
@@ -22,6 +23,9 @@ const SUBNETS_TABLE: &str = "subnets";
 const PEERINGS_TABLE: &str = "vpc_peerings";
 const SECURITY_GROUPS_TABLE: &str = "security_groups";
 const NICS_TABLE: &str = "network_interfaces";
+const ROUTE_TABLES_TABLE: &str = "route_tables";
+const ROUTES_TABLE: &str = "routes";
+const SUBNET_ROUTE_ASSOC_TABLE: &str = "subnet_route_associations";
 const VNI_COUNTER_TABLE: &str = "vni_counter";
 const VNI_COUNTER_KEY: &str = "counter";
 const VNI_START: u32 = 100;
@@ -432,6 +436,9 @@ impl OrgStore {
         // Auto-create the default security group for this VPC.
         self.create_default_sg(&vpc)?;
 
+        // Auto-create the default route table for this VPC.
+        self.create_default_route_table(&vpc)?;
+
         Ok(vpc)
     }
 
@@ -752,6 +759,12 @@ impl OrgStore {
         };
 
         self.db.set(SUBNETS_TABLE, &key, &subnet)?;
+
+        // Auto-add system route for this subnet's CIDR in the VPC's default route table.
+        if let Ok(Some(default_rt)) = self.get_default_route_table(&vpc.id) {
+            let _ = self.add_system_route(&default_rt, &subnet.cidr);
+        }
+
         Ok(subnet)
     }
 
@@ -807,12 +820,22 @@ impl OrgStore {
     /// Delete a subnet by VPC name and subnet name.
     pub fn delete_subnet(&self, vpc_name: &str, subnet_name: &str) -> Result<()> {
         let key = Self::subnet_key(vpc_name, subnet_name);
-        if !self.db.exists(SUBNETS_TABLE, &key)? {
-            return Err(OrgError::SubnetNotFound {
-                vpc: vpc_name.to_string(),
-                subnet: subnet_name.to_string(),
-            });
+        let subnet: Subnet =
+            self.db
+                .get(SUBNETS_TABLE, &key)?
+                .ok_or_else(|| OrgError::SubnetNotFound {
+                    vpc: vpc_name.to_string(),
+                    subnet: subnet_name.to_string(),
+                })?;
+
+        // Remove the system route for this subnet's CIDR from the default route table.
+        if let Ok(Some(default_rt)) = self.get_default_route_table(&subnet.vpc_id) {
+            let _ = self.remove_route_force(&default_rt.id, &subnet.cidr);
         }
+
+        // Remove any route table association for this subnet.
+        let _ = self.disassociate_subnet_route_table(&subnet.id);
+
         self.db.delete(SUBNETS_TABLE, &key)?;
         Ok(())
     }
@@ -1093,6 +1116,383 @@ impl OrgStore {
         }
 
         self.delete_sg(&sg.vpc_id, name)
+    }
+
+    // ── Route Table operations ──────────────────────────────────────
+
+    /// Build the redb key for a route table: "vpc_id/table_name".
+    fn route_table_key(vpc_id: &VpcId, name: &str) -> String {
+        format!("{}/{}", vpc_id.0, name)
+    }
+
+    /// Build the redb key for a route: "table_id/destination".
+    fn route_key(table_id: &RouteTableId, destination: &str) -> String {
+        format!("{}/{}", table_id.0, destination)
+    }
+
+    /// Create the default route table for a VPC. Called automatically
+    /// during VPC creation.
+    pub fn create_default_route_table(&self, vpc: &Vpc) -> Result<RouteTable> {
+        let key = Self::route_table_key(&vpc.id, "default");
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let table = RouteTable {
+            id: RouteTableId(format!("rtb-default-{}", vpc.name)),
+            name: "default".to_string(),
+            vpc_id: vpc.id.clone(),
+            is_default: true,
+            state: ResourceState::Active,
+            created_at: now,
+        };
+
+        self.db.set(ROUTE_TABLES_TABLE, &key, &table)?;
+
+        // Add the VPC CIDR local route as a system route.
+        self.add_system_route(&table, &vpc.cidr)?;
+
+        Ok(table)
+    }
+
+    /// Create a named route table within a VPC.
+    pub fn create_route_table(&self, name: &str, vpc_id: &VpcId) -> Result<RouteTable> {
+        validate_name(name, "route table")?;
+
+        let key = Self::route_table_key(vpc_id, name);
+        if self.db.exists(ROUTE_TABLES_TABLE, &key)? {
+            return Err(OrgError::RouteTableAlreadyExists(name.to_string()));
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let table = RouteTable {
+            id: RouteTableId(format!("rtb-{name}")),
+            name: name.to_string(),
+            vpc_id: vpc_id.clone(),
+            is_default: false,
+            state: ResourceState::Active,
+            created_at: now,
+        };
+
+        self.db.set(ROUTE_TABLES_TABLE, &key, &table)?;
+        Ok(table)
+    }
+
+    /// Get a route table by VPC ID and name.
+    pub fn get_route_table(&self, vpc_id: &VpcId, name: &str) -> Result<Option<RouteTable>> {
+        let key = Self::route_table_key(vpc_id, name);
+        Ok(self.db.get(ROUTE_TABLES_TABLE, &key)?)
+    }
+
+    /// Get the default route table for a VPC.
+    pub fn get_default_route_table(&self, vpc_id: &VpcId) -> Result<Option<RouteTable>> {
+        self.get_route_table(vpc_id, "default")
+    }
+
+    /// List all route tables.
+    pub fn list_route_tables(&self) -> Result<Vec<RouteTable>> {
+        let entries: Vec<(String, RouteTable)> = self.db.list(ROUTE_TABLES_TABLE)?;
+        Ok(entries.into_iter().map(|(_, t)| t).collect())
+    }
+
+    /// List route tables belonging to a specific VPC.
+    pub fn list_route_tables_by_vpc(&self, vpc_id: &VpcId) -> Result<Vec<RouteTable>> {
+        let prefix = format!("{}/", vpc_id.0);
+        let all: Vec<(String, RouteTable)> = self.db.list(ROUTE_TABLES_TABLE)?;
+        Ok(all
+            .into_iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, t)| t)
+            .collect())
+    }
+
+    /// Delete a route table. Fails if it is the default table or has associated subnets.
+    pub fn delete_route_table(&self, vpc_id: &VpcId, name: &str) -> Result<()> {
+        let key = Self::route_table_key(vpc_id, name);
+
+        let table: RouteTable = self
+            .db
+            .get(ROUTE_TABLES_TABLE, &key)?
+            .ok_or_else(|| OrgError::RouteTableNotFound(name.to_string()))?;
+
+        if table.is_default {
+            return Err(OrgError::CannotDeleteDefaultRouteTable);
+        }
+
+        // Check if any subnets are associated with this table.
+        let assoc_count = self.count_subnets_for_route_table(&table.id)?;
+        if assoc_count > 0 {
+            return Err(OrgError::RouteTableHasSubnets {
+                name: name.to_string(),
+                count: assoc_count,
+            });
+        }
+
+        // Delete all routes in this table.
+        let routes = self.list_routes_by_table(&table.id)?;
+        for route in &routes {
+            let rkey = Self::route_key(&table.id, &route.destination);
+            self.db.delete(ROUTES_TABLE, &rkey)?;
+        }
+
+        self.db.delete(ROUTE_TABLES_TABLE, &key)?;
+        Ok(())
+    }
+
+    /// Delete a route table by VPC name (CLI convenience wrapper).
+    pub fn delete_route_table_by_vpc_name(&self, vpc_name: &str, table_name: &str) -> Result<()> {
+        let vpc = self
+            .get_vpc(vpc_name)?
+            .ok_or_else(|| OrgError::VpcNotFound(vpc_name.to_string()))?;
+        self.delete_route_table(&vpc.id, table_name)
+    }
+
+    /// Create a route table by VPC name (CLI convenience wrapper).
+    pub fn create_route_table_by_vpc_name(&self, name: &str, vpc_name: &str) -> Result<RouteTable> {
+        let vpc = self
+            .get_vpc(vpc_name)?
+            .ok_or_else(|| OrgError::VpcNotFound(vpc_name.to_string()))?;
+        self.create_route_table(name, &vpc.id)
+    }
+
+    /// List route tables by VPC name (CLI convenience wrapper).
+    pub fn list_route_tables_by_vpc_name(&self, vpc_name: Option<&str>) -> Result<Vec<RouteTable>> {
+        match vpc_name {
+            Some(vname) => {
+                let vpc = self
+                    .get_vpc(vname)?
+                    .ok_or_else(|| OrgError::VpcNotFound(vname.to_string()))?;
+                self.list_route_tables_by_vpc(&vpc.id)
+            }
+            None => self.list_route_tables(),
+        }
+    }
+
+    /// Count subnets associated with a specific route table.
+    fn count_subnets_for_route_table(&self, table_id: &RouteTableId) -> Result<usize> {
+        let entries: Vec<(String, String)> = self.db.list(SUBNET_ROUTE_ASSOC_TABLE)?;
+        Ok(entries
+            .into_iter()
+            .filter(|(_, tid)| *tid == table_id.0)
+            .count())
+    }
+
+    // ── Route operations ──────────────────────────────────────────────
+
+    /// Add a system route (auto-created, undeletable).
+    pub fn add_system_route(&self, table: &RouteTable, destination: &str) -> Result<Route> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let route = Route {
+            id: RouteId(format!(
+                "rt-sys-{}-{}",
+                table.name,
+                destination.replace('/', "_")
+            )),
+            route_table_id: table.id.clone(),
+            destination: destination.to_string(),
+            target: RouteTarget::Local,
+            origin: RouteOrigin::System,
+            status: RouteStatus::Active,
+            priority: 0,
+            created_at: now,
+        };
+
+        let key = Self::route_key(&table.id, destination);
+        self.db.set(ROUTES_TABLE, &key, &route)?;
+        Ok(route)
+    }
+
+    /// Add a user-created route.
+    pub fn add_route(
+        &self,
+        table_id: &RouteTableId,
+        destination: &str,
+        target: RouteTarget,
+        priority: Option<u32>,
+    ) -> Result<Route> {
+        let key = Self::route_key(table_id, destination);
+        if self.db.exists(ROUTES_TABLE, &key)? {
+            return Err(OrgError::RouteAlreadyExists(destination.to_string()));
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let status = match &target {
+            RouteTarget::Blackhole => RouteStatus::Active,
+            RouteTarget::Local => RouteStatus::Active,
+            _ => RouteStatus::Active,
+        };
+
+        let route = Route {
+            id: RouteId(format!("rt-{}", destination.replace('/', "_"))),
+            route_table_id: table_id.clone(),
+            destination: destination.to_string(),
+            target,
+            origin: RouteOrigin::User,
+            status,
+            priority: priority.unwrap_or(100),
+            created_at: now,
+        };
+
+        self.db.set(ROUTES_TABLE, &key, &route)?;
+        Ok(route)
+    }
+
+    /// Add a propagated route (auto-created from peering).
+    pub fn add_propagated_route(
+        &self,
+        table_id: &RouteTableId,
+        destination: &str,
+        target: RouteTarget,
+    ) -> Result<Route> {
+        let key = Self::route_key(table_id, destination);
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let route = Route {
+            id: RouteId(format!("rt-prop-{}", destination.replace('/', "_"))),
+            route_table_id: table_id.clone(),
+            destination: destination.to_string(),
+            target,
+            origin: RouteOrigin::Propagated,
+            status: RouteStatus::Active,
+            priority: 50,
+            created_at: now,
+        };
+
+        self.db.set(ROUTES_TABLE, &key, &route)?;
+        Ok(route)
+    }
+
+    /// Remove a route. Fails if the route is system or propagated origin.
+    pub fn remove_route(&self, table_id: &RouteTableId, destination: &str) -> Result<()> {
+        let key = Self::route_key(table_id, destination);
+
+        let route: Route = self
+            .db
+            .get(ROUTES_TABLE, &key)?
+            .ok_or_else(|| OrgError::RouteNotFound(destination.to_string()))?;
+
+        match route.origin {
+            RouteOrigin::System => {
+                return Err(OrgError::CannotDeleteSystemRoute);
+            }
+            RouteOrigin::Propagated => {
+                return Err(OrgError::CannotDeletePropagatedRoute);
+            }
+            RouteOrigin::User => {}
+        }
+
+        self.db.delete(ROUTES_TABLE, &key)?;
+        Ok(())
+    }
+
+    /// Force-remove a route regardless of origin (used internally for cleanup).
+    pub fn remove_route_force(&self, table_id: &RouteTableId, destination: &str) -> Result<()> {
+        let key = Self::route_key(table_id, destination);
+        self.db.delete(ROUTES_TABLE, &key)?;
+        Ok(())
+    }
+
+    /// List all routes in a specific route table.
+    pub fn list_routes_by_table(&self, table_id: &RouteTableId) -> Result<Vec<Route>> {
+        let prefix = format!("{}/", table_id.0);
+        let all: Vec<(String, Route)> = self.db.list(ROUTES_TABLE)?;
+        Ok(all
+            .into_iter()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(_, r)| r)
+            .collect())
+    }
+
+    /// List all routes across all tables in a VPC.
+    pub fn list_routes_by_vpc(&self, vpc_id: &VpcId) -> Result<Vec<Route>> {
+        let tables = self.list_route_tables_by_vpc(vpc_id)?;
+        let mut routes = Vec::new();
+        for table in &tables {
+            routes.extend(self.list_routes_by_table(&table.id)?);
+        }
+        Ok(routes)
+    }
+
+    /// Get a specific route by table ID and destination.
+    pub fn get_route(&self, table_id: &RouteTableId, destination: &str) -> Result<Option<Route>> {
+        let key = Self::route_key(table_id, destination);
+        Ok(self.db.get(ROUTES_TABLE, &key)?)
+    }
+
+    /// Update a route's status field.
+    pub fn update_route_status(
+        &self,
+        table_id: &RouteTableId,
+        destination: &str,
+        status: RouteStatus,
+    ) -> Result<()> {
+        let key = Self::route_key(table_id, destination);
+        let mut route: Route = self
+            .db
+            .get(ROUTES_TABLE, &key)?
+            .ok_or_else(|| OrgError::RouteNotFound(destination.to_string()))?;
+        route.status = status;
+        self.db.set(ROUTES_TABLE, &key, &route)?;
+        Ok(())
+    }
+
+    // ── Subnet-RouteTable association ──────────────────────────────────
+
+    /// Associate a subnet with a route table.
+    pub fn associate_subnet_route_table(
+        &self,
+        subnet_id: &SubnetId,
+        table_id: &RouteTableId,
+    ) -> Result<()> {
+        self.db
+            .set(SUBNET_ROUTE_ASSOC_TABLE, &subnet_id.0, &table_id.0)?;
+        Ok(())
+    }
+
+    /// Disassociate a subnet from its custom route table (reverts to default).
+    pub fn disassociate_subnet_route_table(&self, subnet_id: &SubnetId) -> Result<()> {
+        self.db.delete(SUBNET_ROUTE_ASSOC_TABLE, &subnet_id.0)?;
+        Ok(())
+    }
+
+    /// Get the route table ID for a subnet (None means use default).
+    pub fn get_subnet_route_table_id(&self, subnet_id: &SubnetId) -> Result<Option<RouteTableId>> {
+        let val: Option<String> = self.db.get(SUBNET_ROUTE_ASSOC_TABLE, &subnet_id.0)?;
+        Ok(val.map(RouteTableId))
+    }
+
+    /// Resolve the effective route table for a subnet — explicit association or VPC default.
+    pub fn resolve_subnet_route_table(&self, subnet: &Subnet) -> Result<RouteTable> {
+        if let Some(table_id) = self.get_subnet_route_table_id(&subnet.id)? {
+            // Find the table by scanning (table_id is the value, not key).
+            let tables = self.list_route_tables_by_vpc(&subnet.vpc_id)?;
+            for t in tables {
+                if t.id == table_id {
+                    return Ok(t);
+                }
+            }
+        }
+        // Fall back to default.
+        self.get_default_route_table(&subnet.vpc_id)?
+            .ok_or_else(|| OrgError::RouteTableNotFound("default".to_string()))
     }
 
     // ── NIC operations (convenience wrappers for attach/detach) ────
@@ -2744,5 +3144,353 @@ mod tests {
 
         let err = store.delete_sg(&vpc_id, "default").unwrap_err();
         assert!(matches!(err, OrgError::SgIsDefault(_)));
+    }
+
+    // ── Route Table tests ─────────────────────────────────────────
+
+    #[test]
+    fn default_route_table_auto_created() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let default_rt = store.get_default_route_table(&vpc.id).unwrap();
+        assert!(default_rt.is_some());
+        let rt = default_rt.unwrap();
+        assert!(rt.is_default);
+        assert_eq!(rt.name, "default");
+        assert_eq!(rt.vpc_id, vpc.id);
+    }
+
+    #[test]
+    fn default_route_table_has_vpc_cidr_route() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        let routes = store.list_routes_by_table(&rt.id).unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].destination, "10.1.0.0/16");
+        assert_eq!(routes[0].target, RouteTarget::Local);
+        assert_eq!(routes[0].origin, RouteOrigin::System);
+        assert_eq!(routes[0].priority, 0);
+    }
+
+    #[test]
+    fn create_route_table() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.create_route_table("custom", &vpc.id).unwrap();
+        assert_eq!(rt.name, "custom");
+        assert!(!rt.is_default);
+        assert_eq!(rt.vpc_id, vpc.id);
+    }
+
+    #[test]
+    fn list_route_tables_by_vpc() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        store.create_route_table("custom-a", &vpc.id).unwrap();
+        store.create_route_table("custom-b", &vpc.id).unwrap();
+
+        let tables = store.list_route_tables_by_vpc(&vpc.id).unwrap();
+        assert_eq!(tables.len(), 3); // default + 2 custom
+    }
+
+    #[test]
+    fn cannot_delete_default_route_table() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let err = store.delete_route_table(&vpc.id, "default").unwrap_err();
+        assert!(matches!(err, OrgError::CannotDeleteDefaultRouteTable));
+    }
+
+    #[test]
+    fn delete_route_table_succeeds() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        store.create_route_table("ephemeral", &vpc.id).unwrap();
+        store.delete_route_table(&vpc.id, "ephemeral").unwrap();
+
+        let tables = store.list_route_tables_by_vpc(&vpc.id).unwrap();
+        assert_eq!(tables.len(), 1); // only default remains
+    }
+
+    #[test]
+    fn add_user_route_and_list() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+
+        let route = store
+            .add_route(&rt.id, "10.99.0.0/24", RouteTarget::Blackhole, None)
+            .unwrap();
+        assert_eq!(route.origin, RouteOrigin::User);
+        assert_eq!(route.priority, 100);
+
+        let routes = store.list_routes_by_table(&rt.id).unwrap();
+        assert_eq!(routes.len(), 2); // VPC CIDR system route + user route
+    }
+
+    #[test]
+    fn cannot_delete_system_route() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        let err = store.remove_route(&rt.id, "10.1.0.0/16").unwrap_err();
+        assert!(matches!(err, OrgError::CannotDeleteSystemRoute));
+    }
+
+    #[test]
+    fn delete_user_route_succeeds() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        store
+            .add_route(&rt.id, "10.99.0.0/24", RouteTarget::Blackhole, None)
+            .unwrap();
+        store.remove_route(&rt.id, "10.99.0.0/24").unwrap();
+
+        let routes = store.list_routes_by_table(&rt.id).unwrap();
+        assert_eq!(routes.len(), 1); // only system route remains
+    }
+
+    #[test]
+    fn subnet_creation_adds_local_route() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        // Create an environment for the subnet.
+        store
+            .create_env("acme", "backend", "production", None, false, HashMap::new())
+            .unwrap();
+
+        let env_id = EnvironmentId("acme/backend/production".to_string());
+        store
+            .create_subnet("myvpc", &env_id, "web", Some("10.1.1.0/24"))
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        let routes = store.list_routes_by_table(&rt.id).unwrap();
+        // Should have: VPC CIDR route + subnet CIDR route
+        assert_eq!(routes.len(), 2);
+        let subnet_route = routes.iter().find(|r| r.destination == "10.1.1.0/24");
+        assert!(subnet_route.is_some());
+        assert_eq!(subnet_route.unwrap().origin, RouteOrigin::System);
+    }
+
+    #[test]
+    fn subnet_deletion_removes_local_route() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        store
+            .create_env("acme", "backend", "production", None, false, HashMap::new())
+            .unwrap();
+
+        let env_id = EnvironmentId("acme/backend/production".to_string());
+        store
+            .create_subnet("myvpc", &env_id, "web", Some("10.1.1.0/24"))
+            .unwrap();
+
+        store.delete_subnet("myvpc", "web").unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        let routes = store.list_routes_by_table(&rt.id).unwrap();
+        // Only VPC CIDR route should remain.
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].destination, "10.1.0.0/16");
+    }
+
+    #[test]
+    fn subnet_route_table_association() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        store
+            .create_env("acme", "backend", "production", None, false, HashMap::new())
+            .unwrap();
+
+        let env_id = EnvironmentId("acme/backend/production".to_string());
+        let subnet = store
+            .create_subnet("myvpc", &env_id, "web", Some("10.1.1.0/24"))
+            .unwrap();
+
+        // Default: resolves to default route table.
+        let resolved = store.resolve_subnet_route_table(&subnet).unwrap();
+        assert!(resolved.is_default);
+
+        // Create custom table and associate.
+        let custom = store.create_route_table("custom", &vpc.id).unwrap();
+        store
+            .associate_subnet_route_table(&subnet.id, &custom.id)
+            .unwrap();
+
+        let resolved = store.resolve_subnet_route_table(&subnet).unwrap();
+        assert_eq!(resolved.name, "custom");
+
+        // Disassociate: back to default.
+        store.disassociate_subnet_route_table(&subnet.id).unwrap();
+        let resolved = store.resolve_subnet_route_table(&subnet).unwrap();
+        assert!(resolved.is_default);
+    }
+
+    #[test]
+    fn cannot_delete_route_table_with_subnets() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        store
+            .create_env("acme", "backend", "production", None, false, HashMap::new())
+            .unwrap();
+
+        let env_id = EnvironmentId("acme/backend/production".to_string());
+        let subnet = store
+            .create_subnet("myvpc", &env_id, "web", Some("10.1.1.0/24"))
+            .unwrap();
+
+        let custom = store.create_route_table("custom", &vpc.id).unwrap();
+        store
+            .associate_subnet_route_table(&subnet.id, &custom.id)
+            .unwrap();
+
+        let err = store.delete_route_table(&vpc.id, "custom").unwrap_err();
+        assert!(matches!(err, OrgError::RouteTableHasSubnets { .. }));
+    }
+
+    #[test]
+    fn cannot_delete_propagated_route() {
+        let (_dir, store) = temp_store();
+        setup_org_and_project(&store);
+        let vpc = store
+            .create_vpc(
+                "myvpc",
+                "10.1.0.0/16",
+                VpcOwner::Project(ProjectId("acme/backend".to_string())),
+                false,
+            )
+            .unwrap();
+
+        let rt = store.get_default_route_table(&vpc.id).unwrap().unwrap();
+        store
+            .add_propagated_route(
+                &rt.id,
+                "10.2.0.0/16",
+                RouteTarget::VpcPeering("peering-123".to_string()),
+            )
+            .unwrap();
+
+        let err = store.remove_route(&rt.id, "10.2.0.0/16").unwrap_err();
+        assert!(matches!(err, OrgError::CannotDeletePropagatedRoute));
     }
 }

--- a/layers/org/src/types.rs
+++ b/layers/org/src/types.rs
@@ -321,6 +321,104 @@ pub struct SecurityGroupRule {
     pub description: Option<String>,
 }
 
+/// Unique identifier for a route table.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RouteTableId(pub String);
+
+impl fmt::Display for RouteTableId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A route table — a collection of routes scoped to a VPC.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteTable {
+    pub id: RouteTableId,
+    pub name: String,
+    pub vpc_id: VpcId,
+    pub is_default: bool,
+    pub state: ResourceState,
+    pub created_at: u64,
+}
+
+/// Unique identifier for a route.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RouteId(pub String);
+
+impl fmt::Display for RouteId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The target of a route — where matching traffic is sent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RouteTarget {
+    Local,
+    NatGateway(String),
+    VpcPeering(String),
+    Blackhole,
+}
+
+impl fmt::Display for RouteTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteTarget::Local => f.write_str("local"),
+            RouteTarget::NatGateway(id) => write!(f, "nat-gw:{id}"),
+            RouteTarget::VpcPeering(id) => write!(f, "peering:{id}"),
+            RouteTarget::Blackhole => f.write_str("blackhole"),
+        }
+    }
+}
+
+/// How a route was created — determines deletion rules.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RouteOrigin {
+    System,
+    User,
+    Propagated,
+}
+
+impl fmt::Display for RouteOrigin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteOrigin::System => f.write_str("system"),
+            RouteOrigin::User => f.write_str("user"),
+            RouteOrigin::Propagated => f.write_str("propagated"),
+        }
+    }
+}
+
+/// Status of a route — whether it is actively forwarding traffic.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RouteStatus {
+    Active,
+    Blackhole,
+}
+
+impl fmt::Display for RouteStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RouteStatus::Active => f.write_str("active"),
+            RouteStatus::Blackhole => f.write_str("blackhole"),
+        }
+    }
+}
+
+/// A route within a route table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Route {
+    pub id: RouteId,
+    pub route_table_id: RouteTableId,
+    pub destination: String,
+    pub target: RouteTarget,
+    pub origin: RouteOrigin,
+    pub status: RouteStatus,
+    pub priority: u32,
+    pub created_at: u64,
+}
+
 /// Whether a VM placement is being added or removed.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PlacementAction {

--- a/tests/e2e/scenarios/330_route_table_crud.md
+++ b/tests/e2e/scenarios/330_route_table_crud.md
@@ -1,0 +1,42 @@
+# E2E: Route Table CRUD
+
+## Prerequisites
+- Daemon running, org/project/env/VPC exist
+
+## Test
+
+1. **List route tables in VPC (default exists)**
+   ```
+   syfrah route table list --vpc <vpc>
+   ```
+   Expect: at least "default" table listed.
+
+2. **Create a custom route table**
+   ```
+   syfrah route table create custom --vpc <vpc>
+   ```
+   Expect: success, table name "custom" shown.
+
+3. **List again — 2 tables**
+   ```
+   syfrah route table list --vpc <vpc>
+   ```
+   Expect: "default" + "custom".
+
+4. **Delete the custom table**
+   ```
+   syfrah route table delete custom --yes
+   ```
+   Expect: success.
+
+5. **Cannot delete the default table**
+   ```
+   syfrah route table delete default --yes
+   ```
+   Expect: error "cannot delete the default route table".
+
+6. **Default route table has VPC CIDR route**
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: system local route for VPC CIDR.

--- a/tests/e2e/scenarios/331_route_types.md
+++ b/tests/e2e/scenarios/331_route_types.md
@@ -1,0 +1,33 @@
+# E2E: Route Types (System/User/Propagated)
+
+## Prerequisites
+- Daemon running, org/project/env/VPC/subnet exist
+
+## Test
+
+1. **System routes auto-created**
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: system local routes for VPC CIDR and subnet CIDRs.
+
+2. **Add a user route (blackhole)**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target blackhole
+   ```
+   Expect: success, origin=user, priority=100.
+
+3. **Cannot delete system routes**
+   ```
+   syfrah route delete --vpc <vpc> --destination <vpc-cidr>
+   ```
+   Expect: error "cannot delete system-managed route".
+
+4. **Can delete user routes**
+   ```
+   syfrah route delete --vpc <vpc> --destination 10.99.0.0/24
+   ```
+   Expect: success.
+
+5. **Propagated routes are undeletable**
+   (Requires peering to generate propagated routes — tested in 337)

--- a/tests/e2e/scenarios/332_route_cli.md
+++ b/tests/e2e/scenarios/332_route_cli.md
@@ -1,0 +1,61 @@
+# E2E: Route CLI
+
+## Prerequisites
+- Daemon running, org/project/env/VPC/subnet exist
+
+## Test
+
+1. **route list --vpc**
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: table with DESTINATION, TARGET, ORIGIN, STATUS, PRIORITY columns.
+
+2. **route add --vpc --destination --target**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target blackhole
+   ```
+   Expect: success, route displayed.
+
+3. **route delete --vpc --destination**
+   ```
+   syfrah route delete --vpc <vpc> --destination 10.99.0.0/24
+   ```
+   Expect: success.
+
+4. **route table create**
+   ```
+   syfrah route table create isolated --vpc <vpc>
+   ```
+   Expect: success.
+
+5. **route table list --vpc**
+   ```
+   syfrah route table list --vpc <vpc>
+   ```
+   Expect: default + isolated.
+
+6. **route table delete**
+   ```
+   syfrah route table delete isolated --yes
+   ```
+   Expect: success.
+
+7. **Error: route delete on system route**
+   ```
+   syfrah route delete --vpc <vpc> --destination <vpc-cidr>
+   ```
+   Expect: error.
+
+8. **Error: route table delete on default**
+   ```
+   syfrah route table delete default --yes
+   ```
+   Expect: error.
+
+9. **JSON output**
+   ```
+   syfrah route list --vpc <vpc> --json
+   syfrah route table list --vpc <vpc> --json
+   ```
+   Expect: valid JSON.

--- a/tests/e2e/scenarios/333_route_association.md
+++ b/tests/e2e/scenarios/333_route_association.md
@@ -1,0 +1,36 @@
+# E2E: Subnet Route Table Association
+
+## Prerequisites
+- Daemon running, org/project/env/VPC/subnet exist
+
+## Test
+
+1. **Default association**
+   Subnet uses default route table when no explicit association exists.
+
+2. **Associate subnet with custom table**
+   ```
+   syfrah route table create custom --vpc <vpc>
+   syfrah route table associate custom --subnet <subnet>
+   ```
+   Expect: success message.
+
+3. **Disassociate subnet**
+   ```
+   syfrah route table disassociate --subnet <subnet>
+   ```
+   Expect: success, subnet reverts to default table.
+
+4. **Cannot delete table with associated subnets**
+   ```
+   syfrah route table associate custom --subnet <subnet>
+   syfrah route table delete custom --yes
+   ```
+   Expect: error about associated subnets.
+
+5. **Cleanup**
+   ```
+   syfrah route table disassociate --subnet <subnet>
+   syfrah route table delete custom --yes
+   ```
+   Expect: success.

--- a/tests/e2e/scenarios/334_route_blackhole.md
+++ b/tests/e2e/scenarios/334_route_blackhole.md
@@ -1,0 +1,34 @@
+# E2E: Blackhole Routes
+
+## Prerequisites
+- Daemon running, org/project/env/VPC/subnet exist
+
+## Test
+
+1. **Add a blackhole route**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target blackhole
+   ```
+   Expect: success, status=active.
+
+2. **Verify route in list**
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: blackhole route with target "blackhole", status "active".
+
+3. **Delete the blackhole route**
+   ```
+   syfrah route delete --vpc <vpc> --destination 10.99.0.0/24
+   ```
+   Expect: success.
+
+4. **Verify route removed**
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: blackhole route no longer present.
+
+## Note
+nftables DROP rule enforcement is best tested with actual network traffic.
+The data plane (nftables rules) is applied by the daemon reconciliation loop.

--- a/tests/e2e/scenarios/335_route_auto_local.md
+++ b/tests/e2e/scenarios/335_route_auto_local.md
@@ -1,0 +1,23 @@
+# E2E: Auto-Add Local Routes on Subnet Creation
+
+## Prerequisites
+- Daemon running, org/project/env/VPC exist
+
+## Test
+
+1. **Create subnet and verify local route**
+   ```
+   syfrah subnet create test-subnet --env <env> --project <project> --org <org> --vpc <vpc>
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: system local route for the subnet CIDR appears automatically.
+
+2. **Delete subnet and verify route removed**
+   ```
+   syfrah subnet delete test-subnet --yes
+   syfrah route list --vpc <vpc>
+   ```
+   Expect: subnet CIDR route is removed, VPC CIDR route remains.
+
+3. **Multiple subnets = multiple routes**
+   Create 2 subnets, verify 2 local routes (plus VPC CIDR).

--- a/tests/e2e/scenarios/336_route_validation.md
+++ b/tests/e2e/scenarios/336_route_validation.md
@@ -1,0 +1,36 @@
+# E2E: Route Target Validation
+
+## Prerequisites
+- Daemon running, org/project/env/VPC exist
+
+## Test
+
+1. **Invalid target type**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target invalid
+   ```
+   Expect: error about invalid route target.
+
+2. **Peering target that doesn't exist**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target peering:nonexistent
+   ```
+   Expect: error about target resource not found.
+
+3. **Blackhole target is always valid**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target blackhole
+   ```
+   Expect: success.
+
+4. **Local target is always valid**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.88.0.0/24 --target local
+   ```
+   Expect: success.
+
+5. **Cleanup**
+   ```
+   syfrah route delete --vpc <vpc> --destination 10.99.0.0/24
+   syfrah route delete --vpc <vpc> --destination 10.88.0.0/24
+   ```

--- a/tests/e2e/scenarios/337_route_guards.md
+++ b/tests/e2e/scenarios/337_route_guards.md
@@ -1,0 +1,39 @@
+# E2E: Deletion Guards + Reconciliation
+
+## Prerequisites
+- Daemon running, org/project/env/VPC/subnet exist
+
+## Test
+
+1. **Cannot delete default route table**
+   ```
+   syfrah route table delete default --yes
+   ```
+   Expect: error "cannot delete the default route table".
+
+2. **Cannot delete route table with associated subnets**
+   ```
+   syfrah route table create guarded --vpc <vpc>
+   syfrah route table associate guarded --subnet <subnet>
+   syfrah route table delete guarded --yes
+   ```
+   Expect: error about associated subnets.
+
+3. **Cannot delete system routes**
+   ```
+   syfrah route delete --vpc <vpc> --destination <vpc-cidr>
+   ```
+   Expect: error "cannot delete system-managed route".
+
+4. **Can delete user routes**
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/24 --target blackhole
+   syfrah route delete --vpc <vpc> --destination 10.99.0.0/24
+   ```
+   Expect: success.
+
+5. **Cleanup**
+   ```
+   syfrah route table disassociate --subnet <subnet>
+   syfrah route table delete guarded --yes
+   ```


### PR DESCRIPTION
## Summary

Implements the complete route table subsystem for the org layer:

- **Types**: `RouteTable`, `Route`, `RouteTarget` (Local/NatGateway/VpcPeering/Blackhole), `RouteOrigin` (System/User/Propagated), `RouteStatus`
- **Store**: redb tables for route_tables, routes, and subnet_route_associations with full CRUD
- **Auto-creation**: Default route table with VPC CIDR local route on VPC creation; system local routes on subnet creation
- **CLI**: `syfrah route {list,add,delete}` and `syfrah route table {create,list,delete,associate,disassociate}`
- **Guards**: System/propagated routes undeletable, default table undeletable, table-with-subnets undeletable
- **Validation**: Route target resource existence checks (peering, NAT GW placeholder)
- **Tests**: 14 new unit tests, 8 E2E scenario files

Closes #881
Closes #882
Closes #883
Closes #884
Closes #885
Closes #886
Closes #887
Closes #888