### PR TITLE
Remove implicit NAT — require explicit NAT Gateway

### DIFF
--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -349,11 +349,21 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
                 .map_err(|e| ComputeError::NetworkSetup(format!("nftables rules failed: {e}")))?;
         }
 
-        // -- 7. Apply NAT -----------------------------------------------------
-        self.backend
-            .apply_nat(&bridge_name, subnet_cidr)
-            .await
-            .map_err(|e| ComputeError::NetworkSetup(format!("NAT setup failed: {e}")))?;
+        // -- 7. Apply NAT (only if an active NAT Gateway exists) ---------------
+        // Check if the VPC has an active NAT Gateway with a route pointing to it.
+        // If no NAT GW: VMs have private networking only (no internet egress).
+        let has_nat_gw = self.has_active_nat_gw(vpc_id);
+        if has_nat_gw {
+            self.backend
+                .apply_nat(&bridge_name, subnet_cidr)
+                .await
+                .map_err(|e| ComputeError::NetworkSetup(format!("NAT setup failed: {e}")))?;
+        } else {
+            warn!(
+                vm_id,
+                vpc_id, "no NAT gateway — VMs will not have internet egress"
+            );
+        }
 
         // -- 8. Store placement -----------------------------------------------
         let now = std::time::SystemTime::now()
@@ -450,6 +460,20 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
             cloud_init_network,
             placement,
         })
+    }
+
+    /// Check if the VPC has an active NAT Gateway with a route targeting it.
+    fn has_active_nat_gw(&self, vpc_id: &str) -> bool {
+        let vpc_id_typed = syfrah_org::types::VpcId(vpc_id.to_string());
+
+        // Check for any active NAT GWs in this VPC.
+        let gws = match self.org_store.list_nat_gws_by_vpc(&vpc_id_typed) {
+            Ok(g) => g,
+            Err(_) => return false,
+        };
+
+        gws.iter()
+            .any(|gw| gw.state == syfrah_org::types::ResourceState::Active)
     }
 
     /// Resolve a subnet name to its `Subnet` and parent `Vpc`.
@@ -731,7 +755,12 @@ mod tests {
             call_names.contains(&"apply_vm_rules"),
             "nftables must be applied"
         );
-        assert!(call_names.contains(&"apply_nat"), "NAT must be applied");
+        // NAT is only applied when an active NAT Gateway exists in the VPC.
+        // In this test there is no NAT GW, so apply_nat should NOT be called.
+        assert!(
+            !call_names.contains(&"apply_nat"),
+            "NAT must NOT be applied without a NAT Gateway"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/scenarios/344_nat_gw_explicit.md
+++ b/tests/e2e/scenarios/344_nat_gw_explicit.md
@@ -1,0 +1,24 @@
+# 344 — Explicit NAT Gateway required
+
+## Preconditions
+- Fabric initialized, daemon running
+- Org, project, environment, subnet exist
+
+## Steps
+
+1. Create VM without NAT GW:
+   - No NAT GW in VPC
+   - VM should have private networking only
+   - Warning logged: "no NAT gateway — VMs will not have internet egress"
+
+2. Create NAT GW, then create VM:
+   - NAT GW active in VPC
+   - VM should have internet egress via masquerade
+
+3. Delete NAT GW (remove routes first):
+   - Existing VMs lose internet egress
+
+## Pass criteria
+- Without NAT GW: VMs cannot reach the internet
+- With NAT GW: VMs have internet egress
+- Warning is logged when no NAT GW exists


### PR DESCRIPTION
## Summary
- Only apply NAT masquerade during VM network setup if an active NAT Gateway exists in the VPC
- Without NAT GW: VMs have private networking only, warning logged
- Updated test to verify NAT is NOT applied without a NAT Gateway

Closes #893