### PR TITLE
feat(controlplane): FDB incremental update on Raft commit

### DIFF
--- a/layers/controlplane/src/lib.rs
+++ b/layers/controlplane/src/lib.rs
@@ -18,7 +18,7 @@ pub use idempotency::IdempotencyJournal;
 pub use log_storage::RedbLogStore;
 pub use network::{SyfrahNetwork, SyfrahNetworkFactory};
 pub use server::RaftServer;
-pub use state_machine::RedbStateMachine;
+pub use state_machine::{PlacementEvent, RedbStateMachine};
 pub use types::{SyfrahNode, SyfrahRaftConfig};
 
 /// The concrete Raft type for Syfrah.

--- a/layers/controlplane/src/state_machine.rs
+++ b/layers/controlplane/src/state_machine.rs
@@ -15,6 +15,31 @@ use tracing::{info, warn};
 use crate::commands::{StateMachineCommand, StateMachineResponse};
 use crate::types::SyfrahRaftConfig;
 
+/// Event emitted by the state machine when a VM placement changes.
+///
+/// The daemon subscribes to these events to update FDB + ARP proxy
+/// entries incrementally (O(1) per placement change).
+#[derive(Debug, Clone)]
+pub enum PlacementEvent {
+    /// A VM was placed on a hypervisor.
+    Added {
+        vpc_id: String,
+        vm_id: String,
+        vm_mac: String,
+        vm_ip: String,
+        subnet_id: String,
+        hypervisor_id: String,
+    },
+    /// A VM was removed from a hypervisor.
+    Removed {
+        vpc_id: String,
+        vm_id: String,
+        vm_mac: String,
+        vm_ip: String,
+        hypervisor_id: String,
+    },
+}
+
 /// Snapshot of the state machine — serialized state for transfer.
 #[derive(Debug)]
 pub struct SmSnapshot {
@@ -41,11 +66,15 @@ pub struct RedbStateMachine {
     pub sm_state: RwLock<SmState>,
     pub current_snapshot: RwLock<Option<SmSnapshot>>,
     snapshot_idx: std::sync::Mutex<u64>,
+    /// Broadcast channel for placement events (FDB incremental updates).
+    /// Subscribers receive events when PlaceVm/RemoveVm commands are applied.
+    placement_tx: tokio::sync::broadcast::Sender<PlacementEvent>,
 }
 
 impl RedbStateMachine {
     /// Create a new state machine wrapping the given OrgStore.
     pub fn new(org_store: Arc<syfrah_org::OrgStore>) -> Self {
+        let (placement_tx, _) = tokio::sync::broadcast::channel(256);
         Self {
             org_store,
             ipam_store: None,
@@ -53,7 +82,16 @@ impl RedbStateMachine {
             sm_state: RwLock::new(SmState::default()),
             current_snapshot: RwLock::new(None),
             snapshot_idx: std::sync::Mutex::new(0),
+            placement_tx,
         }
+    }
+
+    /// Subscribe to placement events for incremental FDB updates.
+    ///
+    /// Returns a broadcast receiver that yields `PlacementEvent`s whenever
+    /// the state machine applies a PlaceVm or RemoveVm command.
+    pub fn subscribe_placement_events(&self) -> tokio::sync::broadcast::Receiver<PlacementEvent> {
+        self.placement_tx.subscribe()
     }
 
     /// Set the IPAM store for distributed IP allocation.
@@ -357,7 +395,18 @@ impl RedbStateMachine {
                     placement_generation: *generation,
                 };
                 match placement_store.add_placement(&placement) {
-                    Ok(()) => StateMachineResponse::Ok,
+                    Ok(()) => {
+                        // Emit placement event for incremental FDB update.
+                        let _ = self.placement_tx.send(PlacementEvent::Added {
+                            vpc_id: placement.vpc_id,
+                            vm_id: placement.vm_id,
+                            vm_mac: placement.vm_mac,
+                            vm_ip: placement.vm_ip,
+                            subnet_id: placement.subnet_id,
+                            hypervisor_id: placement.hypervisor_id,
+                        });
+                        StateMachineResponse::Ok
+                    }
                     Err(e) => StateMachineResponse::Error(e.to_string()),
                 }
             }
@@ -375,7 +424,16 @@ impl RedbStateMachine {
                     Ok(placements) => {
                         for p in &placements {
                             if p.vm_id == *vm_id {
+                                // Capture info before removal for the event.
+                                let event = PlacementEvent::Removed {
+                                    vpc_id: p.vpc_id.clone(),
+                                    vm_id: p.vm_id.clone(),
+                                    vm_mac: p.vm_mac.clone(),
+                                    vm_ip: p.vm_ip.clone(),
+                                    hypervisor_id: p.hypervisor_id.clone(),
+                                };
                                 let _ = placement_store.remove_placement(&p.vpc_id, vm_id);
+                                let _ = self.placement_tx.send(event);
                                 return StateMachineResponse::Ok;
                             }
                         }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1417,6 +1417,10 @@ pub async fn run_daemon(
 
             let sm = std::sync::Arc::new(sm_builder);
 
+            // Subscribe to placement events for incremental FDB updates.
+            // Must subscribe before starting Raft so we don't miss events.
+            let placement_event_rx = sm.subscribe_placement_events();
+
             let network = syfrah_controlplane::SyfrahNetworkFactory::new();
 
             // Derive node ID from fabric node identity hash.
@@ -1502,6 +1506,89 @@ pub async fn run_daemon(
                         warn!("FDB cold rebuild: failed to list placements: {e}");
                     }
                 }
+            }
+
+            // -- FDB incremental update task ------------------------------------------
+            //
+            // Listen for PlaceVm/RemoveVm events from the Raft state machine and
+            // apply incremental FDB + ARP proxy updates. This is O(1) per event.
+            {
+                let local_node = my_record.mesh_ipv6.to_string();
+                let mut rx = placement_event_rx;
+                tokio::spawn(async move {
+                    let backend: Arc<dyn syfrah_overlay::NetworkBackend> =
+                        Arc::new(syfrah_overlay::LinuxBackend::new());
+                    loop {
+                        match rx.recv().await {
+                            Ok(event) => {
+                                let placement = match &event {
+                                    syfrah_controlplane::PlacementEvent::Added {
+                                        vpc_id,
+                                        vm_id,
+                                        vm_mac,
+                                        vm_ip,
+                                        subnet_id,
+                                        hypervisor_id,
+                                    } => syfrah_overlay::VmPlacement {
+                                        vpc_id: vpc_id.clone(),
+                                        vm_id: vm_id.clone(),
+                                        vm_mac: vm_mac.clone(),
+                                        vm_ip: vm_ip.clone(),
+                                        subnet_id: subnet_id.clone(),
+                                        hypervisor_id: hypervisor_id.clone(),
+                                        action: syfrah_overlay::PlacementAction::Add,
+                                        placement_generation: 0,
+                                    },
+                                    syfrah_controlplane::PlacementEvent::Removed {
+                                        vpc_id,
+                                        vm_id,
+                                        vm_mac,
+                                        vm_ip,
+                                        hypervisor_id,
+                                    } => syfrah_overlay::VmPlacement {
+                                        vpc_id: vpc_id.clone(),
+                                        vm_id: vm_id.clone(),
+                                        vm_mac: vm_mac.clone(),
+                                        vm_ip: vm_ip.clone(),
+                                        subnet_id: String::new(),
+                                        hypervisor_id: hypervisor_id.clone(),
+                                        action: syfrah_overlay::PlacementAction::Remove,
+                                        placement_generation: 0,
+                                    },
+                                };
+                                if let Err(e) = syfrah_overlay::sync_placement(
+                                    backend.as_ref(),
+                                    &placement,
+                                    &local_node,
+                                )
+                                .await
+                                {
+                                    warn!(
+                                        vm_id = %placement.vm_id,
+                                        "FDB incremental update failed: {e}"
+                                    );
+                                } else {
+                                    debug!(
+                                        vm_id = %placement.vm_id,
+                                        action = ?placement.action,
+                                        "FDB incremental update applied"
+                                    );
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                warn!(
+                                    skipped = n,
+                                    "FDB incremental update lagged — missed {n} events, \
+                                     next reconcile pass will catch up"
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                info!("FDB incremental update channel closed, stopping");
+                                break;
+                            }
+                        }
+                    }
+                });
             }
 
             info!("raft: control plane server starting on {raft_bind_addr} (node_id={node_id})");

--- a/tests/e2e/scenarios/521_cp_fdb_incremental.md
+++ b/tests/e2e/scenarios/521_cp_fdb_incremental.md
@@ -1,0 +1,55 @@
+# 521 — FDB incremental update on PlaceVm/RemoveVm commit
+
+## Objective
+
+Verify that when a PlaceVm or RemoveVm command is committed through Raft, each
+node incrementally updates its local FDB + ARP proxy entries without a full
+rebuild.
+
+## Preconditions
+
+- Two-node mesh (hv-eu-1, hv-eu-2) with Raft initialized.
+- Both daemons running.
+
+## Steps
+
+1. **Create a VM on hv-eu-1** in a VPC/subnet:
+   ```bash
+   ssh root@hv-eu-1 "syfrah compute vm create --name inc-1 --image alpine-3.20 \
+     --vcpus 1 --memory 512 --env prod --subnet web --project backend --org acme \
+     --ssh-key ~/.ssh/id_ed25519.pub"
+   ```
+
+2. **Create a VM on hv-eu-2** in the same subnet:
+   ```bash
+   ssh root@hv-eu-2 "syfrah compute vm create --name inc-2 --image alpine-3.20 \
+     --vcpus 1 --memory 512 --env prod --subnet web --project backend --org acme \
+     --ssh-key ~/.ssh/id_ed25519.pub"
+   ```
+
+3. **Check FDB entries appear within seconds** (not waiting for reconcile):
+   ```bash
+   # hv-eu-1 should have FDB entry for inc-2's MAC pointing to hv-eu-2
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00'"
+   # hv-eu-2 should have FDB entry for inc-1's MAC pointing to hv-eu-1
+   ssh root@hv-eu-2 "bridge fdb show | grep '02:00'"
+   ```
+
+4. **Delete inc-2**:
+   ```bash
+   ssh root@hv-eu-2 "syfrah compute vm delete inc-2 --yes"
+   ```
+
+5. **Verify FDB entry for inc-2 is removed from hv-eu-1** within seconds.
+
+## Expected results
+
+- FDB + ARP proxy entries are added within 1-2 seconds of PlaceVm commit.
+- FDB + ARP proxy entries are removed within 1-2 seconds of RemoveVm commit.
+- Local placements are skipped (no self-FDB entries).
+- Daemon logs show: `FDB incremental update applied`.
+
+## Pass criteria
+
+- FDB entry appears on the remote node within 5 seconds of VM creation.
+- FDB entry disappears from the remote node within 5 seconds of VM deletion.


### PR DESCRIPTION
## Summary

When the Raft state machine applies a PlaceVm or RemoveVm command, it now emits a PlacementEvent via a broadcast channel. The daemon subscribes to these events and applies O(1) FDB + ARP proxy updates immediately (within milliseconds of commit).

### Changes
- `layers/controlplane/src/state_machine.rs`: Added `PlacementEvent` enum, broadcast channel in `RedbStateMachine`, emit events on PlaceVm/RemoveVm
- `layers/controlplane/src/lib.rs`: Export `PlacementEvent`
- `layers/fabric/src/daemon.rs`: Subscribe to placement events, spawn incremental FDB update task
- `tests/e2e/scenarios/521_cp_fdb_incremental.md`: E2E test plan

Closes #1055