### PR TITLE
fix(controlplane): sentinel file for Raft init detection

### DIFF
--- a/bin/syfrah/src/controlplane/init.rs
+++ b/bin/syfrah/src/controlplane/init.rs
@@ -31,17 +31,18 @@ pub async fn run() -> Result<()> {
 
     let node_addr = format!("[{fabric_ipv6}]:7200");
 
-    // Check if already initialized.
-    let log_db =
-        syfrah_state::LayerDb::open("raft_log").context("Failed to open raft_log database")?;
-
-    // Check for existing vote (indicates prior initialization).
-    let existing_vote: Option<serde_json::Value> =
-        log_db.get("raft_vote", "current_vote").unwrap_or(None);
-    if existing_vote.is_some() {
+    // Check if already initialized via sentinel file.
+    let syfrah_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".syfrah");
+    let sentinel = syfrah_dir.join("raft_initialized");
+    if sentinel.exists() {
         println!("Control plane already initialized. Restart the daemon to activate.");
         return Ok(());
     }
+
+    let log_db =
+        syfrah_state::LayerDb::open("raft_log").context("Failed to open raft_log database")?;
 
     println!("Initializing control plane...");
     println!("  Node ID:  {node_id}");
@@ -97,6 +98,10 @@ pub async fn run() -> Result<()> {
     raft.shutdown()
         .await
         .map_err(|e| anyhow::anyhow!("Raft shutdown error: {e}"))?;
+
+    // Write sentinel file so the daemon knows to start Raft on next boot.
+    std::fs::write(&sentinel, format!("{node_id}"))
+        .context("Failed to write raft_initialized sentinel")?;
 
     println!();
     println!("Control plane initialized. Restart the daemon to activate:");

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1346,12 +1346,16 @@ pub async fn run_daemon(
         let raft_bind_addr: std::net::SocketAddr =
             std::net::SocketAddr::new(std::net::IpAddr::V6(my_record.mesh_ipv6), 7200);
 
-        // Check if Raft has been initialized (raft_meta.redb exists and has state).
-        let raft_db = syfrah_state::LayerDb::open("raft_log").ok();
-        let raft_initialized = raft_db.is_some();
+        // Check if Raft has been initialized.
+        // The controlplane init command creates a sentinel file when done.
+        let syfrah_dir = dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join(".syfrah");
+        let raft_initialized = syfrah_dir.join("raft_initialized").exists();
 
         if raft_initialized {
-            let log_db = syfrah_state::LayerDb::open("raft_log").unwrap();
+            let log_db =
+                syfrah_state::LayerDb::open("raft_log").expect("failed to open raft_log database");
             let log_store = std::sync::Arc::new(syfrah_controlplane::RedbLogStore::new(log_db));
 
             let sm = std::sync::Arc::new(syfrah_controlplane::RedbStateMachine::new(


### PR DESCRIPTION
## Summary
- Fixes DatabaseAlreadyOpen panic in daemon startup
- Uses sentinel file (~/.syfrah/raft_initialized) instead of double-opening redb
- controlplane init writes sentinel after bootstrap; daemon checks it on start

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Fixes the panic observed during QA testing