### PR TITLE
Add atomic reservation system with expiry

### DIFF
--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -354,6 +354,38 @@ async fn capacity_handler(State(state): State<Arc<ForgeState>>) -> impl IntoResp
     }
 }
 
+/// GET /v1/hypervisor/reservations — list active resource reservations.
+async fn reservations_handler(State(state): State<Arc<ForgeState>>) -> impl IntoResponse {
+    if let Some(ref cap) = state.capacity {
+        let active = cap.list_reservations();
+        let entries: Vec<serde_json::Value> = active
+            .iter()
+            .map(|(id, r)| {
+                serde_json::json!({
+                    "id": id,
+                    "vcpus": r.vcpus,
+                    "memory_mb": r.memory_mb,
+                    "age_secs": r.created_at.elapsed().as_secs(),
+                })
+            })
+            .collect();
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "reservations": entries,
+                "count": entries.len(),
+            })),
+        )
+    } else {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(
+                serde_json::json!({"code": "FORGE_CAPACITY_UNAVAILABLE", "message": "capacity tracker not initialized"}),
+            ),
+        )
+    }
+}
+
 /// GET /v1/hypervisor/metrics (alias: /v1/node/metrics)
 async fn metrics_handler(State(state): State<Arc<ForgeState>>) -> impl IntoResponse {
     let uptime = state.started_at.elapsed().as_secs();
@@ -446,9 +478,11 @@ async fn create_instance_handler(
     State(state): State<Arc<ForgeState>>,
     Json(req): Json<CreateInstanceRequest>,
 ) -> impl IntoResponse {
-    // Admission control: check capacity before anything else.
+    // Admission control: atomic check-and-reserve to prevent double-booking
+    // under concurrent creates. The reservation expires after 60s if creation
+    // doesn't complete. On success, reservation is converted to allocation.
     if let Some(ref capacity) = state.capacity {
-        if !capacity.can_admit(req.vcpus, req.memory_mb as u64) {
+        if !capacity.try_reserve(&req.name, req.vcpus, req.memory_mb as u64) {
             return (
                 StatusCode::CONFLICT,
                 Json(serde_json::json!({
@@ -460,7 +494,6 @@ async fn create_instance_handler(
                 })),
             );
         }
-        capacity.reserve(&req.name, req.vcpus, req.memory_mb as u64);
     }
 
     let Some(ref vm_manager) = state.vm_manager else {
@@ -1720,6 +1753,7 @@ pub fn forge_router(state: Arc<ForgeState>) -> Router {
         .route("/v1/hypervisor/health", get(health_handler))
         .route("/v1/hypervisor/status", get(status_handler))
         .route("/v1/hypervisor/capacity", get(capacity_handler))
+        .route("/v1/hypervisor/reservations", get(reservations_handler))
         .route("/v1/hypervisor/metrics", get(metrics_handler))
         .route("/v1/hypervisor/resources", get(resources_handler))
         // -- Deprecated /v1/node/* aliases --

--- a/layers/forge/src/capacity.rs
+++ b/layers/forge/src/capacity.rs
@@ -208,6 +208,56 @@ impl CapacityTracker {
         self.available_vcpus() >= vcpus && self.available_memory_mb() >= memory_mb
     }
 
+    /// Atomically check-and-reserve: returns true if admitted, false if rejected.
+    /// This prevents double-booking under concurrent creates by holding the lock
+    /// across the check+reserve operation.
+    pub fn try_reserve(&self, id: &str, vcpus: u32, memory_mb: u64) -> bool {
+        let mut reservations = self.reservations.lock().unwrap();
+        // Expire old reservations first
+        reservations.retain(|_, r| r.created_at.elapsed() < RESERVATION_EXPIRY);
+
+        // Calculate available with lock held
+        let used_v = *self.used_vcpus.lock().unwrap();
+        let used_m = *self.used_memory_mb.lock().unwrap();
+        let reserved_v: u32 = reservations.values().map(|r| r.vcpus).sum();
+        let reserved_m: u64 = reservations.values().map(|r| r.memory_mb).sum();
+
+        let avail_v = self.total_vcpus.saturating_sub(used_v + reserved_v);
+        let avail_m = self.total_memory_mb.saturating_sub(used_m + reserved_m);
+
+        if avail_v >= vcpus && avail_m >= memory_mb {
+            reservations.insert(
+                id.to_string(),
+                Reservation {
+                    vcpus,
+                    memory_mb,
+                    created_at: Instant::now(),
+                },
+            );
+            true
+        } else {
+            false
+        }
+    }
+
+    /// List active (non-expired) reservations.
+    pub fn list_reservations(&self) -> Vec<(String, Reservation)> {
+        let reservations = self.reservations.lock().unwrap();
+        reservations
+            .iter()
+            .filter(|(_, r)| r.created_at.elapsed() < RESERVATION_EXPIRY)
+            .map(|(id, r)| (id.clone(), r.clone()))
+            .collect()
+    }
+
+    /// Purge expired reservations, returning the count of purged entries.
+    pub fn purge_expired(&self) -> usize {
+        let mut reservations = self.reservations.lock().unwrap();
+        let before = reservations.len();
+        reservations.retain(|_, r| r.created_at.elapsed() < RESERVATION_EXPIRY);
+        before - reservations.len()
+    }
+
     /// Reserve resources for an upcoming creation (60s expiry).
     pub fn reserve(&self, id: &str, vcpus: u32, memory_mb: u64) {
         let mut reservations = self.reservations.lock().unwrap();
@@ -510,5 +560,75 @@ mod tests {
         tracker.commit("vm-1", 1, 2048);
         assert_eq!(tracker.used_vcpus(), 1);
         assert_eq!(tracker.used_memory_mb(), 2048);
+    }
+
+    #[test]
+    fn try_reserve_atomic_prevents_double_booking() {
+        let tracker = CapacityTracker::with_capacity(4, 8192);
+
+        // First reservation succeeds
+        assert!(tracker.try_reserve("vm-1", 2, 4096));
+        // Second succeeds (still room)
+        assert!(tracker.try_reserve("vm-2", 2, 4096));
+        // Third fails — no room left
+        assert!(!tracker.try_reserve("vm-3", 1, 1024));
+
+        // After committing one, room is still taken (committed, not reserved)
+        tracker.commit("vm-1", 2, 4096);
+        // Still no room because vm-2 reservation is active
+        assert!(!tracker.try_reserve("vm-4", 1, 1024));
+    }
+
+    #[test]
+    fn list_reservations_shows_active() {
+        let tracker = CapacityTracker::with_capacity(8, 16384);
+        tracker.reserve("vm-1", 2, 4096);
+        tracker.reserve("vm-2", 1, 2048);
+
+        let active = tracker.list_reservations();
+        assert_eq!(active.len(), 2);
+    }
+
+    #[test]
+    fn purge_expired_clears_old() {
+        let tracker = CapacityTracker::with_capacity(8, 16384);
+
+        // Insert an expired reservation manually
+        {
+            let mut reservations = tracker.reservations.lock().unwrap();
+            reservations.insert(
+                "old-vm".to_string(),
+                Reservation {
+                    vcpus: 4,
+                    memory_mb: 8192,
+                    created_at: Instant::now() - Duration::from_secs(120),
+                },
+            );
+        }
+
+        let purged = tracker.purge_expired();
+        assert_eq!(purged, 1);
+        assert!(tracker.list_reservations().is_empty());
+    }
+
+    #[test]
+    fn try_reserve_expires_stale_before_check() {
+        let tracker = CapacityTracker::with_capacity(4, 8192);
+
+        // Fill with an expired reservation
+        {
+            let mut reservations = tracker.reservations.lock().unwrap();
+            reservations.insert(
+                "expired-vm".to_string(),
+                Reservation {
+                    vcpus: 4,
+                    memory_mb: 8192,
+                    created_at: Instant::now() - Duration::from_secs(120),
+                },
+            );
+        }
+
+        // try_reserve should succeed because expired reservation is purged first
+        assert!(tracker.try_reserve("new-vm", 4, 8192));
     }
 }

--- a/tests/e2e/scenarios/421_forge_reservation.md
+++ b/tests/e2e/scenarios/421_forge_reservation.md
@@ -1,0 +1,96 @@
+# Test: Forge reservation system with expiry
+
+## Objective
+
+Verify the reservation system prevents double-booking under concurrent creates:
+- Resources are reserved atomically during admission
+- Reservations expire after 60 seconds if creation doesn't complete
+- Successful creation converts reservation to allocation
+- Failed creation releases reservation
+
+## Prerequisites
+
+- A test server with `syfrah` installed and in PATH
+- The syfrah daemon running with a mesh initialized and hypervisor registered
+
+## Steps
+
+### 1. Initialize
+
+```bash
+syfrah fabric stop 2>/dev/null; sleep 2
+rm -rf ~/.syfrah/*.redb ~/.syfrah/state.json
+syfrah fabric init --name test --node-name n1 --endpoint $(hostname -I | awk '{print $1}'):51820
+sleep 3
+syfrah hypervisor register --region eu-west --zone az-1
+syfrah hypervisor enable n1
+FORGE_IP=$(ip -6 addr show syfrah0 | grep 'inet6 fd' | awk '{print $2}' | cut -d/ -f1 | head -1)
+```
+
+### 2. Check initial reservations (should be empty)
+
+```bash
+curl -s http://[$FORGE_IP]:7100/v1/hypervisor/reservations | python3 -m json.tool
+```
+
+**Expected:** `{"reservations": [], "count": 0}`
+
+### 3. Create a VM and observe reservation flow
+
+```bash
+syfrah org create acme
+syfrah project create backend --org acme
+syfrah env create prod --project backend --org acme
+syfrah subnet create web --env prod --project backend --org acme
+syfrah nat-gw create main-gw --vpc acme-backend-default --subnet web
+
+# Create VM — reservation is made during creation
+syfrah compute vm create --name res-test --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme --ssh-key ~/.ssh/id_ed25519.pub
+sleep 15
+
+# After creation completes, reservation should be converted to allocation
+curl -s http://[$FORGE_IP]:7100/v1/hypervisor/reservations | python3 -m json.tool
+```
+
+**Expected:** Reservations list is empty (reservation was committed to allocation).
+
+### 4. Verify capacity reflects allocation
+
+```bash
+curl -s http://[$FORGE_IP]:7100/v1/hypervisor/capacity | python3 -m json.tool
+```
+
+**Expected:** `used_vcpus >= 1`, `used_memory_mb >= 512`.
+
+### 5. Double-booking prevention
+
+Try creating VMs that exceed capacity. The second should be rejected.
+
+```bash
+AVAIL=$(curl -s http://[$FORGE_IP]:7100/v1/hypervisor/capacity | python3 -c 'import sys,json; print(json.load(sys.stdin).get("available_vcpus",0))')
+echo "Available vCPUs: $AVAIL"
+
+# Request more than available
+OVER=$((AVAIL + 10))
+curl -s -X POST http://[$FORGE_IP]:7100/v1/instances \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\": \"overbook\", \"image\": \"alpine-3.20\", \"vcpus\": $OVER, \"memory_mb\": 512}" 2>&1
+```
+
+**Expected:** 409 Conflict with `FORGE_INSUFFICIENT_CAPACITY`.
+
+### 6. Cleanup
+
+```bash
+syfrah compute vm delete res-test --yes
+syfrah fabric stop 2>/dev/null
+```
+
+## Pass criteria
+
+- Reservations are created atomically during admission
+- Reservations expire after 60s
+- Successful creation converts reservation to allocation
+- Over-capacity requests are rejected with 409
+- GET /v1/hypervisor/reservations shows active reservations


### PR DESCRIPTION
## Summary
- Add `try_reserve()` for atomic check-and-reserve preventing double-booking under concurrent creates
- Add `list_reservations()` and `purge_expired()` methods for reservation visibility
- Wire GET /v1/hypervisor/reservations endpoint to inspect active reservations
- Create handler now uses `try_reserve` instead of separate `can_admit` + `reserve`

## E2E
- `421_forge_reservation.md`

Closes #957