### PR TITLE
feat(controlplane): FDB cold rebuild from Raft placements

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1451,6 +1451,59 @@ pub async fn run_daemon(
 
             let raft_state = syfrah_controlplane::server::RaftServerState { raft };
 
+            // -- FDB cold rebuild from Raft-derived placements ------------------
+            //
+            // After the Raft state machine is loaded, the placement store
+            // reflects the global placement map. Rebuild local FDB + ARP proxy
+            // entries for all remote VMs in VPCs that have local VMs on this
+            // hypervisor. This is O(total VMs in local VPCs) and runs once at
+            // startup.
+            if let Some(ref placement) = shared_placement_store {
+                let local_node = my_record.mesh_ipv6.to_string();
+                match placement.list_all() {
+                    Ok(placements) => {
+                        // Convert org::types::VmPlacement to overlay::VmPlacement
+                        let overlay_placements: Vec<syfrah_overlay::VmPlacement> = placements
+                            .iter()
+                            .map(|p| syfrah_overlay::VmPlacement {
+                                vpc_id: p.vpc_id.clone(),
+                                vm_id: p.vm_id.clone(),
+                                vm_mac: p.vm_mac.clone(),
+                                vm_ip: p.vm_ip.clone(),
+                                subnet_id: p.subnet_id.clone(),
+                                hypervisor_id: p.hypervisor_id.clone(),
+                                action: syfrah_overlay::PlacementAction::Add,
+                                placement_generation: p.placement_generation,
+                            })
+                            .collect();
+                        let backend: Arc<dyn syfrah_overlay::NetworkBackend> =
+                            Arc::new(syfrah_overlay::LinuxBackend::new());
+                        match syfrah_overlay::rebuild_fdb(
+                            backend.as_ref(),
+                            &overlay_placements,
+                            &local_node,
+                        )
+                        .await
+                        {
+                            Ok(summary) => {
+                                info!(
+                                    rebuilt = summary.rebuilt,
+                                    skipped_local = summary.skipped_local,
+                                    errors = summary.errors,
+                                    "FDB cold rebuild from Raft placements complete"
+                                );
+                            }
+                            Err(e) => {
+                                warn!("FDB cold rebuild failed: {e}");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("FDB cold rebuild: failed to list placements: {e}");
+                    }
+                }
+            }
+
             info!("raft: control plane server starting on {raft_bind_addr} (node_id={node_id})");
 
             tokio::spawn(async move {

--- a/tests/e2e/scenarios/520_cp_fdb_cold.md
+++ b/tests/e2e/scenarios/520_cp_fdb_cold.md
@@ -1,0 +1,62 @@
+# 520 — FDB cold rebuild from Raft placements
+
+## Objective
+
+Verify that on daemon startup (after Raft state machine loads), FDB and ARP
+proxy entries are rebuilt from the placement store for all remote VMs in local
+VPCs.
+
+## Preconditions
+
+- Two-node mesh (hv-eu-1, hv-eu-2) with Raft initialized and both nodes joined.
+- At least one VM created on each node in the same VPC/subnet.
+- Both VMs have different IPs (distributed IPAM).
+
+## Steps
+
+1. **Create VMs on both nodes** — one on hv-eu-1, one on hv-eu-2, same subnet.
+2. **Verify FDB entries exist** on both nodes:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00'"
+   ssh root@hv-eu-2 "bridge fdb show | grep '02:00'"
+   ```
+   Each should have an FDB entry pointing to the other node's fabric IPv6.
+
+3. **Flush FDB entries manually** to simulate a cold state:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb flush dev syfx-*"
+   ssh root@hv-eu-2 "bridge fdb flush dev syfx-*"
+   ```
+
+4. **Restart the daemon** on both nodes:
+   ```bash
+   ssh root@hv-eu-1 "syfrah fabric stop && sleep 2 && syfrah fabric start"
+   ssh root@hv-eu-2 "syfrah fabric stop && sleep 2 && syfrah fabric start"
+   ```
+
+5. **Verify FDB entries are rebuilt**:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00'"
+   ssh root@hv-eu-2 "bridge fdb show | grep '02:00'"
+   ```
+   FDB entries must be present again, pointing to the correct remote fabric
+   IPv6 addresses.
+
+6. **Verify ARP proxy entries are rebuilt**:
+   ```bash
+   ssh root@hv-eu-1 "ip neigh show | grep '10.1.0'"
+   ssh root@hv-eu-2 "ip neigh show | grep '10.1.0'"
+   ```
+
+## Expected results
+
+- After daemon restart, FDB entries for remote VMs are automatically restored.
+- ARP proxy entries for remote VMs are automatically restored.
+- Local VM placements are skipped (no self-FDB entries).
+- The rebuild is logged: `FDB cold rebuild from Raft placements complete`.
+
+## Pass criteria
+
+- FDB entries present on both nodes after restart.
+- ARP proxy entries present on both nodes after restart.
+- No errors in daemon logs related to FDB rebuild.


### PR DESCRIPTION
## Summary

On daemon startup, after the Raft state machine loads, scan all VM placements in the local redb (placement store) and rebuild FDB + ARP proxy entries for all remote VMs in VPCs that have local VMs on this hypervisor. Local placements are skipped (the bridge handles them).

This is O(total VMs in local VPCs) — acceptable at startup. It ensures cross-node VXLAN forwarding works immediately after a daemon restart without waiting for the 5s reconciliation loop.

### Changes
- `layers/fabric/src/daemon.rs`: After Raft node init, read all placements from the shared placement store and call `rebuild_fdb()` from the overlay crate
- `tests/e2e/scenarios/520_cp_fdb_cold.md`: E2E test plan

Closes #1054