### PR TITLE
feat(controlplane): Raft network factory tests

### DIFF
--- a/layers/controlplane/src/network.rs
+++ b/layers/controlplane/src/network.rs
@@ -140,3 +140,24 @@ impl RaftNetworkV2<SyfrahRaftConfig> for SyfrahNetwork {
         Ok(result)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openraft::network::RaftNetworkFactory;
+
+    #[tokio::test]
+    async fn factory_creates_client() {
+        let mut factory = SyfrahNetworkFactory::new();
+        let node = SyfrahNode {
+            addr: "[::1]:7200".to_string(),
+        };
+        let network = factory.new_client(1, &node).await;
+        assert_eq!(network.target_addr, "[::1]:7200");
+    }
+
+    #[test]
+    fn factory_default() {
+        let _ = SyfrahNetworkFactory::default();
+    }
+}

--- a/tests/e2e/scenarios/504_cp_network.md
+++ b/tests/e2e/scenarios/504_cp_network.md
@@ -1,0 +1,40 @@
+# E2E: Control Plane Raft Network
+
+**ID**: 504_cp_network
+**Layer**: controlplane
+**Priority**: P0
+
+## Objective
+Verify the Raft network implementation correctly sends RPCs over HTTP/JSON to remote nodes.
+
+## Prerequisites
+- Control plane crate builds
+
+## Steps
+
+1. **RaftNetworkFactory implemented**
+   Verify `SyfrahNetworkFactory` implements `RaftNetworkFactory<SyfrahRaftConfig>`:
+   - `new_client` creates a `SyfrahNetwork` for the target node
+
+2. **RaftNetworkV2 implemented**
+   Verify `SyfrahNetwork` implements `RaftNetworkV2<SyfrahRaftConfig>`:
+   - `append_entries` — POST to `/raft/append_entries`
+   - `vote` — POST to `/raft/vote`
+   - `full_snapshot` — POST to `/raft/install_snapshot`
+
+3. **Network factory construction**
+   ```bash
+   cargo test -p syfrah-controlplane -- network
+   ```
+   Expected: factory creates clients without error
+
+4. **Compile check**
+   ```bash
+   cargo build -p syfrah-controlplane
+   ```
+   Expected: clean compilation
+
+## Pass criteria
+- Network types implement required openraft traits
+- HTTP endpoints match server routes
+- Reqwest client configured with 5s timeout


### PR DESCRIPTION
## Summary
- Network factory test for client creation
- E2E scenario `504_cp_network.md`

## Test plan
- [x] `cargo test -p syfrah-controlplane` passes (21 tests)

Closes #1043