### PR TITLE
fix(overlay): use idempotent nft add instead of create

### DIFF
--- a/layers/overlay/src/nft.rs
+++ b/layers/overlay/src/nft.rs
@@ -34,15 +34,15 @@ const PEERING_PORT: u16 = 51821;
 /// `forward` chain if they do not already exist.
 pub fn generate_table_setup() -> String {
     let mut buf = String::new();
-    writeln!(buf, "create table inet {TABLE_NAME}").unwrap();
+    writeln!(buf, "add table inet {TABLE_NAME}").unwrap();
     writeln!(
         buf,
-        "create chain inet {TABLE_NAME} {CHAIN_NAME} {{ type filter hook forward priority 0; policy accept; }}"
+        "add chain inet {TABLE_NAME} {CHAIN_NAME} {{ type filter hook forward priority 0; policy accept; }}"
     )
     .unwrap();
     writeln!(
         buf,
-        "create chain inet {TABLE_NAME} {INPUT_CHAIN} {{ type filter hook input priority 0; policy accept; }}"
+        "add chain inet {TABLE_NAME} {INPUT_CHAIN} {{ type filter hook input priority 0; policy accept; }}"
     )
     .unwrap();
     buf
@@ -351,8 +351,8 @@ mod tests {
     #[test]
     fn table_setup_is_idempotent() {
         let setup = generate_table_setup();
-        assert!(setup.contains("create table inet syfrah"));
-        assert!(setup.contains("create chain inet syfrah forward"));
+        assert!(setup.contains("add table inet syfrah"));
+        assert!(setup.contains("add chain inet syfrah forward"));
     }
 
     #[test]
@@ -493,9 +493,9 @@ mod tests {
     fn infra_protection_includes_table_setup() {
         let rules = generate_infra_protection();
         // Must include table and both chains
-        assert!(rules.contains("create table inet syfrah"));
-        assert!(rules.contains("create chain inet syfrah forward"));
-        assert!(rules.contains("create chain inet syfrah input"));
+        assert!(rules.contains("add table inet syfrah"));
+        assert!(rules.contains("add chain inet syfrah forward"));
+        assert!(rules.contains("add chain inet syfrah input"));
     }
 
     #[test]

--- a/layers/overlay/src/sg_nft.rs
+++ b/layers/overlay/src/sg_nft.rs
@@ -206,7 +206,7 @@ const SG_TABLE: &str = "syfrah_sg";
 /// Build a complete nftables ruleset for a VM's security groups.
 ///
 /// The ruleset includes:
-/// 1. Table creation (`create table inet syfrah_sg` -- idempotent)
+/// 1. Table creation (`add table inet syfrah_sg` -- idempotent)
 /// 2. Named sets for any SG references
 /// 3. Ingress chain (`vm_{hash}_in`)
 /// 4. Egress chain (`vm_{hash}_out`)
@@ -220,7 +220,7 @@ pub fn build_sg_ruleset(
     let mut buf = String::new();
 
     // Idempotent table creation.
-    writeln!(buf, "create table inet {SG_TABLE}").unwrap();
+    writeln!(buf, "add table inet {SG_TABLE}").unwrap();
 
     // Named sets for SG references.
     for (sg_name, ips) in sg_ip_map {
@@ -904,7 +904,7 @@ mod tests {
         )];
         let sg_map = std::collections::HashMap::new();
         let ruleset = build_sg_ruleset(&nic, &rules, &sg_map);
-        assert!(ruleset.contains("create table inet syfrah_sg"));
+        assert!(ruleset.contains("add table inet syfrah_sg"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace all `nft create table` with `nft add table` and `nft create chain` with `nft add chain` in overlay layer
- `add` is idempotent (succeeds if object exists), `create` fails if exists — causing failures on daemon restart

Closes #1003