### PR TITLE
Route table integration — routes point to NAT GW

### DIFF
--- a/layers/org/src/api.rs
+++ b/layers/org/src/api.rs
@@ -978,10 +978,33 @@ fn handle_org_request(
             match apply_nat_gw_nftables(&vpc, &subnet_cidrs) {
                 Ok(()) => {
                     // Transition to Active.
-                    match store.update_nat_gw_state(&vpc_obj.id, &name, ResourceState::Active) {
-                        Ok(active_gw) => OrgResponse::NatGwResp(active_gw),
-                        Err(e) => OrgResponse::Error(e.to_string()),
+                    let active_gw = match store.update_nat_gw_state(
+                        &vpc_obj.id,
+                        &name,
+                        ResourceState::Active,
+                    ) {
+                        Ok(g) => g,
+                        Err(e) => return OrgResponse::Error(e.to_string()),
+                    };
+
+                    // Auto-add default route 0.0.0.0/0 -> NatGateway if none exists.
+                    if let Ok(Some(default_rt)) = store.get_default_route_table(&vpc_obj.id) {
+                        let has_default = store
+                            .get_route(&default_rt.id, "0.0.0.0/0")
+                            .ok()
+                            .flatten()
+                            .is_some();
+                        if !has_default {
+                            let _ = store.add_route(
+                                &default_rt.id,
+                                "0.0.0.0/0",
+                                RouteTarget::NatGateway(name.clone()),
+                                Some(100),
+                            );
+                        }
                     }
+
+                    OrgResponse::NatGwResp(active_gw)
                 }
                 Err(nft_err) => {
                     // Transition to Failed.
@@ -1508,10 +1531,22 @@ fn validate_route_target(
                 Err(e) => Err(e.to_string()),
             }
         }
-        RouteTarget::NatGateway(_name) => {
-            // NAT Gateway is not yet implemented (Phase 3 placeholder).
-            // For now, accept the target — it will be validated when NAT GW is implemented.
-            Ok(())
+        RouteTarget::NatGateway(name) => {
+            // Check if NAT GW exists and is Active.
+            match store.get_nat_gw_by_name(name) {
+                Ok(Some(gw)) => {
+                    if gw.state == ResourceState::Active {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "nat-gw '{}' is not active (current state: {})",
+                            name, gw.state
+                        ))
+                    }
+                }
+                Ok(None) => Err(format!("nat-gw '{name}' not found")),
+                Err(e) => Err(e.to_string()),
+            }
         }
     }
 }

--- a/tests/e2e/scenarios/343_nat_gw_route.md
+++ b/tests/e2e/scenarios/343_nat_gw_route.md
@@ -1,0 +1,38 @@
+# 343 — NAT Gateway route table integration
+
+## Preconditions
+- Fabric initialized, daemon running
+- Org, project, environment, subnet exist
+
+## Steps
+
+1. Create NAT GW:
+   ```
+   syfrah nat-gw create main-gw --vpc <vpc> --subnet frontend
+   ```
+
+2. Verify auto-created default route:
+   ```
+   syfrah route list --vpc <vpc>
+   ```
+   Expected: `0.0.0.0/0 -> nat-gw:main-gw` route exists in default table.
+
+3. Manually add route pointing to NAT GW:
+   ```
+   syfrah route add --vpc <vpc> --destination 10.99.0.0/16 --target nat-gw:main-gw
+   ```
+   Verify: route added successfully.
+
+4. Error: route to non-existent NAT GW:
+   ```
+   syfrah route add --vpc <vpc> --destination 10.98.0.0/16 --target nat-gw:nonexistent
+   ```
+   Expected: error "nat-gw 'nonexistent' not found".
+
+5. No duplicate default route:
+   Create a second NAT GW → should NOT add another 0.0.0.0/0 route.
+
+## Pass criteria
+- Auto-created default route on NAT GW creation
+- Route validation checks NAT GW exists and is Active
+- No duplicate default routes


### PR DESCRIPTION
## Summary
- Validate NAT GW exists and is Active when creating routes with nat-gw target
- Auto-add default route `0.0.0.0/0 -> NatGateway(name)` on NAT GW activation
- Skip auto-route if default route already exists

Closes #892