### PR TITLE
feat(org): hypervisor CLI, labels/taints, and lifecycle commands

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -83,6 +83,11 @@ enum Commands {
         #[command(subcommand)]
         command: syfrah_org::RouteCommand,
     },
+    /// Manage hypervisors (compute hosts)
+    Hypervisor {
+        #[command(subcommand)]
+        command: syfrah_org::HypervisorCommand,
+    },
     /// Inspect and manage layer state databases
     State {
         #[command(subcommand)]
@@ -963,6 +968,7 @@ async fn run() -> Result<()> {
         Commands::Sg { command } => syfrah_org::cli::run_sg(command).await,
         Commands::NatGw { command } => syfrah_org::cli::run_nat_gw(command).await,
         Commands::Route { command } => syfrah_org::cli::run_route(command).await,
+        Commands::Hypervisor { command } => syfrah_org::cli::run_hypervisor(command).await,
         Commands::Completions { shell } => {
             let mut cmd = Cli::command();
             let mut buf = Vec::new();

--- a/layers/api/src/router.rs
+++ b/layers/api/src/router.rs
@@ -19,6 +19,8 @@ pub enum LayerRequest {
     Compute(Vec<u8>),
     /// Request destined for the Org layer.
     Org(Vec<u8>),
+    /// Request destined for the Hypervisor layer.
+    Hypervisor(Vec<u8>),
 }
 
 /// Top-level response envelope returned to the client.
@@ -30,6 +32,8 @@ pub enum LayerResponse {
     Compute(Vec<u8>),
     /// Response originating from the Org layer.
     Org(Vec<u8>),
+    /// Response originating from the Hypervisor layer.
+    Hypervisor(Vec<u8>),
     /// The requested layer is not registered in the router.
     UnknownLayer(String),
 }
@@ -81,6 +85,13 @@ impl LayerRouter {
                     LayerResponse::Org(handler.handle(payload, caller_uid).await)
                 } else {
                     LayerResponse::UnknownLayer("org".into())
+                }
+            }
+            LayerRequest::Hypervisor(payload) => {
+                if let Some(handler) = self.handlers.get("hypervisor") {
+                    LayerResponse::Hypervisor(handler.handle(payload, caller_uid).await)
+                } else {
+                    LayerResponse::UnknownLayer("hypervisor".into())
                 }
             }
         }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1197,6 +1197,14 @@ pub async fn run_daemon(
                     &public_ip,
                     &fabric_ipv6,
                 );
+                // Register the hypervisor layer handler for CLI commands.
+                let hv_handler = syfrah_org::HypervisorLayerHandler::new(
+                    Arc::clone(&store),
+                    my_record.name.clone(),
+                );
+                router.register("hypervisor", Arc::new(hv_handler));
+                info!("hypervisor layer initialised");
+
                 Some(store)
             }
             Err(e) => {
@@ -1204,7 +1212,7 @@ pub async fn run_daemon(
                 None
             }
         };
-    let _ = &shared_hypervisor_store; // suppress unused warning for now
+    let _ = &shared_hypervisor_store;
 
     // Register the forge layer handler on the control socket so future
     // `syfrah forge` CLI commands can be routed through the daemon.

--- a/layers/org/src/cli/hypervisor.rs
+++ b/layers/org/src/cli/hypervisor.rs
@@ -1,0 +1,399 @@
+//! Hypervisor CLI subcommand handlers.
+//!
+//! All operations go through the daemon's control socket via the "hypervisor" layer.
+
+use std::path::PathBuf;
+
+use crate::hypervisor_handler::{send_hypervisor_request, HypervisorRequest, HypervisorResponse};
+
+fn control_socket_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/root"))
+        .join(".syfrah")
+        .join("control.sock")
+}
+
+fn daemon_err(e: &dyn std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!(
+        "cannot reach the syfrah daemon — is it running?\n\
+         Start it with: syfrah fabric init ...\n\n\
+         Error: {e}"
+    )
+}
+
+pub async fn run_list(
+    region: Option<String>,
+    zone: Option<String>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let req = HypervisorRequest::List { region, zone };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::HypervisorList(list) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&list)?);
+                return Ok(());
+            }
+            if list.is_empty() {
+                println!("No hypervisors found.");
+                return Ok(());
+            }
+            println!(
+                "{:<20} {:<12} {:<12} {:<15} {:<4} {:<16} {:<16}",
+                "NAME", "REGION", "ZONE", "STATE", "VMs", "vCPU (used/tot)", "MEM (used/tot)"
+            );
+            for hv in &list {
+                println!(
+                    "{:<20} {:<12} {:<12} {:<15} {:<4} {}/{:<12} {}/{}",
+                    hv.name,
+                    hv.region,
+                    hv.zone,
+                    hv.state.to_string(),
+                    0, // VM count not tracked here yet
+                    hv.capacity.used_vcpus,
+                    hv.capacity.allocatable_vcpus,
+                    format_mb(hv.capacity.used_memory_mb),
+                    format_mb(hv.capacity.allocatable_memory_mb),
+                );
+            }
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_get(name: String, json: bool) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Get { name };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Hypervisor(ref hv) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&hv)?);
+                return Ok(());
+            }
+            println!("Hypervisor: {} ({})", hv.name, hv.id);
+            println!("Region:     {}", hv.region);
+            println!("Zone:       {}", hv.zone);
+            println!("State:      {}", hv.state);
+            println!("Fabric:     {}", hv.fabric_ipv6);
+            println!("Public IP:  {}", hv.public_ip);
+            println!();
+            println!("Hardware:");
+            println!(
+                "  CPU:      {} ({} cores, {} threads)",
+                hv.hardware.cpu_model,
+                hv.hardware.cpu_cores_physical,
+                hv.hardware.cpu_threads_logical
+            );
+            println!("  Memory:   {} GB", hv.hardware.memory_gb);
+            println!(
+                "  Disk:     {} GB {}",
+                hv.hardware.local_disk_gb, hv.hardware.local_disk_type
+            );
+            if let Some(ref gpu) = hv.hardware.gpu {
+                println!("  GPU:      {} x{}", gpu.model, gpu.count);
+            }
+            println!("  Arch:     {}", hv.hardware.architecture);
+            println!();
+            println!("Capacity:");
+            println!(
+                "  vCPUs:    {} used / {} allocatable",
+                hv.capacity.used_vcpus, hv.capacity.allocatable_vcpus
+            );
+            println!(
+                "  Memory:   {} used / {} allocatable",
+                format_mb(hv.capacity.used_memory_mb),
+                format_mb(hv.capacity.allocatable_memory_mb)
+            );
+            println!(
+                "  Disk:     {} GB used / {} GB allocatable",
+                hv.capacity.local_used_gb, hv.capacity.local_allocatable_gb
+            );
+            println!(
+                "  Overcommit: CPU {:.1}x, Memory {:.1}x",
+                hv.capacity.overcommit_cpu, hv.capacity.overcommit_memory
+            );
+            if !hv.labels.is_empty() {
+                let labels: Vec<String> =
+                    hv.labels.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                println!("\nLabels:     {}", labels.join(", "));
+            }
+            if !hv.taints.is_empty() {
+                let taints: Vec<String> = hv.taints.iter().map(|t| t.to_string()).collect();
+                println!("Taints:     {}", taints.join(", "));
+            }
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_register(region: String, zone: String) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Register { region, zone };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Hypervisor(ref hv) => {
+            println!("Hypervisor '{}' registered ({}).", hv.name, hv.id);
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_enable(name: String) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Enable { name: name.clone() };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Hypervisor '{name}' enabled (Available).");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_status() -> anyhow::Result<()> {
+    let req = HypervisorRequest::Status;
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Hypervisor(ref hv) => {
+            println!("Hypervisor: {} ({})", hv.name, hv.id);
+            println!("State:      {}", hv.state);
+            println!("Region:     {}", hv.region);
+            println!("Zone:       {}", hv.zone);
+            println!(
+                "vCPUs:      {} used / {} allocatable",
+                hv.capacity.used_vcpus, hv.capacity.allocatable_vcpus
+            );
+            println!(
+                "Memory:     {} used / {} allocatable",
+                format_mb(hv.capacity.used_memory_mb),
+                format_mb(hv.capacity.allocatable_memory_mb)
+            );
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_capacity() -> anyhow::Result<()> {
+    let req = HypervisorRequest::Capacity;
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Hypervisor(ref hv) => {
+            println!("Capacity for {} ({}):", hv.name, hv.state);
+            println!();
+            println!(
+                "  Physical:   {} vCPUs, {} MB memory",
+                hv.capacity.physical_vcpus, hv.capacity.physical_memory_mb
+            );
+            println!(
+                "  Reserved:   {} vCPUs, {} MB memory",
+                hv.capacity.reserved_vcpus, hv.capacity.reserved_memory_mb
+            );
+            println!(
+                "  Overcommit: CPU {:.1}x, Memory {:.1}x",
+                hv.capacity.overcommit_cpu, hv.capacity.overcommit_memory
+            );
+            println!(
+                "  Allocatable: {} vCPUs, {} MB memory",
+                hv.capacity.allocatable_vcpus, hv.capacity.allocatable_memory_mb
+            );
+            println!(
+                "  Used:       {} vCPUs, {} MB memory",
+                hv.capacity.used_vcpus, hv.capacity.used_memory_mb
+            );
+            println!(
+                "  Available:  {} vCPUs, {} MB memory",
+                hv.capacity.available_vcpus, hv.capacity.available_memory_mb
+            );
+            println!();
+            println!(
+                "  Disk:       {} GB total, {} GB used, {} GB allocatable",
+                hv.capacity.local_total_gb,
+                hv.capacity.local_used_gb,
+                hv.capacity.local_allocatable_gb
+            );
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_label_set(name: String, labels: Vec<(String, String)>) -> anyhow::Result<()> {
+    let req = HypervisorRequest::LabelSet {
+        name: name.clone(),
+        labels,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Labels updated on '{name}'.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_label_remove(name: String, keys: Vec<String>) -> anyhow::Result<()> {
+    let req = HypervisorRequest::LabelRemove {
+        name: name.clone(),
+        keys,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Labels removed from '{name}'.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_taint_add(name: String, taints: Vec<String>) -> anyhow::Result<()> {
+    let req = HypervisorRequest::TaintAdd {
+        name: name.clone(),
+        taints,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Taints added to '{name}'.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_taint_remove(name: String, keys: Vec<String>) -> anyhow::Result<()> {
+    let req = HypervisorRequest::TaintRemove {
+        name: name.clone(),
+        keys,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Taints removed from '{name}'.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_drain(name: String, force: bool) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Drain {
+        name: name.clone(),
+        force,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Hypervisor '{name}' is now draining.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_activate(name: String) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Activate { name: name.clone() };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Hypervisor '{name}' activated (Available).");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_maintenance(name: String, drain: bool) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Maintenance {
+        name: name.clone(),
+        drain,
+    };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Hypervisor '{name}' is now in maintenance.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+pub async fn run_decommission(name: String) -> anyhow::Result<()> {
+    let req = HypervisorRequest::Decommission { name: name.clone() };
+    let resp = send_hypervisor_request(&control_socket_path(), &req)
+        .await
+        .map_err(|e| daemon_err(&e))?;
+
+    match resp {
+        HypervisorResponse::Ok => {
+            println!("Hypervisor '{name}' decommissioned.");
+            Ok(())
+        }
+        HypervisorResponse::Error(msg) => anyhow::bail!("{msg}"),
+        other => anyhow::bail!("unexpected response: {other:?}"),
+    }
+}
+
+fn format_mb(mb: u64) -> String {
+    if mb >= 1024 {
+        format!("{}G", mb / 1024)
+    } else {
+        format!("{}M", mb)
+    }
+}

--- a/layers/org/src/cli/mod.rs
+++ b/layers/org/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI commands for `syfrah org ...`, `syfrah project ...`, `syfrah env ...`, `syfrah vpc ...`, `syfrah subnet ...`, and `syfrah route ...`.
 
 pub mod env;
+pub mod hypervisor;
 pub mod nat_gw;
 pub mod org;
 pub mod project;
@@ -883,5 +884,147 @@ pub async fn run_route(cmd: RouteCommand) -> anyhow::Result<()> {
             destination,
             table,
         } => route::run_delete(&vpc, &destination, table.as_deref()).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hypervisor CLI
+// ---------------------------------------------------------------------------
+
+/// Top-level hypervisor CLI command.
+#[derive(Debug, Subcommand)]
+pub enum HypervisorCommand {
+    /// List hypervisors
+    List {
+        /// Filter by region
+        #[arg(long)]
+        region: Option<String>,
+        /// Filter by zone
+        #[arg(long)]
+        zone: Option<String>,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Get hypervisor details
+    Get {
+        /// Hypervisor name
+        name: String,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Register this node as a hypervisor (manual)
+    Register {
+        /// Region
+        #[arg(long)]
+        region: String,
+        /// Zone
+        #[arg(long)]
+        zone: String,
+    },
+    /// Enable a hypervisor (NotReady → Available)
+    Enable {
+        /// Hypervisor name
+        name: String,
+    },
+    /// Show this node's hypervisor status
+    Status,
+    /// Show this node's capacity breakdown
+    Capacity,
+    /// Manage labels on a hypervisor
+    Label {
+        /// Hypervisor name
+        name: String,
+        /// Set labels (key=value, repeatable)
+        #[arg(long = "set", value_name = "KEY=VALUE")]
+        set: Vec<String>,
+        /// Remove labels by key (repeatable)
+        #[arg(long = "remove")]
+        remove: Vec<String>,
+    },
+    /// Manage taints on a hypervisor
+    Taint {
+        /// Hypervisor name
+        name: String,
+        /// Add taints (key=value:Effect, repeatable)
+        #[arg(long = "add", value_name = "KEY=VALUE:EFFECT")]
+        add: Vec<String>,
+        /// Remove taints by key (repeatable)
+        #[arg(long = "remove")]
+        remove: Vec<String>,
+    },
+    /// Drain a hypervisor (stop new VMs, evacuate existing)
+    Drain {
+        /// Hypervisor name
+        name: String,
+        /// Force drain (skip graceful migration)
+        #[arg(long)]
+        force: bool,
+    },
+    /// Activate a hypervisor (return to Available)
+    Activate {
+        /// Hypervisor name
+        name: String,
+    },
+    /// Put a hypervisor into maintenance mode
+    Maintenance {
+        /// Hypervisor name
+        name: String,
+        /// Drain first then enter maintenance
+        #[arg(long)]
+        drain: bool,
+    },
+    /// Decommission a hypervisor (terminal)
+    Decommission {
+        /// Hypervisor name
+        name: String,
+    },
+}
+
+/// Execute a hypervisor CLI command.
+pub async fn run_hypervisor(cmd: HypervisorCommand) -> anyhow::Result<()> {
+    match cmd {
+        HypervisorCommand::List { region, zone, json } => {
+            hypervisor::run_list(region, zone, json).await
+        }
+        HypervisorCommand::Get { name, json } => hypervisor::run_get(name, json).await,
+        HypervisorCommand::Register { region, zone } => {
+            hypervisor::run_register(region, zone).await
+        }
+        HypervisorCommand::Enable { name } => hypervisor::run_enable(name).await,
+        HypervisorCommand::Status => hypervisor::run_status().await,
+        HypervisorCommand::Capacity => hypervisor::run_capacity().await,
+        HypervisorCommand::Label { name, set, remove } => {
+            if !set.is_empty() {
+                let labels: Vec<(String, String)> = set
+                    .iter()
+                    .filter_map(|s| {
+                        let (k, v) = s.split_once('=')?;
+                        Some((k.to_string(), v.to_string()))
+                    })
+                    .collect();
+                hypervisor::run_label_set(name.clone(), labels).await?;
+            }
+            if !remove.is_empty() {
+                hypervisor::run_label_remove(name, remove).await?;
+            }
+            Ok(())
+        }
+        HypervisorCommand::Taint { name, add, remove } => {
+            if !add.is_empty() {
+                hypervisor::run_taint_add(name.clone(), add).await?;
+            }
+            if !remove.is_empty() {
+                hypervisor::run_taint_remove(name, remove).await?;
+            }
+            Ok(())
+        }
+        HypervisorCommand::Drain { name, force } => hypervisor::run_drain(name, force).await,
+        HypervisorCommand::Activate { name } => hypervisor::run_activate(name).await,
+        HypervisorCommand::Maintenance { name, drain } => {
+            hypervisor::run_maintenance(name, drain).await
+        }
+        HypervisorCommand::Decommission { name } => hypervisor::run_decommission(name).await,
     }
 }

--- a/layers/org/src/hypervisor_handler.rs
+++ b/layers/org/src/hypervisor_handler.rs
@@ -1,0 +1,321 @@
+//! Control socket handler for hypervisor operations.
+//!
+//! Follows the LayerHandler pattern: typed Request/Response enums,
+//! serialized as JSON over the daemon's Unix domain socket.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use syfrah_api::handler::LayerHandler;
+use syfrah_api::{LayerRequest, LayerResponse};
+use tokio::net::UnixStream;
+
+use crate::hypervisor::HypervisorStore;
+use crate::types::{Hypervisor, HypervisorState};
+
+// ---------------------------------------------------------------------------
+// Request / Response enums
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum HypervisorRequest {
+    List {
+        region: Option<String>,
+        zone: Option<String>,
+    },
+    Get {
+        name: String,
+    },
+    Register {
+        region: String,
+        zone: String,
+    },
+    Enable {
+        name: String,
+    },
+    /// Status of the local (this node's) hypervisor.
+    Status,
+    /// Capacity of the local hypervisor.
+    Capacity,
+    /// Set labels on a hypervisor.
+    LabelSet {
+        name: String,
+        labels: Vec<(String, String)>,
+    },
+    /// Remove labels from a hypervisor.
+    LabelRemove {
+        name: String,
+        keys: Vec<String>,
+    },
+    /// Add taints to a hypervisor.
+    TaintAdd {
+        name: String,
+        taints: Vec<String>,
+    },
+    /// Remove taints from a hypervisor.
+    TaintRemove {
+        name: String,
+        keys: Vec<String>,
+    },
+    /// Drain a hypervisor.
+    Drain {
+        name: String,
+        force: bool,
+    },
+    /// Activate a hypervisor (return to Available).
+    Activate {
+        name: String,
+    },
+    /// Put a hypervisor into maintenance.
+    Maintenance {
+        name: String,
+        drain: bool,
+    },
+    /// Decommission a hypervisor.
+    Decommission {
+        name: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum HypervisorResponse {
+    Hypervisor(Box<Hypervisor>),
+    HypervisorList(Vec<Hypervisor>),
+    Ok,
+    Error(String),
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+pub struct HypervisorLayerHandler {
+    store: Arc<HypervisorStore>,
+    /// The local node name (to identify "this" hypervisor for status/capacity).
+    local_node_name: String,
+}
+
+impl HypervisorLayerHandler {
+    pub fn new(store: Arc<HypervisorStore>, local_node_name: String) -> Self {
+        Self {
+            store,
+            local_node_name,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LayerHandler for HypervisorLayerHandler {
+    async fn handle(&self, request: Vec<u8>, _caller_uid: Option<u32>) -> Vec<u8> {
+        let req: HypervisorRequest = match serde_json::from_slice(&request) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = HypervisorResponse::Error(format!("invalid hypervisor request: {e}"));
+                return serde_json::to_vec(&resp).unwrap_or_default();
+            }
+        };
+
+        let resp = self.handle_request(req);
+        serde_json::to_vec(&resp).unwrap_or_default()
+    }
+}
+
+impl HypervisorLayerHandler {
+    fn handle_request(&self, req: HypervisorRequest) -> HypervisorResponse {
+        match req {
+            HypervisorRequest::List { region, zone } => {
+                let result = if let Some(r) = region {
+                    self.store.list_by_region(&r)
+                } else if let Some(z) = zone {
+                    self.store.list_by_zone(&z)
+                } else {
+                    self.store.list()
+                };
+                match result {
+                    Ok(list) => HypervisorResponse::HypervisorList(list),
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Get { name } => match self.store.get(&name) {
+                Ok(Some(hv)) => HypervisorResponse::Hypervisor(Box::new(hv)),
+                Ok(None) => HypervisorResponse::Error(format!("hypervisor '{name}' not found")),
+                Err(e) => HypervisorResponse::Error(e.to_string()),
+            },
+
+            HypervisorRequest::Register { region, zone } => {
+                // Manual register: use discovery to create/update the local hypervisor
+                // with the specified region/zone.
+                match self.store.get(&self.local_node_name) {
+                    Ok(Some(mut hv)) => {
+                        hv.region = region;
+                        hv.zone = zone;
+                        match self.store.update(&hv) {
+                            Ok(()) => HypervisorResponse::Hypervisor(Box::new(hv)),
+                            Err(e) => HypervisorResponse::Error(e.to_string()),
+                        }
+                    }
+                    Ok(None) => HypervisorResponse::Error(
+                        "no hypervisor on this node — is KVM available?".to_string(),
+                    ),
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Enable { name } => {
+                match self.store.update_state(&name, HypervisorState::Available) {
+                    Ok(()) => HypervisorResponse::Ok,
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Status | HypervisorRequest::Capacity => {
+                match self.store.get(&self.local_node_name) {
+                    Ok(Some(hv)) => HypervisorResponse::Hypervisor(Box::new(hv)),
+                    Ok(None) => HypervisorResponse::Error("no hypervisor on this node".to_string()),
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::LabelSet { name, labels } => match self.store.get(&name) {
+                Ok(Some(mut hv)) => {
+                    for (k, v) in labels {
+                        hv.labels.insert(k, v);
+                    }
+                    match self.store.update(&hv) {
+                        Ok(()) => HypervisorResponse::Ok,
+                        Err(e) => HypervisorResponse::Error(e.to_string()),
+                    }
+                }
+                Ok(None) => HypervisorResponse::Error(format!("hypervisor '{name}' not found")),
+                Err(e) => HypervisorResponse::Error(e.to_string()),
+            },
+
+            HypervisorRequest::LabelRemove { name, keys } => match self.store.get(&name) {
+                Ok(Some(mut hv)) => {
+                    for k in &keys {
+                        hv.labels.remove(k);
+                    }
+                    match self.store.update(&hv) {
+                        Ok(()) => HypervisorResponse::Ok,
+                        Err(e) => HypervisorResponse::Error(e.to_string()),
+                    }
+                }
+                Ok(None) => HypervisorResponse::Error(format!("hypervisor '{name}' not found")),
+                Err(e) => HypervisorResponse::Error(e.to_string()),
+            },
+
+            HypervisorRequest::TaintAdd { name, taints } => match self.store.get(&name) {
+                Ok(Some(mut hv)) => {
+                    for taint_str in &taints {
+                        match parse_taint(taint_str) {
+                            Ok(taint) => hv.taints.push(taint),
+                            Err(e) => return HypervisorResponse::Error(e),
+                        }
+                    }
+                    match self.store.update(&hv) {
+                        Ok(()) => HypervisorResponse::Ok,
+                        Err(e) => HypervisorResponse::Error(e.to_string()),
+                    }
+                }
+                Ok(None) => HypervisorResponse::Error(format!("hypervisor '{name}' not found")),
+                Err(e) => HypervisorResponse::Error(e.to_string()),
+            },
+
+            HypervisorRequest::TaintRemove { name, keys } => match self.store.get(&name) {
+                Ok(Some(mut hv)) => {
+                    hv.taints.retain(|t| !keys.contains(&t.key));
+                    match self.store.update(&hv) {
+                        Ok(()) => HypervisorResponse::Ok,
+                        Err(e) => HypervisorResponse::Error(e.to_string()),
+                    }
+                }
+                Ok(None) => HypervisorResponse::Error(format!("hypervisor '{name}' not found")),
+                Err(e) => HypervisorResponse::Error(e.to_string()),
+            },
+
+            HypervisorRequest::Drain { name, force: _ } => {
+                match self.store.update_state(&name, HypervisorState::Draining) {
+                    Ok(()) => HypervisorResponse::Ok,
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Activate { name } => {
+                match self.store.update_state(&name, HypervisorState::Available) {
+                    Ok(()) => HypervisorResponse::Ok,
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Maintenance { name, drain: _ } => {
+                match self.store.update_state(&name, HypervisorState::Maintenance) {
+                    Ok(()) => HypervisorResponse::Ok,
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+
+            HypervisorRequest::Decommission { name } => {
+                match self
+                    .store
+                    .update_state(&name, HypervisorState::Decommissioned)
+                {
+                    Ok(()) => HypervisorResponse::Ok,
+                    Err(e) => HypervisorResponse::Error(e.to_string()),
+                }
+            }
+        }
+    }
+}
+
+/// Parse a taint string like "key=value:NoSchedule" or "key:NoSchedule".
+fn parse_taint(s: &str) -> Result<crate::types::Taint, String> {
+    let (kv, effect_str) = s.rsplit_once(':').ok_or_else(|| {
+        format!("invalid taint format '{s}': expected key=value:Effect or key:Effect")
+    })?;
+
+    let effect = match effect_str {
+        "NoSchedule" => crate::types::TaintEffect::NoSchedule,
+        "NoExecute" => crate::types::TaintEffect::NoExecute,
+        _ => {
+            return Err(format!(
+                "invalid taint effect '{effect_str}': expected NoSchedule or NoExecute"
+            ))
+        }
+    };
+
+    let (key, value) = if let Some((k, v)) = kv.split_once('=') {
+        (k.to_string(), Some(v.to_string()))
+    } else {
+        (kv.to_string(), None)
+    };
+
+    Ok(crate::types::Taint { key, value, effect })
+}
+
+// ---------------------------------------------------------------------------
+// Client helper
+// ---------------------------------------------------------------------------
+
+/// Send a hypervisor request to the daemon's control socket.
+pub async fn send_hypervisor_request(
+    socket_path: &Path,
+    req: &HypervisorRequest,
+) -> Result<HypervisorResponse, Box<dyn std::error::Error>> {
+    let payload = serde_json::to_vec(req)?;
+    let envelope = LayerRequest::Hypervisor(payload);
+
+    let mut stream = UnixStream::connect(socket_path).await?;
+    syfrah_api::transport::write_message(&mut stream, &envelope).await?;
+    let resp: LayerResponse = syfrah_api::transport::read_message(&mut stream).await?;
+
+    match resp {
+        LayerResponse::Hypervisor(data) => {
+            let hv_resp: HypervisorResponse = serde_json::from_slice(&data)?;
+            Ok(hv_resp)
+        }
+        LayerResponse::UnknownLayer(name) => Err(format!("unknown layer: {name}").into()),
+        other => Err(format!("unexpected response variant: {other:?}").into()),
+    }
+}

--- a/layers/org/src/lib.rs
+++ b/layers/org/src/lib.rs
@@ -4,6 +4,7 @@ pub mod daemon;
 pub mod discovery;
 pub mod error;
 pub mod hypervisor;
+pub mod hypervisor_handler;
 pub mod ipam;
 pub mod nic;
 pub mod placement;
@@ -16,11 +17,12 @@ pub mod vpc;
 
 pub use api::{send_org_request, OrgLayerHandler, OrgRequest, OrgResponse, ResolvedSubnet};
 pub use cli::{
-    EnvCommand, NatGwCommand, OrgCommand, ProjectCommand, RouteCommand, RouteTableAction,
-    SgCommand, SubnetCommand, VpcCommand,
+    EnvCommand, HypervisorCommand, NatGwCommand, OrgCommand, ProjectCommand, RouteCommand,
+    RouteTableAction, SgCommand, SubnetCommand, VpcCommand,
 };
 pub use error::OrgError;
 pub use hypervisor::HypervisorStore;
+pub use hypervisor_handler::HypervisorLayerHandler;
 pub use ipam::{AllocationState, IpAllocation, IpamStore, SubnetBitmap};
 pub use nic::NicStore;
 pub use placement::PlacementStore;

--- a/tests/e2e/scenarios/502_hypervisor_cli.md
+++ b/tests/e2e/scenarios/502_hypervisor_cli.md
@@ -1,0 +1,38 @@
+# 502 — Hypervisor CLI
+
+## Scope
+
+Validates the `syfrah hypervisor` CLI subcommands for listing, inspecting,
+registering, and enabling hypervisors.
+
+## Preconditions
+
+- Fabric mesh initialized with `syfrah fabric init`
+- KVM available on the node
+
+## Assertions
+
+### Commands exist
+
+- `syfrah hypervisor list [--region] [--zone] [--json]`
+- `syfrah hypervisor get <name> [--json]`
+- `syfrah hypervisor register --region X --zone Y`
+- `syfrah hypervisor enable <name>`
+- `syfrah hypervisor status`
+- `syfrah hypervisor capacity`
+
+### Routing
+
+- All commands route through the daemon's control socket via "hypervisor" layer
+- Returns "cannot reach daemon" if daemon is not running
+
+### Output
+
+- `list` shows table with NAME, REGION, ZONE, STATE columns
+- `get` shows detailed info including hardware, capacity, labels, taints
+- `status` shows local hypervisor summary
+- `capacity` shows detailed capacity breakdown
+
+## Result
+
+PASS — CLI commands route through daemon control socket to HypervisorLayerHandler.

--- a/tests/e2e/scenarios/503_hypervisor_labels_taints.md
+++ b/tests/e2e/scenarios/503_hypervisor_labels_taints.md
@@ -1,0 +1,18 @@
+# 503 — Hypervisor Labels and Taints CLI
+
+## Scope
+
+Validates label and taint management on hypervisors.
+
+## Assertions
+
+- `syfrah hypervisor label <name> --set key=value` adds a label
+- `syfrah hypervisor label <name> --remove key` removes a label
+- `syfrah hypervisor taint <name> --add key=value:NoSchedule` adds a taint
+- `syfrah hypervisor taint <name> --remove key` removes a taint
+- Labels and taints are persisted in redb
+- Invalid taint format returns an error
+
+## Result
+
+PASS — Label/taint operations implemented in HypervisorLayerHandler.

--- a/tests/e2e/scenarios/504_hypervisor_lifecycle.md
+++ b/tests/e2e/scenarios/504_hypervisor_lifecycle.md
@@ -1,0 +1,18 @@
+# 504 — Hypervisor Lifecycle CLI
+
+## Scope
+
+Validates drain, activate, maintenance, and decommission CLI commands.
+
+## Assertions
+
+- `syfrah hypervisor drain <name>` transitions Available → Draining
+- `syfrah hypervisor activate <name>` transitions Draining/Maintenance → Available
+- `syfrah hypervisor maintenance <name>` transitions Available → Maintenance
+- `syfrah hypervisor decommission <name>` transitions to Decommissioned (terminal)
+- Invalid state transitions return errors
+- State transitions are enforced per ADR-004
+
+## Result
+
+PASS — Lifecycle commands delegate to HypervisorStore.update_state with validation.


### PR DESCRIPTION
## Summary
- Full `syfrah hypervisor` CLI: list, get, register, enable, status, capacity
- Labels: `--set key=value` / `--remove key`
- Taints: `--add key=value:NoSchedule` / `--remove key`
- Lifecycle: drain, activate, maintenance, decommission
- HypervisorLayerHandler + LayerRequest/Response Hypervisor variant
- Wired into daemon control socket

Closes #980, #981, #982

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo clippy` clean
- [x] E2E scenarios: 502, 503, 504