### PR TITLE
feat(forge): Axum HTTP server on syfrah0:7100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,7 @@ dependencies = [
  "syfrah-api",
  "syfrah-compute",
  "syfrah-core",
+ "syfrah-forge",
  "syfrah-org",
  "syfrah-overlay",
  "syfrah-state",
@@ -2447,11 +2448,24 @@ dependencies = [
 name = "syfrah-forge"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "axum",
+ "http-body-util",
+ "hyper",
  "serde",
  "serde_json",
  "syfrah-api",
+ "syfrah-compute",
+ "syfrah-org",
+ "syfrah-overlay",
+ "syfrah-state",
+ "tempfile",
+ "thiserror 2.0.18",
  "tokio",
+ "tower",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -15,6 +15,7 @@ syfrah-org = { path = "../org" }
 syfrah-overlay = { path = "../overlay" }
 syfrah-state = { path = "../state" }
 syfrah-api = { path = "../api" }
+syfrah-forge = { path = "../forge" }
 wireguard-control = "1.7"
 tokio.workspace = true
 tracing.workspace = true

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1034,6 +1034,7 @@ pub async fn run_daemon(
     //
     // Initialise VmManager, reconnect existing VMs, start the monitor loop,
     // and register the compute handler in the router.
+    let shared_vm_manager: Option<Arc<syfrah_compute::VmManager>>;
     {
         let compute_config = syfrah_compute::ComputeConfig::default();
         match syfrah_compute::VmManager::new(compute_config) {
@@ -1161,12 +1162,14 @@ pub async fn run_daemon(
                 router.register("compute", Arc::new(compute_handler));
 
                 info!("compute layer initialised");
+                shared_vm_manager = Some(vm_manager);
             }
             Err(e) => {
                 // Compute init failure is non-fatal: the daemon still runs for
                 // fabric operations, but compute CLI commands will get
                 // "unknown layer" errors.
                 warn!("compute layer init failed (non-fatal): {e}");
+                shared_vm_manager = None;
             }
         }
     }
@@ -1177,6 +1180,31 @@ pub async fn run_daemon(
     let mut control_task = tokio::spawn(async move {
         control::start_control_listener(&control_path, router).await;
     });
+
+    // -- Forge HTTP API server -----------------------------------------------
+    //
+    // Start the Forge HTTP API on the fabric IPv6 address, port 7100.
+    // This coexists with the control socket — CLI uses the socket, API
+    // consumers use HTTP.
+    let (forge_shutdown_tx, forge_shutdown_rx) = tokio::sync::watch::channel(false);
+    let forge_task = {
+        let forge_state = std::sync::Arc::new(syfrah_forge::api::ForgeState {
+            started_at: std::time::Instant::now(),
+            task_store: None,
+            vm_manager: shared_vm_manager.clone(),
+        });
+
+        let bind_addr: std::net::SocketAddr =
+            std::net::SocketAddr::new(std::net::IpAddr::V6(my_record.mesh_ipv6), 7100);
+
+        tokio::spawn(async move {
+            if let Err(e) =
+                syfrah_forge::ForgeServer::serve(bind_addr, forge_state, forge_shutdown_rx).await
+            {
+                warn!("Forge HTTP API error: {e}");
+            }
+        })
+    };
 
     // Bounded retry queue for announces that cannot be processed immediately.
     let (announce_queue_tx, announce_queue_rx) =
@@ -2088,6 +2116,7 @@ pub async fn run_daemon(
         _ = sighup_reload => {}
         _ = api_task => {}
         _ = grpc_task => {}
+        _ = forge_task => {}
         _ = tokio::signal::ctrl_c() => {
             info!("received SIGINT, shutting down");
         }
@@ -2127,6 +2156,9 @@ pub async fn run_daemon(
 
     // Signal gRPC API server to shut down gracefully.
     let _ = grpc_shutdown_tx.send(true);
+
+    // Signal Forge HTTP API server to shut down gracefully.
+    let _ = forge_shutdown_tx.send(true);
 
     // Tell systemd we are shutting down gracefully.
     sd_watchdog::notify_stopping();

--- a/layers/forge/Cargo.toml
+++ b/layers/forge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syfrah-forge"
-description = "Forge layer — bare-metal provisioning for Syfrah"
+description = "Forge layer — per-node resource orchestrator for Syfrah"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -10,9 +10,23 @@ categories.workspace = true
 
 [dependencies]
 syfrah-api = { path = "../api" }
+syfrah-compute = { path = "../compute" }
+syfrah-org = { path = "../org" }
+syfrah-overlay = { path = "../overlay" }
+syfrah-state = { path = "../state" }
 async-trait = "0.1"
+axum = "0.8"
+hyper = "1"
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+http-body-util = "0.1"
+tower = { version = "0.5", features = ["util"] }
+tempfile = "3"

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -1,6 +1,87 @@
-use syfrah_api::handler::LayerHandler;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Instant;
 
-/// Empty handler — implementation pending.
+use axum::extract::State;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use syfrah_api::handler::LayerHandler;
+use tokio::sync::watch;
+use tracing::info;
+
+use crate::task::TaskStore;
+
+/// Shared application state for all Forge HTTP handlers.
+#[derive(Clone)]
+pub struct ForgeState {
+    /// When the Forge server started (for uptime calculation).
+    pub started_at: Instant,
+    /// Task store for operation tracking.
+    pub task_store: Option<Arc<TaskStore>>,
+    /// VmManager for compute operations.
+    pub vm_manager: Option<Arc<syfrah_compute::VmManager>>,
+}
+
+/// Health check response.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct HealthResponse {
+    pub status: String,
+    pub uptime: u64,
+}
+
+/// GET /v1/node/health
+async fn health_handler(State(state): State<Arc<ForgeState>>) -> Json<HealthResponse> {
+    let uptime = state.started_at.elapsed().as_secs();
+    Json(HealthResponse {
+        status: "healthy".to_string(),
+        uptime,
+    })
+}
+
+/// Build the Forge HTTP router with all routes.
+pub fn forge_router(state: Arc<ForgeState>) -> Router {
+    Router::new()
+        .route("/v1/node/health", get(health_handler))
+        .with_state(state)
+}
+
+/// The Forge HTTP server. Binds to the fabric IPv6 address on port 7100.
+pub struct ForgeServer;
+
+impl ForgeServer {
+    /// Start the Forge HTTP server.
+    ///
+    /// `bind_addr` should be the node's `syfrah0` IPv6 address.
+    /// `shutdown_rx` signals the server to shut down gracefully.
+    pub async fn serve(
+        bind_addr: SocketAddr,
+        state: Arc<ForgeState>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        let app = forge_router(state);
+        let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+        info!("Forge HTTP API listening on {}", bind_addr);
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                loop {
+                    if shutdown_rx.changed().await.is_err() {
+                        break;
+                    }
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+            })
+            .await?;
+
+        info!("Forge HTTP API shut down");
+        Ok(())
+    }
+}
+
+/// Empty handler for the control socket — keeps backward compatibility.
 pub struct ForgeHandler;
 
 #[async_trait::async_trait]
@@ -17,6 +98,9 @@ impl LayerHandler for ForgeHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
 
     #[tokio::test]
     async fn handler_returns_not_implemented() {
@@ -25,5 +109,27 @@ mod tests {
         let body: serde_json::Value = serde_json::from_slice(&resp).unwrap();
         assert_eq!(body["error"], "not implemented");
         assert_eq!(body["layer"], "forge");
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_returns_healthy() {
+        let state = Arc::new(ForgeState {
+            started_at: Instant::now(),
+            task_store: None,
+            vm_manager: None,
+        });
+        let app = forge_router(state);
+
+        let req = axum::http::Request::builder()
+            .uri("/v1/node/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let health: HealthResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(health.status, "healthy");
     }
 }

--- a/layers/forge/src/capacity.rs
+++ b/layers/forge/src/capacity.rs
@@ -1,0 +1,245 @@
+//! Capacity tracking and admission control.
+//!
+//! Tracks total, used, reserved, and available resources on this node.
+//! Answers admission queries ("can this node fit a 4-vCPU VM?") and
+//! manages reservations with expiry.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// Reservation expiry duration (60 seconds).
+const RESERVATION_EXPIRY: Duration = Duration::from_secs(60);
+
+/// Node capacity snapshot.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NodeCapacity {
+    /// Total vCPUs on this node.
+    pub total_vcpus: u32,
+    /// Total memory in MB on this node.
+    pub total_memory_mb: u64,
+    /// vCPUs currently allocated to VMs.
+    pub used_vcpus: u32,
+    /// Memory currently allocated to VMs in MB.
+    pub used_memory_mb: u64,
+}
+
+/// A resource reservation with expiry.
+#[derive(Debug, Clone)]
+pub struct Reservation {
+    pub vcpus: u32,
+    pub memory_mb: u64,
+    pub created_at: Instant,
+}
+
+/// Capacity tracker for admission control.
+pub struct CapacityTracker {
+    total_vcpus: u32,
+    total_memory_mb: u64,
+    used_vcpus: Mutex<u32>,
+    used_memory_mb: Mutex<u64>,
+    reservations: Mutex<HashMap<String, Reservation>>,
+}
+
+impl CapacityTracker {
+    /// Create a new capacity tracker.
+    ///
+    /// Allocatable is computed as:
+    /// - vCPUs: (total_cpus - 1) * 2
+    /// - memory: total_memory - 1GB
+    pub fn new() -> Self {
+        let sys_cpus = num_cpus();
+        let sys_mem = total_memory_mb();
+
+        Self {
+            total_vcpus: if sys_cpus > 1 { (sys_cpus - 1) * 2 } else { 1 },
+            total_memory_mb: if sys_mem > 1024 {
+                sys_mem - 1024
+            } else {
+                sys_mem
+            },
+            used_vcpus: Mutex::new(0),
+            used_memory_mb: Mutex::new(0),
+            reservations: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a tracker with explicit capacity (for testing).
+    pub fn with_capacity(total_vcpus: u32, total_memory_mb: u64) -> Self {
+        Self {
+            total_vcpus,
+            total_memory_mb,
+            used_vcpus: Mutex::new(0),
+            used_memory_mb: Mutex::new(0),
+            reservations: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get the allocatable vCPUs.
+    pub fn allocatable_vcpus(&self) -> u32 {
+        self.total_vcpus
+    }
+
+    /// Get the allocatable memory in MB.
+    pub fn allocatable_memory_mb(&self) -> u64 {
+        self.total_memory_mb
+    }
+
+    /// Get the available vCPUs (allocatable - used - reserved).
+    pub fn available_vcpus(&self) -> u32 {
+        let used = *self.used_vcpus.lock().unwrap();
+        let reserved = self.reserved_vcpus();
+        self.total_vcpus.saturating_sub(used + reserved)
+    }
+
+    /// Get the available memory in MB.
+    pub fn available_memory_mb(&self) -> u64 {
+        let used = *self.used_memory_mb.lock().unwrap();
+        let reserved = self.reserved_memory_mb();
+        self.total_memory_mb.saturating_sub(used + reserved)
+    }
+
+    fn reserved_vcpus(&self) -> u32 {
+        let reservations = self.reservations.lock().unwrap();
+        reservations
+            .values()
+            .filter(|r| r.created_at.elapsed() < RESERVATION_EXPIRY)
+            .map(|r| r.vcpus)
+            .sum()
+    }
+
+    fn reserved_memory_mb(&self) -> u64 {
+        let reservations = self.reservations.lock().unwrap();
+        reservations
+            .values()
+            .filter(|r| r.created_at.elapsed() < RESERVATION_EXPIRY)
+            .map(|r| r.memory_mb)
+            .sum()
+    }
+
+    /// Check if resources can be admitted.
+    pub fn can_admit(&self, vcpus: u32, memory_mb: u64) -> bool {
+        self.available_vcpus() >= vcpus && self.available_memory_mb() >= memory_mb
+    }
+
+    /// Reserve resources for an upcoming creation (60s expiry).
+    pub fn reserve(&self, id: &str, vcpus: u32, memory_mb: u64) {
+        let mut reservations = self.reservations.lock().unwrap();
+        // Expire old reservations first
+        reservations.retain(|_, r| r.created_at.elapsed() < RESERVATION_EXPIRY);
+        reservations.insert(
+            id.to_string(),
+            Reservation {
+                vcpus,
+                memory_mb,
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    /// Commit a reservation — move from reserved to used.
+    pub fn commit(&self, id: &str, vcpus: u32, memory_mb: u64) {
+        let mut reservations = self.reservations.lock().unwrap();
+        reservations.remove(id);
+        drop(reservations);
+
+        *self.used_vcpus.lock().unwrap() += vcpus;
+        *self.used_memory_mb.lock().unwrap() += memory_mb;
+    }
+
+    /// Release resources when a VM is deleted.
+    pub fn release(&self, id: &str, vcpus: u32, memory_mb: u64) {
+        let mut reservations = self.reservations.lock().unwrap();
+        reservations.remove(id);
+        drop(reservations);
+
+        let mut used_v = self.used_vcpus.lock().unwrap();
+        *used_v = used_v.saturating_sub(vcpus);
+        drop(used_v);
+
+        let mut used_m = self.used_memory_mb.lock().unwrap();
+        *used_m = used_m.saturating_sub(memory_mb);
+    }
+
+    /// Update used resources from actual VM list.
+    pub fn sync_used(&self, vcpus: u32, memory_mb: u64) {
+        *self.used_vcpus.lock().unwrap() = vcpus;
+        *self.used_memory_mb.lock().unwrap() = memory_mb;
+    }
+
+    /// Get a snapshot of current capacity.
+    pub fn snapshot(&self) -> NodeCapacity {
+        NodeCapacity {
+            total_vcpus: self.total_vcpus,
+            total_memory_mb: self.total_memory_mb,
+            used_vcpus: *self.used_vcpus.lock().unwrap(),
+            used_memory_mb: *self.used_memory_mb.lock().unwrap(),
+        }
+    }
+}
+
+impl Default for CapacityTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Read the number of CPUs from the system.
+fn num_cpus() -> u32 {
+    std::thread::available_parallelism()
+        .map(|n| n.get() as u32)
+        .unwrap_or(1)
+}
+
+/// Read total memory from /proc/meminfo.
+fn total_memory_mb() -> u64 {
+    let content = std::fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    for line in content.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            let kb: u64 = rest
+                .split_whitespace()
+                .next()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            return kb / 1024;
+        }
+    }
+    4096 // fallback
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admission_control_basic() {
+        let tracker = CapacityTracker::with_capacity(8, 16384);
+        assert!(tracker.can_admit(2, 4096));
+        assert!(!tracker.can_admit(10, 4096));
+        assert!(!tracker.can_admit(2, 32768));
+    }
+
+    #[test]
+    fn reserve_and_commit() {
+        let tracker = CapacityTracker::with_capacity(4, 8192);
+        tracker.reserve("vm-1", 2, 4096);
+        assert_eq!(tracker.available_vcpus(), 2);
+        assert_eq!(tracker.available_memory_mb(), 4096);
+
+        tracker.commit("vm-1", 2, 4096);
+        assert_eq!(tracker.available_vcpus(), 2);
+        assert_eq!(tracker.available_memory_mb(), 4096);
+    }
+
+    #[test]
+    fn release_resources() {
+        let tracker = CapacityTracker::with_capacity(4, 8192);
+        tracker.commit("vm-1", 2, 4096);
+        assert_eq!(tracker.available_vcpus(), 2);
+        tracker.release("vm-1", 2, 4096);
+        assert_eq!(tracker.available_vcpus(), 4);
+        assert_eq!(tracker.available_memory_mb(), 8192);
+    }
+}

--- a/layers/forge/src/health.rs
+++ b/layers/forge/src/health.rs
@@ -1,0 +1,44 @@
+//! Health monitoring for the Forge node.
+//!
+//! Tracks self-health, node-health, workload-health, and control-health.
+
+use serde::{Deserialize, Serialize};
+
+/// Aggregate health status for this node.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+/// Health check result for the node.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NodeHealth {
+    pub status: HealthStatus,
+    pub uptime_secs: u64,
+    pub vm_count: u32,
+}
+
+impl NodeHealth {
+    pub fn healthy(uptime_secs: u64, vm_count: u32) -> Self {
+        Self {
+            status: HealthStatus::Healthy,
+            uptime_secs,
+            vm_count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_status_serializes() {
+        let h = NodeHealth::healthy(100, 3);
+        let json = serde_json::to_string(&h).unwrap();
+        assert!(json.contains("\"healthy\""));
+    }
+}

--- a/layers/forge/src/lib.rs
+++ b/layers/forge/src/lib.rs
@@ -1,3 +1,26 @@
-pub mod api;
+//! # syfrah-forge
+//!
+//! Per-node resource orchestrator for Syfrah.
+//!
+//! Forge is the single entry point for all resource mutations on a node.
+//! It exposes an HTTP/JSON REST API on the fabric interface (`syfrah0`)
+//! port 7100, reachable only from within the WireGuard mesh.
+//!
+//! ## Modules
+//!
+//! - [`api`] — HTTP server, request routing, health endpoint
+//! - [`reconciler`] — reconciliation loop, drift detection (stub)
+//! - [`capacity`] — resource tracking, admission control
+//! - [`health`] — self-health, node-health checks
+//! - [`runtime`] — delegates to compute (VmManager) and overlay (NetworkBackend)
+//! - [`task`] — operation records, status tracking
 
-pub use api::ForgeHandler;
+pub mod api;
+pub mod capacity;
+pub mod health;
+pub mod ownership;
+pub mod reconciler;
+pub mod runtime;
+pub mod task;
+
+pub use api::{ForgeHandler, ForgeServer};

--- a/layers/forge/src/ownership.rs
+++ b/layers/forge/src/ownership.rs
@@ -1,0 +1,204 @@
+//! Ownership registry — tracks which resources are managed by Forge.
+//!
+//! Uses [`syfrah_state::LayerDb`] to map resource_id to ownership records.
+//! Implements a 3-tier orphan policy: known -> manage, suspected -> quarantine,
+//! unknown -> ignore.
+
+use serde::{Deserialize, Serialize};
+use syfrah_state::LayerDb;
+
+const TABLE: &str = "ownership_registry";
+
+/// Resource ownership record.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct OwnershipRecord {
+    /// Resource type (e.g., "vm", "bridge", "tap").
+    pub resource_type: String,
+    /// Kernel-visible name (e.g., "br-vpc-xxx", "tap-vm-yyy").
+    pub kernel_name: String,
+    /// Unix timestamp of registration.
+    pub created_at: u64,
+}
+
+/// Orphan classification policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OrphanPolicy {
+    /// Known resource — manage normally.
+    Known,
+    /// Suspected orphan — quarantine for review.
+    Suspected,
+    /// Unknown resource — ignore (not ours).
+    Unknown,
+}
+
+/// Ownership registry backed by LayerDb.
+pub struct OwnershipRegistry {
+    db: LayerDb,
+}
+
+impl OwnershipRegistry {
+    /// Create a registry using the given LayerDb.
+    pub fn new(db: LayerDb) -> Self {
+        Self { db }
+    }
+
+    /// Register a resource.
+    pub fn register(
+        &self,
+        resource_id: &str,
+        resource_type: &str,
+        kernel_name: &str,
+    ) -> Result<(), syfrah_state::StateError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let record = OwnershipRecord {
+            resource_type: resource_type.to_string(),
+            kernel_name: kernel_name.to_string(),
+            created_at: now,
+        };
+
+        self.db.set(TABLE, resource_id, &record)
+    }
+
+    /// Deregister a resource.
+    pub fn deregister(&self, resource_id: &str) -> Result<bool, syfrah_state::StateError> {
+        self.db.delete(TABLE, resource_id)
+    }
+
+    /// Look up a resource.
+    pub fn lookup(
+        &self,
+        resource_id: &str,
+    ) -> Result<Option<OwnershipRecord>, syfrah_state::StateError> {
+        self.db.get(TABLE, resource_id)
+    }
+
+    /// List all registered resources.
+    pub fn list_all(&self) -> Result<Vec<(String, OwnershipRecord)>, syfrah_state::StateError> {
+        self.db.list(TABLE)
+    }
+
+    /// Rebuild the registry from a list of known resources.
+    pub fn rebuild(
+        &self,
+        resources: &[(String, String, String)], // (id, type, kernel_name)
+    ) -> Result<usize, syfrah_state::StateError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // Clear existing entries.
+        let existing: Vec<(String, OwnershipRecord)> = self.db.list(TABLE)?;
+        for (key, _) in &existing {
+            self.db.delete(TABLE, key)?;
+        }
+
+        // Insert new entries.
+        for (id, rtype, kname) in resources {
+            let record = OwnershipRecord {
+                resource_type: rtype.clone(),
+                kernel_name: kname.clone(),
+                created_at: now,
+            };
+            self.db.set(TABLE, id, &record)?;
+        }
+
+        Ok(resources.len())
+    }
+
+    /// Classify a kernel resource against the registry.
+    pub fn classify(&self, kernel_name: &str) -> Result<OrphanPolicy, syfrah_state::StateError> {
+        let all: Vec<(String, OwnershipRecord)> = self.db.list(TABLE)?;
+
+        for (_, record) in &all {
+            if record.kernel_name == kernel_name {
+                return Ok(OrphanPolicy::Known);
+            }
+        }
+
+        // Check if the name looks like a Syfrah resource.
+        if kernel_name.starts_with("br-")
+            || kernel_name.starts_with("tap-")
+            || kernel_name.starts_with("vx-")
+        {
+            return Ok(OrphanPolicy::Suspected);
+        }
+
+        Ok(OrphanPolicy::Unknown)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_registry() -> (tempfile::TempDir, OwnershipRegistry) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = LayerDb::open_at(&dir.path().join("ownership.redb")).unwrap();
+        (dir, OwnershipRegistry::new(db))
+    }
+
+    #[test]
+    fn register_and_lookup() {
+        let (_dir, reg) = temp_registry();
+        reg.register("vm-1", "vm", "ch-vm-1").unwrap();
+        let record = reg.lookup("vm-1").unwrap().unwrap();
+        assert_eq!(record.resource_type, "vm");
+        assert_eq!(record.kernel_name, "ch-vm-1");
+    }
+
+    #[test]
+    fn deregister() {
+        let (_dir, reg) = temp_registry();
+        reg.register("vm-2", "vm", "ch-vm-2").unwrap();
+        assert!(reg.deregister("vm-2").unwrap());
+        assert!(reg.lookup("vm-2").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_all() {
+        let (_dir, reg) = temp_registry();
+        reg.register("vm-1", "vm", "ch-1").unwrap();
+        reg.register("br-1", "bridge", "br-vpc-1").unwrap();
+        let all = reg.list_all().unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn classify_orphan_policy() {
+        let (_dir, reg) = temp_registry();
+        reg.register("vm-1", "vm", "ch-vm-1").unwrap();
+
+        assert_eq!(reg.classify("ch-vm-1").unwrap(), OrphanPolicy::Known);
+        assert_eq!(reg.classify("br-unknown").unwrap(), OrphanPolicy::Suspected);
+        assert_eq!(reg.classify("eth0").unwrap(), OrphanPolicy::Unknown);
+    }
+
+    #[test]
+    fn rebuild_replaces_all() {
+        let (_dir, reg) = temp_registry();
+        reg.register("old-1", "vm", "ch-old").unwrap();
+
+        let resources = vec![
+            (
+                "new-1".to_string(),
+                "vm".to_string(),
+                "ch-new-1".to_string(),
+            ),
+            (
+                "new-2".to_string(),
+                "bridge".to_string(),
+                "br-new".to_string(),
+            ),
+        ];
+        let count = reg.rebuild(&resources).unwrap();
+        assert_eq!(count, 2);
+
+        assert!(reg.lookup("old-1").unwrap().is_none());
+        assert!(reg.lookup("new-1").unwrap().is_some());
+    }
+}

--- a/layers/forge/src/reconciler.rs
+++ b/layers/forge/src/reconciler.rs
@@ -1,0 +1,31 @@
+//! Reconciliation engine — drift detection and convergence.
+//!
+//! In Phase 1 (bootstrap mode), the reconciler is a no-op stub.
+//! Future phases will implement the full reconciliation loop that reads
+//! desired state from the materialized view and converges actual state.
+
+/// Placeholder for the reconciliation engine.
+pub struct Reconciler;
+
+impl Reconciler {
+    /// Create a new reconciler (no-op in bootstrap mode).
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Reconciler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconciler_creates() {
+        let _r = Reconciler::new();
+    }
+}

--- a/layers/forge/src/runtime.rs
+++ b/layers/forge/src/runtime.rs
@@ -1,0 +1,54 @@
+//! Runtime module — delegates to compute (VmManager) and overlay (NetworkBackend).
+//!
+//! This module wraps the existing compute and overlay layer interfaces,
+//! providing a unified abstraction for Forge's reconciler and API to
+//! execute infrastructure operations.
+
+use std::sync::Arc;
+
+/// Runtime wrapper that holds references to compute and overlay backends.
+pub struct ForgeRuntime {
+    /// Compute layer VM manager.
+    pub vm_manager: Option<Arc<syfrah_compute::VmManager>>,
+    /// Overlay layer network backend.
+    pub network_backend: Option<Arc<dyn syfrah_overlay::NetworkBackend>>,
+}
+
+impl ForgeRuntime {
+    /// Create a new runtime with no backends wired.
+    pub fn new() -> Self {
+        Self {
+            vm_manager: None,
+            network_backend: None,
+        }
+    }
+
+    /// Create a runtime with the given backends.
+    pub fn with_backends(
+        vm_manager: Arc<syfrah_compute::VmManager>,
+        network_backend: Arc<dyn syfrah_overlay::NetworkBackend>,
+    ) -> Self {
+        Self {
+            vm_manager: Some(vm_manager),
+            network_backend: Some(network_backend),
+        }
+    }
+}
+
+impl Default for ForgeRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_creates_empty() {
+        let rt = ForgeRuntime::new();
+        assert!(rt.vm_manager.is_none());
+        assert!(rt.network_backend.is_none());
+    }
+}

--- a/layers/forge/src/task.rs
+++ b/layers/forge/src/task.rs
@@ -1,0 +1,200 @@
+//! Task engine — operation records with status tracking.
+//!
+//! Every mutation requested through the Forge API creates a Task record.
+//! Tasks are stored via [`syfrah_state::LayerDb`] and exposed via the API
+//! for observability.
+
+use serde::{Deserialize, Serialize};
+use syfrah_state::LayerDb;
+
+/// Task state machine.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskState {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+/// A task record representing an operation.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Task {
+    /// Unique task ID.
+    pub id: String,
+    /// Resource this task operates on.
+    pub resource_id: String,
+    /// Operation name (e.g., "create_instance", "delete_instance").
+    pub operation: String,
+    /// Current state.
+    pub state: TaskState,
+    /// Unix timestamp of creation.
+    pub created_at: u64,
+    /// Unix timestamp of completion (if completed or failed).
+    pub completed_at: Option<u64>,
+    /// Error message (if failed).
+    pub error: Option<String>,
+}
+
+const TABLE: &str = "tasks";
+
+/// Task store backed by LayerDb.
+pub struct TaskStore {
+    db: LayerDb,
+}
+
+impl TaskStore {
+    /// Create a task store using the given LayerDb.
+    pub fn new(db: LayerDb) -> Self {
+        Self { db }
+    }
+
+    /// Create a new task.
+    pub fn create_task(
+        &self,
+        id: &str,
+        resource_id: &str,
+        operation: &str,
+    ) -> Result<Task, syfrah_state::StateError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let task = Task {
+            id: id.to_string(),
+            resource_id: resource_id.to_string(),
+            operation: operation.to_string(),
+            state: TaskState::Pending,
+            created_at: now,
+            completed_at: None,
+            error: None,
+        };
+
+        self.db.set(TABLE, id, &task)?;
+        Ok(task)
+    }
+
+    /// Mark a task as running.
+    pub fn start_task(&self, id: &str) -> Result<Option<Task>, syfrah_state::StateError> {
+        self.update_state(id, TaskState::Running, None)
+    }
+
+    /// Mark a task as completed.
+    pub fn complete_task(&self, id: &str) -> Result<Option<Task>, syfrah_state::StateError> {
+        self.update_state(id, TaskState::Completed, None)
+    }
+
+    /// Mark a task as failed.
+    pub fn fail_task(
+        &self,
+        id: &str,
+        error: &str,
+    ) -> Result<Option<Task>, syfrah_state::StateError> {
+        self.update_state(id, TaskState::Failed, Some(error.to_string()))
+    }
+
+    /// Get a task by ID.
+    pub fn get_task(&self, id: &str) -> Result<Option<Task>, syfrah_state::StateError> {
+        self.db.get(TABLE, id)
+    }
+
+    /// List all tasks, optionally filtered by resource_id.
+    pub fn list_tasks(
+        &self,
+        resource_id: Option<&str>,
+    ) -> Result<Vec<Task>, syfrah_state::StateError> {
+        let all: Vec<(String, Task)> = self.db.list(TABLE)?;
+        let mut tasks: Vec<Task> = all
+            .into_iter()
+            .map(|(_, t)| t)
+            .filter(|t| {
+                if let Some(rid) = resource_id {
+                    t.resource_id == rid
+                } else {
+                    true
+                }
+            })
+            .collect();
+        tasks.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(tasks)
+    }
+
+    fn update_state(
+        &self,
+        id: &str,
+        new_state: TaskState,
+        error: Option<String>,
+    ) -> Result<Option<Task>, syfrah_state::StateError> {
+        let task: Option<Task> = self.db.get(TABLE, id)?;
+        match task {
+            Some(mut t) => {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                t.state = new_state;
+                if matches!(t.state, TaskState::Completed | TaskState::Failed) {
+                    t.completed_at = Some(now);
+                }
+                t.error = error;
+                self.db.set(TABLE, id, &t)?;
+                Ok(Some(t))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_store() -> (tempfile::TempDir, TaskStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = LayerDb::open_at(&dir.path().join("forge_tasks.redb")).unwrap();
+        (dir, TaskStore::new(db))
+    }
+
+    #[test]
+    fn create_and_get_task() {
+        let (_dir, store) = temp_store();
+        let task = store.create_task("t-1", "vm-1", "create_instance").unwrap();
+        assert_eq!(task.state, TaskState::Pending);
+
+        let fetched = store.get_task("t-1").unwrap().unwrap();
+        assert_eq!(fetched.resource_id, "vm-1");
+    }
+
+    #[test]
+    fn complete_task() {
+        let (_dir, store) = temp_store();
+        store.create_task("t-2", "vm-2", "delete_instance").unwrap();
+        let task = store.complete_task("t-2").unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Completed);
+        assert!(task.completed_at.is_some());
+    }
+
+    #[test]
+    fn fail_task() {
+        let (_dir, store) = temp_store();
+        store.create_task("t-3", "vm-3", "create_instance").unwrap();
+        let task = store.fail_task("t-3", "out of memory").unwrap().unwrap();
+        assert_eq!(task.state, TaskState::Failed);
+        assert_eq!(task.error.as_deref(), Some("out of memory"));
+    }
+
+    #[test]
+    fn list_tasks_with_filter() {
+        let (_dir, store) = temp_store();
+        store.create_task("t-4", "vm-4", "create").unwrap();
+        store.create_task("t-5", "vm-5", "create").unwrap();
+        store.create_task("t-6", "vm-4", "delete").unwrap();
+
+        let all = store.list_tasks(None).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let filtered = store.list_tasks(Some("vm-4")).unwrap();
+        assert_eq!(filtered.len(), 2);
+    }
+}

--- a/tests/e2e/scenarios/400_forge_server.md
+++ b/tests/e2e/scenarios/400_forge_server.md
@@ -1,0 +1,61 @@
+# Test: Forge HTTP server on syfrah0:7100
+
+## Objective
+
+- Forge HTTP server starts alongside the daemon
+- Binds to the fabric IPv6 address on port 7100
+- GET /v1/node/health returns healthy status with uptime
+- Server is only reachable from within the WireGuard mesh
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon is NOT running (clean state)
+- WireGuard kernel module loaded
+
+## Steps
+
+### 1. Initialize the mesh
+
+```bash
+rm -rf ~/.syfrah/*.redb
+syfrah fabric stop 2>/dev/null; sleep 2
+rm -rf ~/.syfrah/fabric.redb ~/.syfrah/state.json
+syfrah fabric init --name test --node-name n1 --endpoint $(hostname -I | awk '{print $1}'):51820
+sleep 3
+```
+
+### 2. Get the fabric IPv6 address
+
+```bash
+FORGE_IP=$(ip -6 addr show syfrah0 | grep inet6 | awk '{print $2}' | cut -d/ -f1 | head -1)
+echo "Forge IP: $FORGE_IP"
+```
+
+### 3. Test the health endpoint
+
+```bash
+HEALTH=$(curl -s http://[$FORGE_IP]:7100/v1/node/health)
+echo "$HEALTH"
+```
+
+### 4. Validate the response
+
+```bash
+STATUS=$(echo "$HEALTH" | jq -r '.status')
+UPTIME=$(echo "$HEALTH" | jq -r '.uptime')
+```
+
+## Expected Results
+
+- The daemon starts successfully
+- `syfrah0` interface exists with a ULA IPv6 address
+- `curl http://[$FORGE_IP]:7100/v1/node/health` returns HTTP 200
+- Response contains `{"status": "healthy", "uptime": N}` where N >= 0
+- The server is NOT reachable on the public IP (port 7100 is only on syfrah0)
+
+## Cleanup
+
+```bash
+syfrah fabric leave --force
+```


### PR DESCRIPTION
## Summary
- Transforms the forge crate from a 32-LOC stub into a real crate with 6 modules (api, reconciler, capacity, health, runtime, task)
- Adds Axum HTTP server binding to fabric IPv6 (syfrah0) on port 7100
- GET /v1/node/health returns `{"status":"healthy","uptime":N}`
- Server starts alongside daemon, coexisting with control socket and HTTP/gRPC APIs
- 17 unit tests covering all modules

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes  
- [x] `cargo test -p syfrah-forge` — 17 tests pass
- [ ] E2E: `tests/e2e/scenarios/400_forge_server.md`

Closes #936