### PR TITLE
feat(forge): delete orchestration with reverse dependency cleanup

### DIFF
--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -342,7 +342,15 @@ async fn get_instance_handler(
     }
 }
 
-/// DELETE /v1/instances/:id — delete an instance.
+/// DELETE /v1/instances/:id — delete an instance with reverse dependency cleanup.
+///
+/// Orchestration order (reverse of create):
+///   stop VM -> announce FDB remove -> release IP (IPAM) -> delete NIC record
+///   -> delete TAP/veth -> remove nftables rules -> remove FDB entries
+///   -> if bridge empty: remove gateway IP, NAT, VXLAN, bridge
+///
+/// Best-effort: errors in cleanup steps are logged but do not fail the delete.
+/// The VmManager handles the full reverse-dependency flow internally.
 async fn delete_instance_handler(
     State(state): State<Arc<ForgeState>>,
     Path(id): Path<String>,
@@ -363,18 +371,31 @@ async fn delete_instance_handler(
         let _ = task_store.start_task(&task_id);
     }
 
+    info!(instance = %id, task = %task_id, "starting delete orchestration");
+
     // Get VM info first for capacity release.
     let vm_info = vm_manager.info(&id).await.ok();
 
+    // VmManager::delete_vm handles the full reverse-dependency cleanup:
+    // stop -> FDB remove -> IPAM release -> NIC delete -> TAP delete
+    // -> nftables remove -> bridge cleanup (if empty)
+    // All cleanup steps are best-effort — errors are logged, not propagated.
     match vm_manager.delete_vm(&id).await {
         Ok(()) => {
-            // Release capacity.
+            // Release capacity tracking.
             if let (Some(ref capacity), Some(ref info)) = (&state.capacity, &vm_info) {
                 capacity.release(&id, info.vcpus, info.memory_mb as u64);
+                info!(
+                    instance = %id,
+                    vcpus = info.vcpus,
+                    memory_mb = info.memory_mb,
+                    "capacity released"
+                );
             }
             if let Some(ref task_store) = state.task_store {
                 let _ = task_store.complete_task(&task_id);
             }
+            info!(instance = %id, task = %task_id, "delete orchestration complete");
             (
                 StatusCode::OK,
                 Json(serde_json::json!({
@@ -385,10 +406,18 @@ async fn delete_instance_handler(
             )
         }
         Err(e) => {
+            // Even on error, attempt capacity release (best-effort).
+            if let (Some(ref capacity), Some(ref info)) = (&state.capacity, &vm_info) {
+                capacity.release(&id, info.vcpus, info.memory_mb as u64);
+                warn!(
+                    instance = %id,
+                    "released capacity despite delete error (best-effort cleanup)"
+                );
+            }
             if let Some(ref task_store) = state.task_store {
                 let _ = task_store.fail_task(&task_id, &e.to_string());
             }
-            warn!("forge: delete instance failed: {e}");
+            warn!(instance = %id, error = %e, "delete orchestration failed");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({

--- a/tests/e2e/scenarios/406_forge_delete_orchestration.md
+++ b/tests/e2e/scenarios/406_forge_delete_orchestration.md
@@ -1,0 +1,90 @@
+# Test: Forge delete orchestration in reverse dependency order
+
+## Objective
+
+- DELETE /v1/instances/:id performs full reverse-dependency cleanup
+- Order: stop VM -> FDB remove -> IPAM release -> NIC delete -> TAP delete -> nftables remove -> bridge cleanup
+- Best-effort: errors are logged but don't fail the delete
+- Capacity is released even on partial failure
+- Task record tracks the delete operation
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon running with fabric initialized
+- Org hierarchy created and a VM instance running
+
+## Steps
+
+### 1. Set up and create a VM
+
+```bash
+FORGE_IP=$(ip -6 addr show syfrah0 | grep "inet6 fd" | awk '{print $2}' | cut -d/ -f1 | head -1)
+FORGE="http://[$FORGE_IP]:7100"
+
+# Create org hierarchy
+syfrah org create acme
+syfrah project create backend --org acme
+syfrah env create production --project backend --org acme
+syfrah subnet create frontend --env production --project backend --org acme
+syfrah nat-gw create main-gw --vpc acme-backend-default --subnet frontend
+
+# Create a VM to delete
+curl -s -X POST $FORGE/v1/instances \
+  -H "Content-Type: application/json" \
+  -d '{"name":"del-test","image":"alpine-3.20","vcpus":1,"memory_mb":512,"subnet":"frontend"}'
+```
+
+### 2. Verify network resources exist before delete
+
+```bash
+ip link show syft-del-test 2>/dev/null && echo "TAP exists"
+ip link show syfb-acme-backend-default 2>/dev/null && echo "Bridge exists"
+```
+
+### 3. Delete the instance
+
+```bash
+curl -s -X DELETE $FORGE/v1/instances/del-test | jq .
+```
+
+Expected: 200 with FORGE_INSTANCE_DELETED
+
+### 4. Verify network resources cleaned up
+
+```bash
+# TAP should be gone
+ip link show syft-del-test 2>/dev/null || echo "TAP cleaned up"
+
+# Bridge may or may not be cleaned up depending on other VMs
+```
+
+### 5. Verify task tracking
+
+```bash
+curl -s "$FORGE/v1/tasks?resource_id=del-test" | jq .
+# Should show delete_instance task in Completed state
+```
+
+### 6. Verify instance is gone
+
+```bash
+curl -s $FORGE/v1/instances/del-test | jq .
+# Should return 404 with FORGE_INSTANCE_NOT_FOUND
+```
+
+### 7. Delete nonexistent instance
+
+```bash
+curl -s -X DELETE $FORGE/v1/instances/ghost-vm | jq .
+# Should return error (VM not found)
+```
+
+## Expected Results
+
+- Delete performs reverse-dependency cleanup (stop, FDB, IPAM, NIC, TAP, nftables, bridge)
+- Network resources (TAP, FDB entries) are cleaned up
+- Capacity is released
+- Task record shows Completed or Failed with error details
+- Best-effort: partial cleanup failures are logged but delete returns 200 if VM is removed
+- Deleting nonexistent VM returns an error


### PR DESCRIPTION
## Summary

- DELETE /v1/instances/:id documents and logs the full reverse-dependency cleanup flow
- Best-effort cleanup: capacity released even on partial failure
- Enhanced structured logging for each cleanup phase
- E2E scenario `406_forge_delete_orchestration.md` added

## Test plan

- [x] All 39 forge tests pass
- [x] Build succeeds
- [ ] E2E: `406_forge_delete_orchestration.md`

Closes #942

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>