### PR TITLE
feat(controlplane): RaftStateMachine tests

### DIFF
--- a/layers/controlplane/src/state_machine.rs
+++ b/layers/controlplane/src/state_machine.rs
@@ -226,3 +226,115 @@ impl RaftStateMachine<SyfrahRaftConfig> for Arc<RedbStateMachine> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_org_store() -> (tempfile::TempDir, Arc<syfrah_org::OrgStore>) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_org.redb");
+        let db = syfrah_state::LayerDb::open_at(&db_path).unwrap();
+        (dir, Arc::new(syfrah_org::OrgStore::new(db)))
+    }
+
+    #[test]
+    fn apply_create_org() {
+        let (_dir, store) = make_org_store();
+        let sm = RedbStateMachine::new(store.clone());
+        let cmd = StateMachineCommand::CreateOrg {
+            name: "testorg".to_string(),
+        };
+        let resp = sm.apply_command(&cmd);
+        match resp {
+            StateMachineResponse::Created(id) => assert!(id.contains("testorg")),
+            other => panic!("expected Created, got {other:?}"),
+        }
+        // Verify it was actually created.
+        let org = store.get("testorg").unwrap();
+        assert!(org.is_some());
+    }
+
+    #[test]
+    fn apply_create_org_duplicate() {
+        let (_dir, store) = make_org_store();
+        let sm = RedbStateMachine::new(store.clone());
+        let cmd = StateMachineCommand::CreateOrg {
+            name: "dup".to_string(),
+        };
+        let _ = sm.apply_command(&cmd);
+        let resp = sm.apply_command(&cmd);
+        match resp {
+            StateMachineResponse::Error(msg) => assert!(msg.contains("already exists")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_delete_org() {
+        let (_dir, store) = make_org_store();
+        let sm = RedbStateMachine::new(store.clone());
+        let _ = sm.apply_command(&StateMachineCommand::CreateOrg {
+            name: "del".to_string(),
+        });
+        let resp = sm.apply_command(&StateMachineCommand::DeleteOrg {
+            name: "del".to_string(),
+        });
+        assert!(matches!(resp, StateMachineResponse::Ok));
+        assert!(store.get("del").unwrap().is_none());
+    }
+
+    #[test]
+    fn apply_create_project() {
+        let (_dir, store) = make_org_store();
+        let sm = RedbStateMachine::new(store.clone());
+        let _ = sm.apply_command(&StateMachineCommand::CreateOrg {
+            name: "acme".to_string(),
+        });
+        let resp = sm.apply_command(&StateMachineCommand::CreateProject {
+            name: "backend".to_string(),
+            org: "acme".to_string(),
+        });
+        match resp {
+            StateMachineResponse::Created(id) => assert!(id.contains("backend")),
+            other => panic!("expected Created, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_unimplemented_returns_ok() {
+        let (_dir, store) = make_org_store();
+        let sm = RedbStateMachine::new(store);
+        let resp = sm.apply_command(&StateMachineCommand::AllocateIp {
+            subnet_id: "sub-1".to_string(),
+        });
+        assert!(matches!(resp, StateMachineResponse::Ok));
+    }
+
+    #[tokio::test]
+    async fn snapshot_roundtrip() {
+        let (_dir, store) = make_org_store();
+        let mut sm = Arc::new(RedbStateMachine::new(store));
+
+        // Build a snapshot.
+        use openraft::storage::RaftSnapshotBuilder;
+        let snap = sm.build_snapshot().await.unwrap();
+        assert!(!snap.snapshot.into_inner().is_empty());
+
+        // Get current snapshot.
+        use openraft::storage::RaftStateMachine;
+        let current = sm.get_current_snapshot().await.unwrap();
+        assert!(current.is_some());
+    }
+
+    #[tokio::test]
+    async fn applied_state_default() {
+        let (_dir, store) = make_org_store();
+        let mut sm = Arc::new(RedbStateMachine::new(store));
+        use openraft::storage::RaftStateMachine;
+        let (last, membership) = sm.applied_state().await.unwrap();
+        assert!(last.is_none());
+        // Default membership should be empty.
+        assert_eq!(membership.membership().voter_ids().count(), 0);
+    }
+}

--- a/tests/e2e/scenarios/502_cp_state_machine.md
+++ b/tests/e2e/scenarios/502_cp_state_machine.md
@@ -1,0 +1,60 @@
+# E2E: Control Plane State Machine
+
+**ID**: 502_cp_state_machine
+**Layer**: controlplane
+**Priority**: P0
+
+## Objective
+Verify the Raft state machine correctly applies commands to the OrgStore, builds snapshots, and handles install_snapshot for state transfer.
+
+## Prerequisites
+- Control plane crate builds
+- OrgStore works correctly
+
+## Steps
+
+1. **RaftStateMachine trait implemented**
+   Verify `Arc<RedbStateMachine>` implements all required methods:
+   - `applied_state` — returns last_applied_log and membership
+   - `apply` — dispatches commands to OrgStore
+   - `get_snapshot_builder` — returns self clone
+   - `begin_receiving_snapshot` — returns empty cursor
+   - `install_snapshot` — deserializes and restores SmState
+   - `get_current_snapshot` — returns latest snapshot
+
+2. **Command dispatch**
+   ```bash
+   cargo test -p syfrah-controlplane -- state_machine::tests::apply_create_org
+   cargo test -p syfrah-controlplane -- state_machine::tests::apply_delete_org
+   cargo test -p syfrah-controlplane -- state_machine::tests::apply_create_project
+   ```
+   Expected: commands dispatched to OrgStore, results match expectations
+
+3. **Duplicate handling**
+   ```bash
+   cargo test -p syfrah-controlplane -- state_machine::tests::apply_create_org_duplicate
+   ```
+   Expected: returns Error response for duplicate creation
+
+4. **Unimplemented commands**
+   ```bash
+   cargo test -p syfrah-controlplane -- state_machine::tests::apply_unimplemented_returns_ok
+   ```
+   Expected: returns Ok (not panic or error)
+
+5. **Snapshot roundtrip**
+   ```bash
+   cargo test -p syfrah-controlplane -- state_machine::tests::snapshot_roundtrip
+   ```
+   Expected: snapshot can be built and retrieved
+
+6. **Default applied state**
+   ```bash
+   cargo test -p syfrah-controlplane -- state_machine::tests::applied_state_default
+   ```
+   Expected: fresh state machine has no applied log and empty membership
+
+## Pass criteria
+- All tests pass
+- Commands correctly modify OrgStore state
+- Snapshot build/restore cycle works


### PR DESCRIPTION
## Summary
- Tests for state machine command dispatch (create/delete org, project)
- Snapshot build/retrieve roundtrip test
- E2E scenario `502_cp_state_machine.md`

## Test plan
- [x] `cargo test -p syfrah-controlplane` passes (16 tests)
- [x] Clippy clean

Closes #1041