### PR TITLE
feat(controlplane): scaffold openraft crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -109,10 +129,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyerror"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71add24cc141a1e8326f249b74c41cfd217aeb2a67c9c6cf9134d175469afd49"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
@@ -122,7 +157,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -220,12 +255,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -242,6 +313,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -282,6 +387,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -360,7 +478,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -393,6 +511,21 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -523,7 +656,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -543,6 +676,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -585,8 +741,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -712,6 +874,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +935,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -762,6 +956,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -860,6 +1055,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -1030,6 +1234,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1301,6 +1529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,6 +1772,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openraft"
+version = "0.10.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b9d8db10f834d517e4c2c45ab5c645bc5cafee9d07f7b150b8029a0b1ebdca"
+dependencies = [
+ "anyerror",
+ "byte-unit",
+ "chrono",
+ "clap",
+ "derive_more",
+ "futures-util",
+ "maplit",
+ "openraft-macros",
+ "openraft-rt",
+ "openraft-rt-tokio",
+ "peel-off",
+ "rand 0.9.2",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
+ "validit",
+]
+
+[[package]]
+name = "openraft-macros"
+version = "0.10.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22b0bd215948ed47997a1d0447ea592e49220096360a833b118f329a08aa286"
+dependencies = [
+ "chrono",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openraft-rt"
+version = "0.10.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b651e6e2f25d022e34549e605eb8875c78ebc26862b16b06143a551e53ec00"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "openraft-macros",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "openraft-rt-tokio"
+version = "0.10.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478d5625fdeb13293e68549ba1d42b7a25085f3be04204412147637ad22e2827"
+dependencies = [
+ "futures-util",
+ "openraft-rt",
+ "rand 0.9.2",
+ "tokio",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1866,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "peel-off"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3420ea4424090cbd75a688996f696a807c68d6744b4863591b86435dc3078e9"
 
 [[package]]
 name = "pem"
@@ -1693,7 +1994,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.9+spec-1.1.0",
 ]
 
 [[package]]
@@ -1703,6 +2013,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1780,6 +2110,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1912,6 +2248,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2295,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -1994,6 +2359,52 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2091,6 +2502,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2527,12 @@ checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -2138,7 +2567,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2249,6 +2678,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2377,6 +2812,26 @@ dependencies = [
  "tower",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "syfrah-controlplane"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "futures",
+ "openraft",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syfrah-org",
+ "syfrah-state",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2536,6 +2991,17 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2562,8 +3028,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -2625,7 +3097,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2636,7 +3108,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2727,7 +3199,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2761,8 +3233,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2775,6 +3247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,9 +3264,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -2860,7 +3362,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2934,6 +3436,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +3533,15 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validit"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
+dependencies = [
+ "anyerror",
 ]
 
 [[package]]
@@ -3118,7 +3641,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3248,10 +3771,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3428,6 +4004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wireguard-control"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,7 +4064,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3495,7 +4080,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3542,6 +4127,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -3593,7 +4187,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3614,7 +4208,7 @@ checksum = "2bb729294f1600579d8e234c069706c8d0f1f63e1817633ccf7944983dca39b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3634,7 +4228,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3655,7 +4249,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3688,7 +4282,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "layers/overlay",
     "layers/storage",
     "layers/org",
+    "layers/controlplane",
     "bin/syfrah",
 ]
 exclude = [

--- a/layers/controlplane/Cargo.toml
+++ b/layers/controlplane/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "syfrah-controlplane"
+description = "Control plane layer — distributed consensus via Raft for Syfrah"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+openraft = { version = "0.10.0-alpha.17", features = ["serde", "type-alias"] }
+syfrah-org = { path = "../org" }
+syfrah-state = { path = "../state" }
+async-trait = "0.1"
+axum = "0.8"
+futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = "3"

--- a/layers/controlplane/src/commands.rs
+++ b/layers/controlplane/src/commands.rs
@@ -1,0 +1,260 @@
+//! State machine command and response types for Raft-replicated operations.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A command that is replicated through Raft and applied to the state machine.
+///
+/// Each variant maps to an existing store method in the org/hypervisor/ipam layers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum StateMachineCommand {
+    // -- Org --
+    CreateOrg {
+        name: String,
+    },
+    DeleteOrg {
+        name: String,
+    },
+
+    // -- Project --
+    CreateProject {
+        name: String,
+        org: String,
+    },
+    DeleteProject {
+        name: String,
+        org: String,
+    },
+
+    // -- Environment --
+    CreateEnv {
+        name: String,
+        project: String,
+        org: String,
+        ttl: Option<u64>,
+        deletion_protection: bool,
+        labels: HashMap<String, String>,
+    },
+    DeleteEnv {
+        name: String,
+        project: String,
+        org: String,
+    },
+
+    // -- VPC --
+    CreateVpc {
+        name: String,
+        cidr: String,
+        owner: String,
+        shared: bool,
+    },
+    DeleteVpc {
+        name: String,
+    },
+    PeerVpc {
+        vpc_a: String,
+        vpc_b: String,
+    },
+    UnpeerVpc {
+        vpc_a: String,
+        vpc_b: String,
+    },
+
+    // -- Subnet --
+    CreateSubnet {
+        name: String,
+        vpc: String,
+        env_id: String,
+        cidr: Option<String>,
+    },
+    DeleteSubnet {
+        name: String,
+        vpc: String,
+    },
+
+    // -- IPAM --
+    AllocateIp {
+        subnet_id: String,
+    },
+    ReleaseIp {
+        subnet_id: String,
+        ip: String,
+    },
+
+    // -- Security Groups --
+    CreateSg {
+        name: String,
+        vpc: String,
+    },
+    DeleteSg {
+        name: String,
+    },
+    AddSgRule {
+        sg: String,
+        direction: String,
+        protocol: String,
+        port: Option<String>,
+        source: String,
+    },
+    RemoveSgRule {
+        sg: String,
+        rule_id: String,
+    },
+    AttachSg {
+        sg: String,
+        nic_id: String,
+    },
+    DetachSg {
+        sg: String,
+        nic_id: String,
+    },
+
+    // -- NAT Gateway --
+    CreateNatGw {
+        name: String,
+        vpc: String,
+        subnet: String,
+    },
+    DeleteNatGw {
+        name: String,
+    },
+
+    // -- Routes --
+    AddRoute {
+        vpc: String,
+        destination: String,
+        target: String,
+    },
+    DeleteRoute {
+        vpc: String,
+        destination: String,
+    },
+
+    // -- VM Placement --
+    PlaceVm {
+        vm_id: String,
+        hypervisor_id: String,
+        subnet_id: String,
+        ip: String,
+        mac: String,
+        generation: u64,
+    },
+    RemoveVm {
+        vm_id: String,
+    },
+    RescheduleVm {
+        vm_id: String,
+        from: String,
+        to: String,
+        generation: u64,
+    },
+
+    // -- Hypervisor --
+    RegisterHypervisor {
+        name: String,
+        region: String,
+        zone: String,
+    },
+    EnableHypervisor {
+        name: String,
+    },
+    DrainHypervisor {
+        name: String,
+    },
+    DecommissionHypervisor {
+        name: String,
+    },
+    UpdateHypervisorLabels {
+        name: String,
+        labels: HashMap<String, String>,
+    },
+    UpdateHypervisorTaints {
+        name: String,
+        taints: Vec<String>,
+    },
+
+    // -- NIC --
+    CreateNic {
+        vm_id: String,
+        subnet_id: String,
+        ip: String,
+        mac: String,
+    },
+    DeleteNic {
+        nic_id: String,
+    },
+}
+
+impl std::fmt::Display for StateMachineCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CreateOrg { name } => write!(f, "CreateOrg({name})"),
+            Self::DeleteOrg { name } => write!(f, "DeleteOrg({name})"),
+            Self::CreateProject { name, org } => write!(f, "CreateProject({name}@{org})"),
+            Self::DeleteProject { name, org } => write!(f, "DeleteProject({name}@{org})"),
+            Self::CreateVpc { name, .. } => write!(f, "CreateVpc({name})"),
+            Self::DeleteVpc { name } => write!(f, "DeleteVpc({name})"),
+            Self::RegisterHypervisor { name, .. } => write!(f, "RegisterHypervisor({name})"),
+            Self::EnableHypervisor { name } => write!(f, "EnableHypervisor({name})"),
+            _ => write!(f, "{:?}", std::mem::discriminant(self)),
+        }
+    }
+}
+
+/// Response from the state machine after applying a command.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub enum StateMachineResponse {
+    /// Operation succeeded with no additional data.
+    #[default]
+    Ok,
+    /// A resource was created; contains its ID.
+    Created(String),
+    /// Operation failed with an error message.
+    Error(String),
+    /// IP allocation result.
+    AllocatedIp { ip: String, mac: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_serde_roundtrip() {
+        let cmd = StateMachineCommand::CreateOrg {
+            name: "acme".to_string(),
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let deserialized: StateMachineCommand = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            StateMachineCommand::CreateOrg { name } => assert_eq!(name, "acme"),
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn response_serde_roundtrip() {
+        let resp = StateMachineResponse::AllocatedIp {
+            ip: "10.0.0.1".to_string(),
+            mac: "02:00:0a:00:00:01".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let deserialized: StateMachineResponse = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            StateMachineResponse::AllocatedIp { ip, mac } => {
+                assert_eq!(ip, "10.0.0.1");
+                assert_eq!(mac, "02:00:0a:00:00:01");
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn command_display() {
+        let cmd = StateMachineCommand::CreateOrg {
+            name: "acme".to_string(),
+        };
+        assert_eq!(format!("{cmd}"), "CreateOrg(acme)");
+    }
+}

--- a/layers/controlplane/src/lib.rs
+++ b/layers/controlplane/src/lib.rs
@@ -1,0 +1,21 @@
+//! Control plane layer — distributed consensus via Raft for Syfrah.
+//!
+//! Uses openraft to replicate state machine commands across cluster nodes.
+//! Phase 1: single-node bootstrap with redb-backed log and state machine.
+
+pub mod commands;
+pub mod log_storage;
+pub mod network;
+pub mod server;
+pub mod state_machine;
+pub mod types;
+
+pub use commands::{StateMachineCommand, StateMachineResponse};
+pub use log_storage::RedbLogStore;
+pub use network::{SyfrahNetwork, SyfrahNetworkFactory};
+pub use server::RaftServer;
+pub use state_machine::RedbStateMachine;
+pub use types::{SyfrahNode, SyfrahRaftConfig};
+
+/// The concrete Raft type for Syfrah.
+pub type SyfrahRaft = openraft::Raft<SyfrahRaftConfig, RedbStateMachine>;

--- a/layers/controlplane/src/log_storage.rs
+++ b/layers/controlplane/src/log_storage.rs
@@ -1,0 +1,236 @@
+//! Raft log storage backed by redb.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::io;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use openraft::alias::{EntryOf, LogIdOf};
+use openraft::entry::RaftEntry;
+use openraft::storage::{IOFlushed, LogState, RaftLogReader, RaftLogStorage};
+use openraft::{OptionalSend, Vote};
+use serde_json;
+use syfrah_state::LayerDb;
+use tokio::sync::RwLock;
+
+use crate::types::SyfrahRaftConfig;
+
+type LeaderId = openraft::impls::leader_id_adv::LeaderId<u64, u64>;
+
+/// Raft log storage backed by redb.
+///
+/// Stores log entries in a redb table keyed by log index.
+/// Also persists the current vote for leader election durability.
+pub struct RedbLogStore {
+    db: LayerDb,
+    /// In-memory log cache for fast access. Flushed to redb on append.
+    log: RwLock<BTreeMap<u64, String>>,
+    /// Last purged log ID.
+    last_purged_log_id: RwLock<Option<LogIdOf<SyfrahRaftConfig>>>,
+    /// Persisted committed log ID.
+    committed: RwLock<Option<LogIdOf<SyfrahRaftConfig>>>,
+    /// Current vote.
+    vote: RwLock<Option<Vote<LeaderId>>>,
+}
+
+const LOG_TABLE: &str = "raft_log";
+const VOTE_TABLE: &str = "raft_vote";
+const META_TABLE: &str = "raft_meta";
+const VOTE_KEY: &str = "current_vote";
+const PURGED_KEY: &str = "last_purged";
+const COMMITTED_KEY: &str = "committed";
+
+impl RedbLogStore {
+    /// Create a new log store backed by the given redb database.
+    pub fn new(db: LayerDb) -> Self {
+        // Restore persisted state from redb.
+        let vote: Option<Vote<LeaderId>> = db.get(VOTE_TABLE, VOTE_KEY).ok().flatten();
+        let last_purged: Option<LogIdOf<SyfrahRaftConfig>> =
+            db.get(META_TABLE, PURGED_KEY).ok().flatten();
+        let committed: Option<LogIdOf<SyfrahRaftConfig>> =
+            db.get(META_TABLE, COMMITTED_KEY).ok().flatten();
+
+        // Load all log entries into memory.
+        let entries: Vec<(String, String)> = db.list(LOG_TABLE).unwrap_or_default();
+        let mut log = BTreeMap::new();
+        for (key, value) in entries {
+            if let Ok(idx) = key.parse::<u64>() {
+                log.insert(idx, value);
+            }
+        }
+
+        Self {
+            db,
+            log: RwLock::new(log),
+            last_purged_log_id: RwLock::new(last_purged),
+            committed: RwLock::new(committed),
+            vote: RwLock::new(vote),
+        }
+    }
+}
+
+impl RaftLogReader<SyfrahRaftConfig> for Arc<RedbLogStore> {
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<EntryOf<SyfrahRaftConfig>>, io::Error> {
+        let log = self.log.read().await;
+        let mut entries = vec![];
+        for (_, serialized) in log.range(range) {
+            let ent: EntryOf<SyfrahRaftConfig> = serde_json::from_str(serialized)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            entries.push(ent);
+        }
+        Ok(entries)
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<Vote<LeaderId>>, io::Error> {
+        Ok(*self.vote.read().await)
+    }
+
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<EntryOf<SyfrahRaftConfig>>, io::Error> {
+        self.try_get_log_entries(start..end).await
+    }
+}
+
+impl RaftLogStorage<SyfrahRaftConfig> for Arc<RedbLogStore> {
+    type LogReader = Self;
+
+    async fn get_log_state(&mut self) -> Result<LogState<SyfrahRaftConfig>, io::Error> {
+        let log = self.log.read().await;
+        let last_serialized = log.iter().next_back().map(|(_, ent)| ent);
+
+        let last = match last_serialized {
+            None => None,
+            Some(serialized) => {
+                let ent: EntryOf<SyfrahRaftConfig> = serde_json::from_str(serialized)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+                Some(ent.log_id())
+            }
+        };
+
+        let last_purged = *self.last_purged_log_id.read().await;
+
+        let last = match last {
+            None => last_purged,
+            Some(x) => Some(x),
+        };
+
+        Ok(LogState {
+            last_purged_log_id: last_purged,
+            last_log_id: last,
+        })
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+
+    async fn save_vote(&mut self, vote: &Vote<LeaderId>) -> Result<(), io::Error> {
+        let mut v = self.vote.write().await;
+        *v = Some(*vote);
+        self.db
+            .set(VOTE_TABLE, VOTE_KEY, vote)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn save_committed(
+        &mut self,
+        committed: Option<LogIdOf<SyfrahRaftConfig>>,
+    ) -> Result<(), io::Error> {
+        let mut c = self.committed.write().await;
+        *c = committed;
+        if let Some(ref c) = committed {
+            self.db
+                .set(META_TABLE, COMMITTED_KEY, c)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    async fn read_committed(&mut self) -> Result<Option<LogIdOf<SyfrahRaftConfig>>, io::Error> {
+        Ok(*self.committed.read().await)
+    }
+
+    async fn append<I>(
+        &mut self,
+        entries: I,
+        callback: IOFlushed<SyfrahRaftConfig>,
+    ) -> Result<(), io::Error>
+    where
+        I: IntoIterator<Item = EntryOf<SyfrahRaftConfig>> + OptionalSend,
+    {
+        let mut log = self.log.write().await;
+        for entry in entries {
+            let s = serde_json::to_string(&entry)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            let idx = entry.index();
+            // Persist to redb.
+            self.db
+                .set(LOG_TABLE, &idx.to_string(), &s)
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            log.insert(idx, s);
+        }
+        callback.io_completed(Ok(()));
+        Ok(())
+    }
+
+    async fn truncate_after(
+        &mut self,
+        last_log_id: Option<LogIdOf<SyfrahRaftConfig>>,
+    ) -> Result<(), io::Error> {
+        let start_index = match last_log_id {
+            Some(log_id) => log_id.index() + 1,
+            None => 0,
+        };
+
+        let mut log = self.log.write().await;
+        let keys: Vec<u64> = log.range(start_index..).map(|(k, _)| *k).collect();
+        for key in keys {
+            log.remove(&key);
+            let _ = self.db.delete(LOG_TABLE, &key.to_string());
+        }
+        Ok(())
+    }
+
+    async fn purge(&mut self, log_id: LogIdOf<SyfrahRaftConfig>) -> Result<(), io::Error> {
+        {
+            let mut ld = self.last_purged_log_id.write().await;
+            *ld = Some(log_id);
+        }
+        self.db
+            .set(META_TABLE, PURGED_KEY, &log_id)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+
+        let mut log = self.log.write().await;
+        let keys: Vec<u64> = log.range(..=log_id.index()).map(|(k, _)| *k).collect();
+        for key in keys {
+            log.remove(&key);
+            let _ = self.db.delete(LOG_TABLE, &key.to_string());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn log_store_empty_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_raft.redb");
+        std::env::set_var("SYFRAH_STATE_DIR", dir.path());
+        let db = LayerDb::open_at(&db_path).unwrap();
+        let mut store = Arc::new(RedbLogStore::new(db));
+        let state = store.get_log_state().await.unwrap();
+        assert!(state.last_log_id.is_none());
+        assert!(state.last_purged_log_id.is_none());
+    }
+}

--- a/layers/controlplane/src/network.rs
+++ b/layers/controlplane/src/network.rs
@@ -1,0 +1,142 @@
+//! Raft network implementation — HTTP/JSON over syfrah0 on port 7200.
+
+use std::future::Future;
+use std::io;
+
+use openraft::errors::{RPCError, ReplicationClosed, StreamingError, Unreachable};
+use openraft::network::v2::RaftNetworkV2;
+use openraft::network::{RPCOption, RaftNetworkFactory};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+};
+use openraft::type_config::alias::{SnapshotOf, VoteOf};
+use openraft::OptionalSend;
+
+use crate::types::{SyfrahNode, SyfrahRaftConfig};
+
+/// Factory that creates network clients for each target node.
+pub struct SyfrahNetworkFactory {
+    client: reqwest::Client,
+}
+
+impl SyfrahNetworkFactory {
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()
+                .expect("failed to build reqwest client"),
+        }
+    }
+}
+
+impl Default for SyfrahNetworkFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A network client for a single target Raft node.
+pub struct SyfrahNetwork {
+    target_addr: String,
+    client: reqwest::Client,
+}
+
+impl RaftNetworkFactory<SyfrahRaftConfig> for SyfrahNetworkFactory {
+    type Network = SyfrahNetwork;
+
+    async fn new_client(&mut self, _target: u64, node: &SyfrahNode) -> Self::Network {
+        SyfrahNetwork {
+            target_addr: node.addr.clone(),
+            client: self.client.clone(),
+        }
+    }
+}
+
+impl RaftNetworkV2<SyfrahRaftConfig> for SyfrahNetwork {
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<SyfrahRaftConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<SyfrahRaftConfig>, RPCError<SyfrahRaftConfig>> {
+        let url = format!("http://{}/raft/append_entries", self.target_addr);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&rpc)
+            .send()
+            .await
+            .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?;
+
+        let result: AppendEntriesResponse<SyfrahRaftConfig> = resp
+            .json()
+            .await
+            .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?;
+        Ok(result)
+    }
+
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<SyfrahRaftConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<SyfrahRaftConfig>, RPCError<SyfrahRaftConfig>> {
+        let url = format!("http://{}/raft/vote", self.target_addr);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&rpc)
+            .send()
+            .await
+            .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?;
+
+        let result: VoteResponse<SyfrahRaftConfig> = resp
+            .json()
+            .await
+            .map_err(|e| RPCError::Unreachable(Unreachable::new(&e)))?;
+        Ok(result)
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        vote: VoteOf<SyfrahRaftConfig>,
+        snapshot: SnapshotOf<SyfrahRaftConfig>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<SyfrahRaftConfig>, StreamingError<SyfrahRaftConfig>> {
+        let url = format!("http://{}/raft/install_snapshot", self.target_addr);
+
+        #[derive(serde::Serialize)]
+        struct SnapshotReq {
+            vote: VoteOf<SyfrahRaftConfig>,
+            meta: openraft::alias::SnapshotMetaOf<SyfrahRaftConfig>,
+            data: Vec<u8>,
+        }
+
+        let req = SnapshotReq {
+            vote,
+            meta: snapshot.meta,
+            data: snapshot.snapshot.into_inner(),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| {
+                StreamingError::Unreachable(Unreachable::new(&io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    e.to_string(),
+                )))
+            })?;
+
+        let result: SnapshotResponse<SyfrahRaftConfig> = resp.json().await.map_err(|e| {
+            StreamingError::Unreachable(Unreachable::new(&io::Error::new(
+                io::ErrorKind::InvalidData,
+                e.to_string(),
+            )))
+        })?;
+        Ok(result)
+    }
+}

--- a/layers/controlplane/src/server.rs
+++ b/layers/controlplane/src/server.rs
@@ -1,0 +1,145 @@
+//! Raft HTTP server — Axum routes for Raft RPCs on port 7200.
+
+use std::io::Cursor;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, SnapshotResponse, VoteRequest, VoteResponse,
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+use crate::types::SyfrahRaftConfig;
+use crate::SyfrahRaft;
+
+/// Shared state for the Raft HTTP server.
+#[derive(Clone)]
+pub struct RaftServerState {
+    pub raft: SyfrahRaft,
+}
+
+/// The Raft HTTP server handling inter-node RPCs.
+pub struct RaftServer;
+
+impl RaftServer {
+    /// Start the Raft HTTP server on the given address.
+    pub async fn serve(
+        bind_addr: SocketAddr,
+        state: RaftServerState,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) -> anyhow::Result<()> {
+        let app = raft_router(Arc::new(state));
+
+        let listener = tokio::net::TcpListener::bind(bind_addr).await?;
+        info!("raft HTTP server listening on {bind_addr}");
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.wait_for(|v| *v).await;
+            })
+            .await?;
+
+        Ok(())
+    }
+}
+
+/// Build the Axum router for Raft RPCs.
+pub fn raft_router(state: Arc<RaftServerState>) -> Router {
+    Router::new()
+        .route("/raft/append_entries", post(append_entries_handler))
+        .route("/raft/vote", post(vote_handler))
+        .route("/raft/install_snapshot", post(install_snapshot_handler))
+        .route("/raft/status", get(status_handler))
+        .with_state(state)
+}
+
+async fn append_entries_handler(
+    State(state): State<Arc<RaftServerState>>,
+    Json(req): Json<AppendEntriesRequest<SyfrahRaftConfig>>,
+) -> Result<Json<AppendEntriesResponse<SyfrahRaftConfig>>, StatusCode> {
+    let resp = state
+        .raft
+        .append_entries(req)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(resp))
+}
+
+async fn vote_handler(
+    State(state): State<Arc<RaftServerState>>,
+    Json(req): Json<VoteRequest<SyfrahRaftConfig>>,
+) -> Result<Json<VoteResponse<SyfrahRaftConfig>>, StatusCode> {
+    let resp = state
+        .raft
+        .vote(req)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    Ok(Json(resp))
+}
+
+#[derive(Deserialize)]
+struct InstallSnapshotReq {
+    vote: openraft::type_config::alias::VoteOf<SyfrahRaftConfig>,
+    meta: openraft::alias::SnapshotMetaOf<SyfrahRaftConfig>,
+    data: Vec<u8>,
+}
+
+async fn install_snapshot_handler(
+    State(state): State<Arc<RaftServerState>>,
+    Json(req): Json<InstallSnapshotReq>,
+) -> Result<Json<SnapshotResponse<SyfrahRaftConfig>>, StatusCode> {
+    let snapshot = openraft::alias::SnapshotOf::<SyfrahRaftConfig> {
+        meta: req.meta,
+        snapshot: Cursor::new(req.data),
+    };
+
+    let resp = state
+        .raft
+        .install_full_snapshot(req.vote, snapshot)
+        .await
+        .map_err(|e| {
+            warn!("install_snapshot error: {e:?}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(resp))
+}
+
+/// Status response for the Raft cluster.
+#[derive(Serialize)]
+pub struct RaftStatusResponse {
+    pub id: u64,
+    pub state: String,
+    pub current_leader: Option<u64>,
+    pub current_term: u64,
+    pub last_log_index: Option<u64>,
+    pub last_applied_index: Option<u64>,
+    pub members: Vec<u64>,
+}
+
+async fn status_handler(
+    State(state): State<Arc<RaftServerState>>,
+) -> Result<Json<RaftStatusResponse>, StatusCode> {
+    use openraft::rt::watch::WatchReceiver;
+    let metrics = state.raft.metrics().borrow_watched().clone();
+
+    let members: Vec<u64> = metrics.membership_config.membership().voter_ids().collect();
+
+    let resp = RaftStatusResponse {
+        id: metrics.id,
+        state: format!("{:?}", metrics.state),
+        current_leader: metrics.current_leader,
+        current_term: metrics.current_term,
+        last_log_index: metrics.last_log_index,
+        last_applied_index: metrics
+            .last_applied
+            .map(|l: openraft::alias::LogIdOf<SyfrahRaftConfig>| l.index()),
+        members,
+    };
+    Ok(Json(resp))
+}

--- a/layers/controlplane/src/state_machine.rs
+++ b/layers/controlplane/src/state_machine.rs
@@ -1,0 +1,228 @@
+//! Raft state machine backed by the existing OrgStore (redb).
+
+use std::io;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use futures::TryStreamExt;
+use openraft::alias::{LogIdOf, SnapshotMetaOf, SnapshotOf, StoredMembershipOf};
+use openraft::storage::{EntryResponder, RaftSnapshotBuilder, RaftStateMachine};
+use openraft::type_config::alias::SnapshotDataOf;
+use openraft::{EntryPayload, OptionalSend};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use crate::commands::{StateMachineCommand, StateMachineResponse};
+use crate::types::SyfrahRaftConfig;
+
+/// Snapshot of the state machine — serialized state for transfer.
+#[derive(Debug)]
+pub struct SmSnapshot {
+    pub meta: SnapshotMetaOf<SyfrahRaftConfig>,
+    pub data: Vec<u8>,
+}
+
+/// Internal state tracking for the Raft state machine.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+pub struct SmState {
+    pub last_applied_log: Option<LogIdOf<SyfrahRaftConfig>>,
+    pub last_membership: StoredMembershipOf<SyfrahRaftConfig>,
+}
+
+/// Raft state machine that dispatches commands to the OrgStore.
+///
+/// On apply, each `StateMachineCommand` is deserialized and dispatched
+/// to the appropriate store method. The OrgStore is backed by redb,
+/// so the state machine output IS the local redb state.
+pub struct RedbStateMachine {
+    pub org_store: Arc<syfrah_org::OrgStore>,
+    pub sm_state: RwLock<SmState>,
+    pub current_snapshot: RwLock<Option<SmSnapshot>>,
+    snapshot_idx: std::sync::Mutex<u64>,
+}
+
+impl RedbStateMachine {
+    /// Create a new state machine wrapping the given OrgStore.
+    pub fn new(org_store: Arc<syfrah_org::OrgStore>) -> Self {
+        Self {
+            org_store,
+            sm_state: RwLock::new(SmState::default()),
+            current_snapshot: RwLock::new(None),
+            snapshot_idx: std::sync::Mutex::new(0),
+        }
+    }
+
+    /// Apply a single command to the state machine.
+    fn apply_command(&self, cmd: &StateMachineCommand) -> StateMachineResponse {
+        match cmd {
+            StateMachineCommand::CreateOrg { name } => match self.org_store.create(name) {
+                Ok(org) => StateMachineResponse::Created(org.id.0),
+                Err(e) => StateMachineResponse::Error(e.to_string()),
+            },
+            StateMachineCommand::DeleteOrg { name } => match self.org_store.delete(name) {
+                Ok(()) => StateMachineResponse::Ok,
+                Err(e) => StateMachineResponse::Error(e.to_string()),
+            },
+            StateMachineCommand::CreateProject { name, org } => {
+                match self.org_store.create_project(org, name) {
+                    Ok(proj) => StateMachineResponse::Created(proj.id.0),
+                    Err(e) => StateMachineResponse::Error(e.to_string()),
+                }
+            }
+            StateMachineCommand::DeleteProject { name, org } => {
+                match self.org_store.delete_project(org, name) {
+                    Ok(()) => StateMachineResponse::Ok,
+                    Err(e) => StateMachineResponse::Error(e.to_string()),
+                }
+            }
+            // For Phase 1, remaining commands return Ok.
+            // They will be wired to actual store methods in Phase 2.
+            _ => {
+                warn!("unimplemented state machine command: {cmd}");
+                StateMachineResponse::Ok
+            }
+        }
+    }
+}
+
+impl RaftSnapshotBuilder<SyfrahRaftConfig> for Arc<RedbStateMachine> {
+    async fn build_snapshot(&mut self) -> Result<SnapshotOf<SyfrahRaftConfig>, io::Error> {
+        let sm_state = self.sm_state.read().await;
+        let data = serde_json::to_vec(&*sm_state)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        let snapshot_idx = {
+            let mut idx = self.snapshot_idx.lock().unwrap();
+            *idx += 1;
+            *idx
+        };
+
+        let snapshot_id = if let Some(last) = sm_state.last_applied_log {
+            format!(
+                "{}-{}-{}",
+                last.committed_leader_id(),
+                last.index(),
+                snapshot_idx
+            )
+        } else {
+            format!("--{}", snapshot_idx)
+        };
+
+        let meta = SnapshotMetaOf::<SyfrahRaftConfig> {
+            last_log_id: sm_state.last_applied_log,
+            last_membership: sm_state.last_membership.clone(),
+            snapshot_id,
+        };
+
+        let snapshot = SmSnapshot {
+            meta: meta.clone(),
+            data: data.clone(),
+        };
+
+        {
+            let mut current = self.current_snapshot.write().await;
+            *current = Some(snapshot);
+        }
+
+        info!(snapshot_size = data.len(), "snapshot built");
+
+        Ok(SnapshotOf::<SyfrahRaftConfig> {
+            meta,
+            snapshot: Cursor::new(data),
+        })
+    }
+}
+
+impl RaftStateMachine<SyfrahRaftConfig> for Arc<RedbStateMachine> {
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<
+        (
+            Option<LogIdOf<SyfrahRaftConfig>>,
+            StoredMembershipOf<SyfrahRaftConfig>,
+        ),
+        io::Error,
+    > {
+        let sm = self.sm_state.read().await;
+        Ok((sm.last_applied_log, sm.last_membership.clone()))
+    }
+
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where
+        Strm: futures::Stream<Item = Result<EntryResponder<SyfrahRaftConfig>, io::Error>>
+            + Unpin
+            + OptionalSend,
+    {
+        let mut sm = self.sm_state.write().await;
+
+        while let Some((entry, responder)) = entries.try_next().await? {
+            sm.last_applied_log = Some(entry.log_id);
+
+            let response = match entry.payload {
+                EntryPayload::Blank => StateMachineResponse::Ok,
+                EntryPayload::Normal(ref cmd) => self.apply_command(cmd),
+                EntryPayload::Membership(ref mem) => {
+                    sm.last_membership = StoredMembershipOf::<SyfrahRaftConfig>::new(
+                        Some(entry.log_id),
+                        mem.clone(),
+                    );
+                    StateMachineResponse::Ok
+                }
+            };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+
+    async fn begin_receiving_snapshot(
+        &mut self,
+    ) -> Result<SnapshotDataOf<SyfrahRaftConfig>, io::Error> {
+        Ok(Cursor::new(Vec::new()))
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMetaOf<SyfrahRaftConfig>,
+        snapshot: SnapshotDataOf<SyfrahRaftConfig>,
+    ) -> Result<(), io::Error> {
+        let data = snapshot.into_inner();
+        let new_sm: SmState = serde_json::from_slice(&data)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+
+        {
+            let mut sm = self.sm_state.write().await;
+            *sm = new_sm;
+        }
+
+        let snap = SmSnapshot {
+            meta: meta.clone(),
+            data,
+        };
+        let mut current = self.current_snapshot.write().await;
+        *current = Some(snap);
+
+        info!("snapshot installed");
+        Ok(())
+    }
+
+    async fn get_current_snapshot(
+        &mut self,
+    ) -> Result<Option<SnapshotOf<SyfrahRaftConfig>>, io::Error> {
+        match &*self.current_snapshot.read().await {
+            Some(snapshot) => Ok(Some(SnapshotOf::<SyfrahRaftConfig> {
+                meta: snapshot.meta.clone(),
+                snapshot: Cursor::new(snapshot.data.clone()),
+            })),
+            None => Ok(None),
+        }
+    }
+}

--- a/layers/controlplane/src/types.rs
+++ b/layers/controlplane/src/types.rs
@@ -1,0 +1,52 @@
+//! Raft type configuration for Syfrah.
+
+use serde::{Deserialize, Serialize};
+
+use crate::commands::{StateMachineCommand, StateMachineResponse};
+
+/// Node identity in the Raft cluster.
+///
+/// The `id` is derived from a hash of the fabric node identity.
+/// The `addr` is the fabric IPv6 address + Raft port (e.g. `[fd00::1]:7200`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
+pub struct SyfrahNode {
+    /// Fabric IPv6 address + port for Raft RPCs.
+    pub addr: String,
+}
+
+impl std::fmt::Display for SyfrahNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SyfrahNode({})", self.addr)
+    }
+}
+
+openraft::declare_raft_types!(
+    /// Raft type configuration for Syfrah control plane.
+    pub SyfrahRaftConfig:
+        D = StateMachineCommand,
+        R = StateMachineResponse,
+        Node = SyfrahNode,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_display() {
+        let node = SyfrahNode {
+            addr: "[fd00::1]:7200".to_string(),
+        };
+        assert_eq!(format!("{node}"), "SyfrahNode([fd00::1]:7200)");
+    }
+
+    #[test]
+    fn node_serde_roundtrip() {
+        let node = SyfrahNode {
+            addr: "[fd00::1]:7200".to_string(),
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        let deserialized: SyfrahNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(node, deserialized);
+    }
+}

--- a/tests/e2e/scenarios/500_cp_scaffold.md
+++ b/tests/e2e/scenarios/500_cp_scaffold.md
@@ -1,0 +1,54 @@
+# E2E: Control Plane Scaffold
+
+**ID**: 500_cp_scaffold
+**Layer**: controlplane
+**Priority**: P0
+
+## Objective
+Verify that the control plane crate compiles, is registered in the workspace, and the core types are correctly defined.
+
+## Prerequisites
+- Workspace builds successfully with `cargo build --workspace`
+
+## Steps
+
+1. **Workspace registration**
+   ```bash
+   grep "layers/controlplane" Cargo.toml
+   ```
+   Expected: `layers/controlplane` appears in `[workspace.members]`
+
+2. **Crate builds**
+   ```bash
+   cargo build -p syfrah-controlplane
+   ```
+   Expected: clean compilation, no errors
+
+3. **Type configuration compiles**
+   Verify `SyfrahRaftConfig` type is declared with correct associated types:
+   - `D = StateMachineCommand`
+   - `R = StateMachineResponse`
+   - `Node = SyfrahNode`
+
+4. **Node type serialization**
+   ```bash
+   cargo test -p syfrah-controlplane -- types::tests
+   ```
+   Expected: `node_display` and `node_serde_roundtrip` pass
+
+5. **Command enum serialization**
+   ```bash
+   cargo test -p syfrah-controlplane -- commands::tests
+   ```
+   Expected: all command/response serde roundtrip tests pass
+
+6. **Clippy clean**
+   ```bash
+   cargo clippy -p syfrah-controlplane -- -D warnings
+   ```
+   Expected: no warnings or errors
+
+## Pass criteria
+- All steps succeed
+- No compilation warnings with `-D warnings`
+- Unit tests pass


### PR DESCRIPTION
## Summary
- Transforms `layers/controlplane/` from a stub README into a real Rust crate with openraft 0.10 integration
- Defines `SyfrahRaftConfig` type configuration, `StateMachineCommand`/`StateMachineResponse` enums, redb-backed log storage, state machine wrapping `OrgStore`, HTTP network transport, and Axum Raft RPC server
- Adds the crate to workspace `Cargo.toml` and includes E2E test scenario `500_cp_scaffold.md`

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p syfrah-controlplane` passes (6 tests)
- [x] E2E scenario defined in `tests/e2e/scenarios/500_cp_scaffold.md`

Closes #1039