### PR TITLE
fix(compute): populate hypervisor/region/zone in vm get

### DIFF
--- a/layers/compute/src/control.rs
+++ b/layers/compute/src/control.rs
@@ -133,9 +133,9 @@ fn vm_status_to_json(s: &crate::types::VmStatus) -> serde_json::Value {
         "subnet": s.subnet,
         "vpc": s.vpc,
         "security_groups": s.security_groups,
-        "hypervisor_id": serde_json::Value::Null,
-        "region": serde_json::Value::Null,
-        "zone": serde_json::Value::Null,
+        "hypervisor_id": s.hypervisor_id,
+        "region": s.region,
+        "zone": s.zone,
     })
 }
 

--- a/layers/compute/src/handler.rs
+++ b/layers/compute/src/handler.rs
@@ -124,6 +124,12 @@ pub struct VmResponse {
     pub vpc: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub security_groups: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hypervisor_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zone: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -162,6 +168,9 @@ fn vm_status_to_response(s: &VmStatus) -> VmResponse {
         subnet: s.subnet.clone(),
         vpc: s.vpc.clone(),
         security_groups: s.security_groups.clone(),
+        hypervisor_id: s.hypervisor_id.clone(),
+        region: s.region.clone(),
+        zone: s.zone.clone(),
     }
 }
 
@@ -341,6 +350,9 @@ async fn stop_vm(State(mgr): State<SharedManager>, Path(id): Path<String>) -> im
                     subnet: None,
                     vpc: None,
                     security_groups: vec![],
+                    hypervisor_id: None,
+                    region: None,
+                    zone: None,
                 }),
             )
                 .into_response(),
@@ -674,6 +686,9 @@ mod tests {
             subnet: Some("frontend".to_string()),
             vpc: Some("default".to_string()),
             security_groups: vec!["web-sg".to_string()],
+            hypervisor_id: Some("hv-1".to_string()),
+            region: Some("eu-west".to_string()),
+            zone: Some("az-1".to_string()),
         };
         let resp = vm_status_to_response(&status);
         assert_eq!(resp.id, "test-vm");
@@ -702,6 +717,9 @@ mod tests {
             subnet: None,
             vpc: None,
             security_groups: vec![],
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
         let resp = vm_status_to_response(&status);
         let json = serde_json::to_string(&resp).unwrap();

--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -237,6 +237,10 @@ pub struct VmManager {
     local_node: Option<String>,
     /// SG rule store for applying SG-based nftables rules during network setup.
     sg_rule_store: Option<Arc<syfrah_org::SgRuleStore>>,
+    /// Hypervisor store for looking up local hypervisor metadata (region, zone).
+    hypervisor_store: Option<Arc<syfrah_org::HypervisorStore>>,
+    /// Name of this node (used to look up the local hypervisor record).
+    local_node_name: Option<String>,
 }
 
 impl VmManager {
@@ -326,6 +330,8 @@ impl VmManager {
             placement_store: None,
             local_node: None,
             sg_rule_store: None,
+            hypervisor_store: None,
+            local_node_name: None,
         })
     }
 
@@ -371,6 +377,17 @@ impl VmManager {
     /// during VM network setup.
     pub fn set_sg_rule_store(&mut self, store: Arc<syfrah_org::SgRuleStore>) {
         self.sg_rule_store = Some(store);
+    }
+
+    /// Set the hypervisor store and local node name for populating
+    /// hypervisor_id, region, and zone on created VMs.
+    pub fn set_hypervisor_store(
+        &mut self,
+        store: Arc<syfrah_org::HypervisorStore>,
+        node_name: String,
+    ) {
+        self.hypervisor_store = Some(store);
+        self.local_node_name = Some(node_name);
     }
 
     /// Set the image catalog (e.g., after fetching from a remote endpoint).
@@ -894,7 +911,7 @@ impl VmManager {
             (None, None, None, None)
         };
 
-        let state = crate::runtime::VmRuntimeState {
+        let mut state = crate::runtime::VmRuntimeState {
             vm_id: spec.id.clone(),
             pid: handle.pid,
             socket_path: handle.runtime_dir.join("api.sock"),
@@ -923,7 +940,19 @@ impl VmManager {
             vpc: vm_vpc,
             security_groups: spec.security_groups.clone(),
             network_info: net_info,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
+
+        // Populate hypervisor metadata from the local hypervisor record.
+        if let (Some(hv_store), Some(node_name)) = (&self.hypervisor_store, &self.local_node_name) {
+            if let Ok(Some(hv)) = hv_store.get(node_name) {
+                state.hypervisor_id = Some(hv.name.clone());
+                state.region = Some(hv.region.clone());
+                state.zone = Some(hv.zone.clone());
+            }
+        }
 
         let status = state.to_status(now);
         let image_name = spec.image.clone();
@@ -1290,6 +1319,9 @@ impl VmManager {
                     vpc: None,
                     security_groups: vec![],
                     network_info: None,
+                    hypervisor_id: None,
+                    region: None,
+                    zone: None,
                 };
                 map.insert(id, Arc::new(Mutex::new(state)));
                 recovered_count += 1;

--- a/layers/compute/src/process.rs
+++ b/layers/compute/src/process.rs
@@ -728,6 +728,9 @@ pub(crate) async fn spawn_vm_inner(
         vpc: None,
         security_groups: vec![],
         network_info: None,
+        hypervisor_id: None,
+        region: None,
+        zone: None,
     })
 }
 
@@ -1311,6 +1314,9 @@ pub async fn reconnect(base_dir: &Path, event_tx: broadcast::Sender<VmEvent>) ->
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         events::emit(
@@ -1703,6 +1709,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1740,6 +1749,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1777,6 +1789,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -1816,6 +1831,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -2031,6 +2049,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));
@@ -2174,6 +2195,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = delete_vm(&mut state, &client, &dir).await;
@@ -2231,6 +2255,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let result = kill_vm(&mut state, &client, &dir).await;
@@ -2353,6 +2380,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
 
         let vm_arc = Arc::new(Mutex::new(state));

--- a/layers/compute/src/runtime.rs
+++ b/layers/compute/src/runtime.rs
@@ -57,6 +57,12 @@ pub(crate) struct VmRuntimeState {
     pub(crate) security_groups: Vec<String>,
     /// Network metadata for teardown on delete. None if VM has no networking.
     pub(crate) network_info: Option<NetworkInfo>,
+    /// Hypervisor name/id this VM is running on.
+    pub(crate) hypervisor_id: Option<String>,
+    /// Region of the hypervisor.
+    pub(crate) region: Option<String>,
+    /// Zone of the hypervisor.
+    pub(crate) zone: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -103,6 +109,9 @@ impl VmRuntimeState {
             subnet: self.subnet.clone(),
             vpc: self.vpc.clone(),
             security_groups: self.security_groups.clone(),
+            hypervisor_id: self.hypervisor_id.clone(),
+            region: self.region.clone(),
+            zone: self.zone.clone(),
         }
     }
 }
@@ -134,6 +143,9 @@ mod tests {
             vpc: None,
             security_groups: vec![],
             network_info: None,
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         }
     }
 

--- a/layers/compute/src/types.rs
+++ b/layers/compute/src/types.rs
@@ -149,6 +149,15 @@ pub struct VmStatus {
     /// Security groups attached to the VM's NIC.
     #[serde(default)]
     pub security_groups: Vec<String>,
+    /// Hypervisor this VM is running on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hypervisor_id: Option<String>,
+    /// Region of the hypervisor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// Availability zone of the hypervisor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zone: Option<String>,
 }
 
 /// Observable events emitted to forge via a broadcast channel.
@@ -327,6 +336,9 @@ mod tests {
             subnet: None,
             vpc: None,
             security_groups: vec![],
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
         let json = serde_json::to_string(&status).unwrap();
         let back: VmStatus = serde_json::from_str(&json).unwrap();
@@ -435,6 +447,9 @@ mod tests {
             subnet: Some("frontend".to_string()),
             vpc: Some("default".to_string()),
             security_groups: vec![],
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["ip"].as_str(), Some("10.1.1.3"));
@@ -455,6 +470,9 @@ mod tests {
             subnet: Some("database".to_string()),
             vpc: Some("default".to_string()),
             security_groups: vec![],
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["subnet"].as_str(), Some("database"));
@@ -475,6 +493,9 @@ mod tests {
             subnet: Some("frontend".to_string()),
             vpc: Some("prod-vpc".to_string()),
             security_groups: vec![],
+            hypervisor_id: None,
+            region: None,
+            zone: None,
         };
         let json_str = serde_json::to_string(&status).unwrap();
         let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1151,6 +1151,14 @@ pub async fn run_daemon(
                 };
                 let _ = net_ok;
 
+                // Wire the hypervisor store so VMs get hypervisor/region/zone
+                // metadata at creation time.
+                if let Ok(hv_db) = syfrah_state::LayerDb::open("hypervisor") {
+                    let hv_store = Arc::new(syfrah_org::HypervisorStore::new(hv_db));
+                    vm_manager.set_hypervisor_store(hv_store, my_record.name.clone());
+                    info!("compute: hypervisor store wired (region/zone in vm get)");
+                }
+
                 let vm_manager = Arc::new(vm_manager);
 
                 // Reconnect VMs that survived a daemon restart.


### PR DESCRIPTION
## Summary
- Add hypervisor_id, region, zone fields to VmRuntimeState, VmStatus, VmResponse
- Look up local hypervisor record at VM creation time and populate metadata
- Wire hypervisor store into VmManager during daemon init
- Both control socket JSON and HTTP API responses now include these fields

Closes #1007