### PR TITLE
fix(controlplane): use top-level fabric state for mesh IPv6

### DIFF
--- a/bin/syfrah/src/controlplane/init.rs
+++ b/bin/syfrah/src/controlplane/init.rs
@@ -13,13 +13,7 @@ pub async fn run() -> Result<()> {
     let fabric_state = syfrah_fabric::store::load()
         .map_err(|_| anyhow::anyhow!("Fabric not initialized. Run 'syfrah fabric init' first."))?;
 
-    let my_record = fabric_state
-        .peers
-        .iter()
-        .find(|p| p.name == fabric_state.node_name)
-        .ok_or_else(|| anyhow::anyhow!("Cannot find own peer record in fabric state"))?;
-
-    let fabric_ipv6 = my_record.mesh_ipv6;
+    let fabric_ipv6 = fabric_state.mesh_ipv6;
 
     // Derive node ID from fabric node name hash.
     let node_id = {

--- a/bin/syfrah/src/controlplane/status.rs
+++ b/bin/syfrah/src/controlplane/status.rs
@@ -8,13 +8,7 @@ pub async fn run(json: bool) -> Result<()> {
     let fabric_state =
         syfrah_fabric::store::load().map_err(|_| anyhow::anyhow!("Fabric not initialized."))?;
 
-    let my_record = fabric_state
-        .peers
-        .iter()
-        .find(|p| p.name == fabric_state.node_name)
-        .ok_or_else(|| anyhow::anyhow!("Cannot find own peer record"))?;
-
-    let fabric_ipv6 = my_record.mesh_ipv6;
+    let fabric_ipv6 = fabric_state.mesh_ipv6;
     let url = format!("http://[{fabric_ipv6}]:7200/raft/status");
 
     let client = reqwest::Client::builder()


### PR DESCRIPTION
## Summary
- Fixes 'Cannot find own peer record' error in controlplane init/status
- Uses fabric_state.mesh_ipv6 directly instead of searching peers array

## Test plan
- [x] Build succeeds
- [x] Tested on live servers