### PR TITLE
feat(forge): ownership registry with 3-tier orphan policy

### DIFF
--- a/layers/forge/src/ownership.rs
+++ b/layers/forge/src/ownership.rs
@@ -81,6 +81,18 @@ impl OwnershipRegistry {
         self.db.list(TABLE)
     }
 
+    /// List resources filtered by type (e.g., "vm", "bridge").
+    pub fn list_by_type(
+        &self,
+        resource_type: &str,
+    ) -> Result<Vec<(String, OwnershipRecord)>, syfrah_state::StateError> {
+        let all = self.list_all()?;
+        Ok(all
+            .into_iter()
+            .filter(|(_, r)| r.resource_type == resource_type)
+            .collect())
+    }
+
     /// Rebuild the registry from a list of known resources.
     pub fn rebuild(
         &self,

--- a/tests/e2e/scenarios/402_forge_ownership.md
+++ b/tests/e2e/scenarios/402_forge_ownership.md
@@ -1,0 +1,49 @@
+# Test: Forge ownership registry in redb
+
+## Objective
+
+- Ownership registry stores resource_id → {type, kernel_name, created_at}
+- register(), deregister(), lookup(), list_all(), rebuild() work correctly
+- 3-tier orphan policy: known→manage, suspected→quarantine, unknown→ignore
+
+## Prerequisites
+
+- Rust toolchain installed
+- Repository checked out
+
+## Steps
+
+### 1. Run ownership unit tests
+
+```bash
+cargo test -p syfrah-forge -- ownership
+```
+
+### 2. Verify the registry functions
+
+The unit tests cover:
+- `register_and_lookup` — register a resource, verify lookup returns it
+- `deregister` — register then deregister, verify it's gone
+- `list_all` — register multiple resources, verify count
+- `classify_orphan_policy` — test 3-tier classification:
+  - Known: resource with matching kernel_name in registry
+  - Suspected: br-*, tap-*, vx-* prefixed names not in registry
+  - Unknown: names that don't match Syfrah patterns
+- `rebuild_replaces_all` — rebuild clears old entries and inserts new ones
+
+### 3. Verify on running daemon
+
+```bash
+# After daemon start with VMs running:
+syfrah state list forge
+# Should show ownership_registry table with entries for each managed resource
+```
+
+## Expected Results
+
+- All ownership unit tests pass
+- Registry persists across daemon restarts (redb durability)
+- Orphan classification correctly identifies:
+  - Known resources (in registry) → manage
+  - Suspected orphans (syfrah-prefixed but not in registry) → quarantine
+  - Unknown resources (not syfrah-related) → ignore


### PR DESCRIPTION
## Summary
- Ownership registry stores resource_id -> {type, kernel_name, created_at} in redb
- Operations: register(), deregister(), lookup(), list_all(), list_by_type(), rebuild()
- 3-tier orphan policy: known->manage, suspected->quarantine, unknown->ignore
- 5 unit tests covering all operations and orphan classification

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test -p syfrah-forge -- ownership` — all tests pass
- [ ] E2E: `tests/e2e/scenarios/402_forge_ownership.md`

Closes #938