### PR TITLE
Add NAT Gateway CLI commands

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -72,6 +72,12 @@ enum Commands {
         #[command(subcommand)]
         command: syfrah_org::SgCommand,
     },
+    /// Manage NAT gateways
+    #[command(name = "nat-gw")]
+    NatGw {
+        #[command(subcommand)]
+        command: syfrah_org::NatGwCommand,
+    },
     /// Manage route tables and routes
     Route {
         #[command(subcommand)]
@@ -955,6 +961,7 @@ async fn run() -> Result<()> {
         Commands::Vpc { command } => syfrah_org::cli::run_vpc(command).await,
         Commands::Subnet { command } => syfrah_org::cli::run_subnet(command).await,
         Commands::Sg { command } => syfrah_org::cli::run_sg(command).await,
+        Commands::NatGw { command } => syfrah_org::cli::run_nat_gw(command).await,
         Commands::Route { command } => syfrah_org::cli::run_route(command).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();

--- a/layers/org/src/api.rs
+++ b/layers/org/src/api.rs
@@ -17,8 +17,8 @@ use tokio::net::UnixStream;
 use crate::sg_rules::SgRuleStore;
 use crate::store::OrgStore;
 use crate::types::{
-    Direction, Environment, EnvironmentId, NetworkInterface, Org, OrgId, PeeringStatus, PortRange,
-    Project, ProjectId, Protocol, Route, RouteTable, RouteTarget, RuleId, RuleSource,
+    Direction, Environment, EnvironmentId, NatGateway, NetworkInterface, Org, OrgId, PeeringStatus,
+    PortRange, Project, ProjectId, Protocol, Route, RouteTable, RouteTarget, RuleId, RuleSource,
     SecurityGroup, SecurityGroupRule, Subnet, Vpc, VpcOwner, VpcPeering,
 };
 
@@ -193,6 +193,22 @@ pub enum OrgRequest {
         source: Option<String>,
     },
 
+    // -- NAT Gateway --
+    NatGwCreate {
+        name: String,
+        vpc: String,
+        subnet: String,
+    },
+    NatGwList {
+        vpc: Option<String>,
+    },
+    NatGwShow {
+        name: String,
+    },
+    NatGwDelete {
+        name: String,
+    },
+
     // -- Route Table --
     RouteTableCreate {
         name: String,
@@ -267,6 +283,8 @@ pub enum OrgResponse {
         verdict: String,
         reason: String,
     },
+    NatGwResp(NatGateway),
+    NatGwList(Vec<NatGateway>),
     RouteTableResp(RouteTable),
     RouteTableList(Vec<RouteTable>),
     RouteResp(Route),
@@ -908,6 +926,82 @@ fn handle_org_request(
             OrgResponse::SgCheckResult { verdict, reason }
         }
 
+        // -- NAT Gateway --
+        OrgRequest::NatGwCreate { name, vpc, subnet } => {
+            // Resolve VPC.
+            let vpc_obj = match store.get_vpc(&vpc) {
+                Ok(Some(v)) => v,
+                Ok(None) => return OrgResponse::Error(format!("VPC not found: {vpc}")),
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            // Resolve subnet.
+            let sub = match store.find_subnets_by_name(&subnet) {
+                Ok(matches) => {
+                    let in_vpc: Vec<_> = matches
+                        .into_iter()
+                        .filter(|(_, s)| s.vpc_id == vpc_obj.id)
+                        .collect();
+                    match in_vpc.len() {
+                        0 => {
+                            return OrgResponse::Error(format!(
+                                "subnet '{subnet}' not found in VPC '{vpc}'"
+                            ))
+                        }
+                        1 => in_vpc.into_iter().next().unwrap().1,
+                        _ => {
+                            return OrgResponse::Error(format!(
+                                "ambiguous subnet '{subnet}' in VPC '{vpc}'"
+                            ))
+                        }
+                    }
+                }
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+            // Auto-detect public IP.
+            let public_ip = detect_public_ip();
+            match store.create_nat_gw(&name, &vpc_obj.id, &sub.id, &public_ip) {
+                Ok(gw) => OrgResponse::NatGwResp(gw),
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+        OrgRequest::NatGwList { vpc } => match store.list_nat_gws_by_vpc_name(vpc.as_deref()) {
+            Ok(gws) => OrgResponse::NatGwList(gws),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::NatGwShow { name } => match store.get_nat_gw_by_name(&name) {
+            Ok(Some(gw)) => OrgResponse::NatGwResp(gw),
+            Ok(None) => OrgResponse::Error(format!("nat-gw not found: {name}")),
+            Err(e) => OrgResponse::Error(e.to_string()),
+        },
+        OrgRequest::NatGwDelete { name } => {
+            let gw = match store.get_nat_gw_by_name(&name) {
+                Ok(Some(g)) => g,
+                Ok(None) => return OrgResponse::Error(format!("nat-gw not found: {name}")),
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            };
+
+            // Check for routes referencing this NAT GW.
+            match store.routes_referencing_nat_gw(&gw.vpc_id, &name) {
+                Ok(refs) => {
+                    if !refs.is_empty() {
+                        let r = &refs[0];
+                        // Find the route table name.
+                        let table_name = r.route_table_id.0.clone();
+                        return OrgResponse::Error(format!(
+                            "cannot delete nat-gw '{}': referenced by route {} in route table '{}'",
+                            name, r.destination, table_name
+                        ));
+                    }
+                }
+                Err(e) => return OrgResponse::Error(e.to_string()),
+            }
+
+            match store.delete_nat_gw(&gw.vpc_id, &name) {
+                Ok(()) => OrgResponse::Ok,
+                Err(e) => OrgResponse::Error(e.to_string()),
+            }
+        }
+
         // -- Route Table --
         OrgRequest::RouteTableCreate { name, vpc } => {
             match store.create_route_table_by_vpc_name(&name, &vpc) {
@@ -1178,6 +1272,25 @@ pub async fn send_org_request(
         LayerResponse::UnknownLayer(name) => Err(format!("unknown layer: {name}").into()),
         other => Err(format!("unexpected response variant: {other:?}").into()),
     }
+}
+
+/// Detect the node's public IP from the default route interface.
+fn detect_public_ip() -> String {
+    // Try to find the IP of the default route interface.
+    if let Ok(output) = std::process::Command::new("ip")
+        .args(["route", "get", "8.8.8.8"])
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Output format: "8.8.8.8 via ... dev ... src <IP> ..."
+        if let Some(src_idx) = stdout.find(" src ") {
+            let after_src = &stdout[src_idx + 5..];
+            if let Some(ip) = after_src.split_whitespace().next() {
+                return ip.to_string();
+            }
+        }
+    }
+    "0.0.0.0".to_string()
 }
 
 /// Parse a port range string like "443" or "8000-9000".

--- a/layers/org/src/cli/mod.rs
+++ b/layers/org/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI commands for `syfrah org ...`, `syfrah project ...`, `syfrah env ...`, `syfrah vpc ...`, `syfrah subnet ...`, and `syfrah route ...`.
 
 pub mod env;
+pub mod nat_gw;
 pub mod org;
 pub mod project;
 pub mod route;
@@ -430,6 +431,53 @@ pub enum RouteTableAction {
     },
 }
 
+/// Top-level NAT Gateway CLI command.
+#[derive(Debug, Subcommand)]
+pub enum NatGwCommand {
+    /// Create a new NAT gateway
+    #[command(
+        after_help = "Examples:\n  syfrah nat-gw create main-gw --vpc acme-backend-default --subnet frontend"
+    )]
+    Create {
+        /// NAT gateway name (lowercase alphanumeric and hyphens, 3-63 chars)
+        #[arg(allow_hyphen_values = true)]
+        name: String,
+        /// VPC the NAT gateway belongs to
+        #[arg(long)]
+        vpc: String,
+        /// Subnet to place the NAT gateway in
+        #[arg(long)]
+        subnet: String,
+    },
+    /// List NAT gateways
+    #[command(
+        after_help = "Examples:\n  syfrah nat-gw list --vpc acme-backend-default\n  syfrah nat-gw list --json"
+    )]
+    List {
+        /// Filter by VPC name
+        #[arg(long)]
+        vpc: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show NAT gateway details
+    #[command(after_help = "Examples:\n  syfrah nat-gw show main-gw")]
+    Show {
+        /// NAT gateway name
+        name: String,
+    },
+    /// Delete a NAT gateway
+    #[command(after_help = "Examples:\n  syfrah nat-gw delete main-gw --yes")]
+    Delete {
+        /// NAT gateway name
+        name: String,
+        /// Skip confirmation prompt
+        #[arg(long, short)]
+        yes: bool,
+    },
+}
+
 /// Top-level SG CLI command.
 #[derive(Debug, Subcommand)]
 pub enum SgCommand {
@@ -787,6 +835,18 @@ pub async fn run_sg(cmd: SgCommand) -> anyhow::Result<()> {
             protocol,
             source,
         } => sg::run_check(&vm, port, &protocol, source.as_deref()).await,
+    }
+}
+
+/// Execute a NAT gateway CLI command.
+pub async fn run_nat_gw(cmd: NatGwCommand) -> anyhow::Result<()> {
+    match cmd {
+        NatGwCommand::Create { name, vpc, subnet } => {
+            nat_gw::run_create(&name, &vpc, &subnet).await
+        }
+        NatGwCommand::List { vpc, json } => nat_gw::run_list(vpc.as_deref(), json).await,
+        NatGwCommand::Show { name } => nat_gw::run_show(&name).await,
+        NatGwCommand::Delete { name, yes } => nat_gw::run_delete(&name, yes).await,
     }
 }
 

--- a/layers/org/src/cli/nat_gw.rs
+++ b/layers/org/src/cli/nat_gw.rs
@@ -1,0 +1,163 @@
+//! `syfrah nat-gw` handlers.
+//!
+//! All operations go through the daemon's control socket.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::api::{send_org_request, OrgRequest, OrgResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
+}
+
+fn daemon_err(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
+
+pub async fn run_create(name: &str, vpc: &str, subnet: &str) -> Result<()> {
+    let req = OrgRequest::NatGwCreate {
+        name: name.to_string(),
+        vpc: vpc.to_string(),
+        subnet: subnet.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::NatGwResp(gw) => {
+            println!("NAT Gateway created: {}", gw.name);
+            println!("  VPC:       {}", gw.vpc_id);
+            println!("  Subnet:    {}", gw.subnet_id);
+            println!("  Public IP: {}", gw.public_ip);
+            println!("  State:     {}", gw.state);
+            println!("  Created:   {}", format_timestamp(gw.created_at));
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_list(vpc: Option<&str>, json: bool) -> Result<()> {
+    let req = OrgRequest::NatGwList {
+        vpc: vpc.map(String::from),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::NatGwList(gws) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&gws)?);
+                return Ok(());
+            }
+
+            if gws.is_empty() {
+                println!("No NAT gateways found.");
+                return Ok(());
+            }
+
+            println!(
+                "{:<20} {:<25} {:<18} {:<10} CREATED",
+                "NAME", "VPC", "PUBLIC IP", "STATE"
+            );
+            println!("{}", "-".repeat(83));
+            for gw in &gws {
+                println!(
+                    "{:<20} {:<25} {:<18} {:<10} {}",
+                    gw.name,
+                    gw.vpc_id,
+                    gw.public_ip,
+                    gw.state,
+                    format_timestamp(gw.created_at),
+                );
+            }
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_show(name: &str) -> Result<()> {
+    let req = OrgRequest::NatGwShow {
+        name: name.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::NatGwResp(gw) => {
+            println!("Name:       {}", gw.name);
+            println!("ID:         {}", gw.id);
+            println!("VPC:        {}", gw.vpc_id);
+            println!("Subnet:     {}", gw.subnet_id);
+            println!("Public IP:  {}", gw.public_ip);
+            println!("State:      {}", gw.state);
+            println!("Created:    {}", format_timestamp(gw.created_at));
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_delete(name: &str, yes: bool) -> Result<()> {
+    if !yes {
+        eprint!("Delete NAT gateway '{name}'? [y/N] ");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    let req = OrgRequest::NatGwDelete {
+        name: name.to_string(),
+    };
+    let resp = send_org_request(&control_socket_path(), &req)
+        .await
+        .map_err(daemon_err)?;
+
+    match resp {
+        OrgResponse::Ok => {
+            println!("NAT gateway '{name}' deleted.");
+            Ok(())
+        }
+        OrgResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+fn format_timestamp(ts: u64) -> String {
+    if ts == 0 {
+        return "-".to_string();
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let age = now.saturating_sub(ts);
+    if age < 60 {
+        format!("{age}s ago")
+    } else if age < 3600 {
+        format!("{}m ago", age / 60)
+    } else if age < 86400 {
+        format!("{}h ago", age / 3600)
+    } else {
+        format!("{}d ago", age / 86400)
+    }
+}

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -14,8 +14,8 @@ pub mod vpc;
 
 pub use api::{send_org_request, OrgLayerHandler, OrgRequest, OrgResponse, ResolvedSubnet};
 pub use cli::{
-    EnvCommand, OrgCommand, ProjectCommand, RouteCommand, RouteTableAction, SgCommand,
-    SubnetCommand, VpcCommand,
+    EnvCommand, NatGwCommand, OrgCommand, ProjectCommand, RouteCommand, RouteTableAction,
+    SgCommand, SubnetCommand, VpcCommand,
 };
 pub use error::OrgError;
 pub use ipam::{AllocationState, IpAllocation, IpamStore, SubnetBitmap};

--- a/tests/e2e/scenarios/341_nat_gw_cli.md
+++ b/tests/e2e/scenarios/341_nat_gw_cli.md
@@ -1,0 +1,43 @@
+# 341 — NAT Gateway CLI
+
+## Preconditions
+- Fabric initialized, daemon running
+- Org, project, environment, subnet exist
+
+## Steps
+
+1. Create NAT GW:
+   ```
+   syfrah nat-gw create main-gw --vpc acme-backend-default --subnet frontend
+   ```
+   Verify: shows name, VPC, subnet, public IP, state.
+
+2. List NAT GWs:
+   ```
+   syfrah nat-gw list --vpc acme-backend-default
+   syfrah nat-gw list --json
+   ```
+   Verify: table and JSON output.
+
+3. Show NAT GW:
+   ```
+   syfrah nat-gw show main-gw
+   ```
+   Verify: all fields displayed.
+
+4. Delete NAT GW:
+   ```
+   syfrah nat-gw delete main-gw --yes
+   ```
+   Verify: deleted, no longer in list.
+
+5. Error paths:
+   - Create with non-existent VPC → error
+   - Create with non-existent subnet → error
+   - Show non-existent → error
+   - Delete non-existent → error
+
+## Pass criteria
+- All CLI commands work as documented in --help
+- Error messages are clear and actionable
+- JSON output is valid


### PR DESCRIPTION
## Summary
- Add `syfrah nat-gw create/list/show/delete` CLI commands
- Wire through daemon control socket with VPC/subnet validation
- Auto-detect public IP from node's default route interface
- Deletion guard refuses delete if routes reference the NAT GW

Closes #890