### PR TITLE
feat(controlplane): multi-node Raft cluster — join/promote/members

### DIFF
--- a/bin/syfrah/src/controlplane/join.rs
+++ b/bin/syfrah/src/controlplane/join.rs
@@ -1,0 +1,112 @@
+//! `syfrah controlplane join` — join this node to an existing Raft cluster.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+/// Join an existing Raft cluster by contacting the leader.
+pub async fn run() -> Result<()> {
+    // Load fabric state to get our node identity and the leader's address.
+    let fabric_state = syfrah_fabric::store::load()
+        .map_err(|_| anyhow::anyhow!("Fabric not initialized. Run 'syfrah fabric init' first."))?;
+
+    let fabric_ipv6 = fabric_state.mesh_ipv6;
+
+    // Derive node ID from fabric node name hash.
+    let node_id = {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        fabric_state.node_name.hash(&mut hasher);
+        hasher.finish()
+    };
+
+    let node_addr = format!("[{fabric_ipv6}]:7200");
+
+    // Check if already initialized.
+    let syfrah_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".syfrah");
+    let sentinel = syfrah_dir.join("raft_initialized");
+    if sentinel.exists() {
+        println!("Control plane already initialized on this node.");
+        return Ok(());
+    }
+
+    // Find a peer that has Raft initialized (the leader).
+    // Try each fabric peer's Raft status endpoint.
+    let peers = &fabric_state.peers;
+    if peers.is_empty() {
+        anyhow::bail!("No fabric peers found. Join the fabric first with 'syfrah fabric join'.");
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("Failed to build HTTP client")?;
+
+    let mut leader_addr = None;
+    for peer in peers {
+        let peer_raft_url = format!("http://[{}]:7200/raft/status", peer.mesh_ipv6);
+        if let Ok(resp) = client.get(&peer_raft_url).send().await {
+            if resp.status().is_success() {
+                if let Ok(status) = resp
+                    .json::<syfrah_controlplane::server::RaftStatusResponse>()
+                    .await
+                {
+                    if status.current_leader.is_some() {
+                        leader_addr = Some(format!("[{}]:7200", peer.mesh_ipv6));
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let leader_addr = leader_addr.ok_or_else(|| {
+        anyhow::anyhow!(
+            "No Raft leader found among fabric peers. Initialize the control plane on one node first."
+        )
+    })?;
+
+    println!("Joining Raft cluster...");
+    println!("  Node ID:  {node_id}");
+    println!("  Address:  {node_addr}");
+    println!("  Leader:   {leader_addr}");
+
+    // Initialize local Raft storage first.
+    let log_db =
+        syfrah_state::LayerDb::open("raft_log").context("Failed to open raft_log database")?;
+    let _log_store = Arc::new(syfrah_controlplane::RedbLogStore::new(log_db));
+
+    // Send join request to the leader.
+    let join_url = format!("http://{leader_addr}/raft/join");
+    let join_req = serde_json::json!({
+        "node_id": node_id,
+        "addr": node_addr,
+    });
+
+    let resp = client
+        .post(&join_url)
+        .json(&join_req)
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to send join request: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!("Join failed: {status} — {body}");
+    }
+
+    println!("  Joined successfully!");
+
+    // Write sentinel file so the daemon knows to start Raft on next boot.
+    std::fs::write(&sentinel, format!("{node_id}"))
+        .context("Failed to write raft_initialized sentinel")?;
+
+    println!();
+    println!("Control plane joined. Restart the daemon to activate:");
+    println!("  syfrah fabric stop && syfrah fabric start");
+
+    Ok(())
+}

--- a/bin/syfrah/src/controlplane/members.rs
+++ b/bin/syfrah/src/controlplane/members.rs
@@ -1,0 +1,45 @@
+//! `syfrah controlplane members` — list all Raft cluster members.
+
+use anyhow::{Context, Result};
+
+/// List all members of the Raft cluster with their roles.
+pub async fn run() -> Result<()> {
+    let fabric_state =
+        syfrah_fabric::store::load().map_err(|_| anyhow::anyhow!("Fabric not initialized."))?;
+
+    let fabric_ipv6 = fabric_state.mesh_ipv6;
+    let url = format!("http://[{fabric_ipv6}]:7200/raft/members");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .context("Failed to build HTTP client")?;
+
+    let resp = client.get(&url).send().await.map_err(|e| {
+        anyhow::anyhow!("Cannot reach control plane server. Is the daemon running?\nError: {e}")
+    })?;
+
+    if !resp.status().is_success() {
+        anyhow::bail!("Control plane returned status {}", resp.status());
+    }
+
+    let members: syfrah_controlplane::server::MembersResponse = resp
+        .json()
+        .await
+        .context("Failed to parse members response")?;
+
+    if members.members.is_empty() {
+        println!("(no members)");
+        return Ok(());
+    }
+
+    println!("{:<20} {:<40} {:<10}", "NODE ID", "ADDRESS", "ROLE");
+    println!("{}", "-".repeat(70));
+    for m in &members.members {
+        println!("{:<20} {:<40} {:<10}", m.node_id, m.addr, m.role);
+    }
+    println!();
+    println!("{} member(s) total", members.members.len());
+
+    Ok(())
+}

--- a/bin/syfrah/src/controlplane/mod.rs
+++ b/bin/syfrah/src/controlplane/mod.rs
@@ -1,6 +1,8 @@
 //! CLI commands for `syfrah controlplane`.
 
 pub mod init;
+pub mod join;
+pub mod members;
 pub mod status;
 
 use clap::Subcommand;
@@ -10,18 +12,24 @@ use clap::Subcommand;
 pub enum ControlPlaneCommand {
     /// Initialize the control plane (single-node Raft bootstrap)
     Init,
+    /// Join an existing Raft cluster
+    Join,
     /// Show control plane status (Raft leader, term, members)
     Status {
         /// Output as JSON
         #[arg(long)]
         json: bool,
     },
+    /// List all Raft cluster members with their roles
+    Members,
 }
 
 /// Run a control plane CLI command.
 pub async fn run(command: ControlPlaneCommand) -> anyhow::Result<()> {
     match command {
         ControlPlaneCommand::Init => init::run().await,
+        ControlPlaneCommand::Join => join::run().await,
         ControlPlaneCommand::Status { json } => status::run(json).await,
+        ControlPlaneCommand::Members => members::run().await,
     }
 }

--- a/layers/controlplane/src/server.rs
+++ b/layers/controlplane/src/server.rs
@@ -56,7 +56,10 @@ pub fn raft_router(state: Arc<RaftServerState>) -> Router {
         .route("/raft/vote", post(vote_handler))
         .route("/raft/install_snapshot", post(install_snapshot_handler))
         .route("/raft/write", post(client_write_handler))
+        .route("/raft/join", post(join_handler))
+        .route("/raft/promote", post(promote_handler))
         .route("/raft/status", get(status_handler))
+        .route("/raft/members", get(members_handler))
         .with_state(state)
 }
 
@@ -127,6 +130,120 @@ async fn install_snapshot_handler(
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
     Ok(Json(resp))
+}
+
+/// Request to join the Raft cluster as a learner.
+#[derive(Deserialize)]
+pub struct JoinRequest {
+    pub node_id: u64,
+    pub addr: String,
+}
+
+/// Request to promote a learner to voter.
+#[derive(Deserialize)]
+pub struct PromoteRequest {
+    pub node_id: u64,
+}
+
+/// Handle a join request: add the node as a learner.
+async fn join_handler(
+    State(state): State<Arc<RaftServerState>>,
+    Json(req): Json<JoinRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    use crate::types::SyfrahNode;
+
+    info!(
+        "raft: join request from node {} at {}",
+        req.node_id, req.addr
+    );
+
+    let node = SyfrahNode {
+        addr: req.addr.clone(),
+    };
+
+    // Add as learner (non-blocking — replication starts immediately).
+    state
+        .raft
+        .add_learner(req.node_id, node, false)
+        .await
+        .map_err(|e| {
+            warn!("join (add_learner) failed: {e:?}");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    info!("raft: node {} added as learner", req.node_id);
+    Ok(Json(
+        serde_json::json!({ "status": "joined", "node_id": req.node_id }),
+    ))
+}
+
+/// Handle a promote request: promote learner to voter.
+async fn promote_handler(
+    State(state): State<Arc<RaftServerState>>,
+    Json(req): Json<PromoteRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    use openraft::ChangeMembers;
+
+    info!("raft: promote request for node {}", req.node_id);
+
+    // Promote the learner to voter (retain=true keeps existing learners).
+    state
+        .raft
+        .change_membership(
+            ChangeMembers::AddVoterIds(std::collections::BTreeSet::from([req.node_id])),
+            true,
+        )
+        .await
+        .map_err(|e| {
+            warn!("promote failed: {e:?}");
+            StatusCode::SERVICE_UNAVAILABLE
+        })?;
+
+    info!("raft: node {} promoted to voter", req.node_id);
+    Ok(Json(
+        serde_json::json!({ "status": "promoted", "node_id": req.node_id }),
+    ))
+}
+
+/// Member info in the members response.
+#[derive(Serialize, Deserialize)]
+pub struct MemberInfo {
+    pub node_id: u64,
+    pub addr: String,
+    pub role: String, // "voter" or "learner"
+}
+
+/// Members response — list all Raft members with roles.
+#[derive(Serialize, Deserialize)]
+pub struct MembersResponse {
+    pub members: Vec<MemberInfo>,
+}
+
+async fn members_handler(
+    State(state): State<Arc<RaftServerState>>,
+) -> Result<Json<MembersResponse>, StatusCode> {
+    use openraft::rt::watch::WatchReceiver;
+    let metrics = state.raft.metrics().borrow_watched().clone();
+
+    let voter_ids: std::collections::HashSet<u64> =
+        metrics.membership_config.membership().voter_ids().collect();
+
+    let members: Vec<MemberInfo> = metrics
+        .membership_config
+        .membership()
+        .nodes()
+        .map(|(id, node)| MemberInfo {
+            node_id: *id,
+            addr: node.addr.clone(),
+            role: if voter_ids.contains(id) {
+                "voter".to_string()
+            } else {
+                "learner".to_string()
+            },
+        })
+        .collect();
+
+    Ok(Json(MembersResponse { members }))
 }
 
 /// Status response for the Raft cluster.

--- a/tests/e2e/scenarios/514_cp_membership.md
+++ b/tests/e2e/scenarios/514_cp_membership.md
@@ -1,0 +1,42 @@
+# 514 — Control Plane: Multi-node Raft cluster — add/remove members
+
+## Goal
+Verify that a second node can join the Raft cluster and both nodes share state.
+
+## Steps
+
+### 1. Bootstrap Raft on node 1
+```bash
+ssh root@node1 "syfrah controlplane init"
+```
+
+### 2. Join node 2
+```bash
+ssh root@node2 "syfrah controlplane join"
+# Should find the leader on node 1, send join request, write sentinel
+```
+
+### 3. Restart node 2 daemon
+```bash
+ssh root@node2 "syfrah fabric stop && syfrah fabric start"
+```
+
+### 4. Verify membership
+```bash
+ssh root@node1 "syfrah controlplane members"
+# Should show 2 members
+ssh root@node2 "syfrah controlplane members"
+```
+
+### 5. Create data on node 1, verify on node 2
+```bash
+ssh root@node1 "syfrah org create test-replication"
+sleep 2
+ssh root@node2 "syfrah org list"
+# Should show test-replication (replicated via Raft)
+```
+
+## Expected Outcome
+- `syfrah controlplane join` adds node as learner to the Raft cluster.
+- `syfrah controlplane members` shows all members with roles (voter/learner).
+- State created on any node is replicated to all nodes.


### PR DESCRIPTION
## Summary
- `syfrah controlplane join` — discovers leader, sends join request
- `syfrah controlplane members` — lists members with roles
- `/raft/join` and `/raft/promote` HTTP endpoints on the Raft server
- Leader uses `add_learner()` and `change_membership(AddVoterIds)` APIs

## E2E
- `514_cp_membership.md`

Closes #1051