### PR TITLE
Add route table enforcement endpoint to Forge API

### DIFF
--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -2388,4 +2388,118 @@ mod tests {
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(result["applied"], 0);
     }
+
+    #[tokio::test]
+    async fn blackhole_applied() {
+        // Blackhole routes are applied as nftables DROP rules.
+        // In test env nft binary may not exist — the handler still records errors.
+        let state = test_state_with_network();
+        let app = forge_router(state);
+
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/networks/routes/enforce")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"routes":[{"destination":"10.99.0.0/16","target_type":"blackhole"}]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // nft may or may not be available — either applied==1 or errors==1.
+        let applied = result["applied"].as_u64().unwrap_or(0);
+        let errors = result["errors"].as_array().map(|a| a.len()).unwrap_or(0);
+        assert_eq!(applied as usize + errors, 1, "exactly one route processed");
+    }
+
+    #[tokio::test]
+    async fn target_validation_peering() {
+        let state = test_state_with_network();
+        let app = forge_router(state);
+
+        // Peering route with target_id succeeds validation.
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/networks/routes/enforce")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"routes":[{"destination":"10.4.0.0/24","target_type":"peering","target_id":"peer-abc"}]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["applied"], 1);
+        assert_eq!(result["errors"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn target_validation_peering_missing_id() {
+        let state = test_state_with_network();
+        let app = forge_router(state);
+
+        // Peering route without target_id fails validation.
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/networks/routes/enforce")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"routes":[{"destination":"10.4.0.0/24","target_type":"peering"}]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 500);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["applied"], 0);
+    }
+
+    #[tokio::test]
+    async fn inactive_target_logged() {
+        // NAT GW exists but is not Active — route should fail with descriptive error.
+        let state = test_state_with_network();
+
+        // Insert a NAT GW in Pending state (not Active).
+        {
+            let mut registry = state.nat_gw_registry.lock().unwrap();
+            registry.insert(
+                "nat-pending-1".to_string(),
+                NatGwRecord {
+                    id: "nat-pending-1".to_string(),
+                    bridge: "syfb-12345678".to_string(),
+                    subnet_cidr: "10.5.0.0/24".to_string(),
+                    state: NatGwState::Pending,
+                },
+            );
+        }
+
+        let app = forge_router(state);
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/networks/routes/enforce")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"routes":[{"destination":"10.5.0.0/24","target_type":"nat-gw","target_id":"nat-pending-1"}]}"#,
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 500);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["applied"], 0);
+        let err_msg = result["errors"][0]["error"].as_str().unwrap();
+        assert!(
+            err_msg.contains("not Active"),
+            "error should mention inactive state: {err_msg}"
+        );
+    }
 }

--- a/tests/e2e/scenarios/414_forge_route_enforce.md
+++ b/tests/e2e/scenarios/414_forge_route_enforce.md
@@ -3,7 +3,8 @@
 ## Objective
 
 - POST /v1/networks/routes/enforce applies blackhole routes as nftables DROP
-- Validates route targets (NAT GW must be active, peering must have target_id)
+- Validates route targets (NAT GW must be Active, peering must have target_id)
+- Inactive NAT GW targets produce descriptive errors
 - Unknown target types are rejected with errors
 - Partial success: some routes may succeed while others fail
 
@@ -44,19 +45,78 @@ nft list table inet syfrah_routes 2>/dev/null
 
 **Expected:** Contains a DROP rule for 10.99.0.0/24.
 
-### 4. Enforce route with invalid NAT GW target
+### 4. Create NAT GW for target validation
+
+```bash
+BRIDGE=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/bridges \
+  -H 'Content-Type: application/json' \
+  -d '{"vpc_id": "vpc-route-test"}' | jq -r '.bridge_name')
+
+NAT_RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/nat-gw \
+  -H 'Content-Type: application/json' \
+  -d "{\"bridge\":\"$BRIDGE\",\"subnet_cidr\":\"10.1.0.0/24\"}")
+NAT_ID=$(echo "$NAT_RESULT" | jq -r '.id')
+echo "NAT GW: $NAT_ID"
+```
+
+### 5. Enforce route with valid Active NAT GW target
 
 ```bash
 RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/routes/enforce \
   -H 'Content-Type: application/json' \
-  -d '{"routes":[{"destination":"10.2.0.0/24","target_type":"nat-gw","target_id":"nat-nonexistent"}]}')
+  -d "{\"routes\":[{\"destination\":\"10.2.0.0/24\",\"target_type\":\"nat-gw\",\"target_id\":\"$NAT_ID\"}]}")
+echo "$RESULT"
+```
+
+**Expected:** HTTP 200, `applied: 1`.
+
+### 6. Enforce route with non-existent NAT GW target
+
+```bash
+RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/routes/enforce \
+  -H 'Content-Type: application/json' \
+  -d '{"routes":[{"destination":"10.3.0.0/24","target_type":"nat-gw","target_id":"nat-nonexistent"}]}')
 echo "$RESULT"
 ```
 
 **Expected:** `applied: 0`, `errors` array with "NAT GW not found".
 
+### 7. Enforce peering route with target_id
+
+```bash
+RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/routes/enforce \
+  -H 'Content-Type: application/json' \
+  -d '{"routes":[{"destination":"10.4.0.0/24","target_type":"peering","target_id":"peer-abc"}]}')
+echo "$RESULT"
+```
+
+**Expected:** HTTP 200, `applied: 1`.
+
+### 8. Enforce peering route without target_id
+
+```bash
+RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/routes/enforce \
+  -H 'Content-Type: application/json' \
+  -d '{"routes":[{"destination":"10.5.0.0/24","target_type":"peering"}]}')
+echo "$RESULT"
+```
+
+**Expected:** `applied: 0`, error mentions "requires target_id".
+
+### 9. Enforce route with unknown target type
+
+```bash
+RESULT=$(curl -s -X POST http://[$FORGE_IP]:7100/v1/networks/routes/enforce \
+  -H 'Content-Type: application/json' \
+  -d '{"routes":[{"destination":"10.6.0.0/24","target_type":"invalid"}]}')
+echo "$RESULT"
+```
+
+**Expected:** `applied: 0`, error mentions "unknown target_type".
+
 ## Cleanup
 
 ```bash
+nft delete table inet syfrah_routes 2>/dev/null
 syfrah fabric stop; sleep 2
 ```


### PR DESCRIPTION
## Summary

- Add POST /v1/networks/routes/enforce for route table enforcement
- Blackhole routes applied as nftables DROP rules in syfrah_routes table
- Validates NAT GW targets are Active before accepting routes
- Validates peering targets have target_id
- Reports applied count and errors for partial success
- Unit tests: enforce_routes_unavailable, validates_nat_gw_target, unknown_target_type

Closes #950