### PR TITLE
feat(overlay): FDB reconciliation — drift detection

### DIFF
--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -105,4 +105,16 @@ pub trait NetworkBackend: Send + Sync {
     /// discover existing `syfb-*`, `syfx-*`, `syft-*`, and
     /// `syfp*` interfaces.
     async fn list_interfaces(&self, prefix: &str) -> Result<Vec<String>>;
+
+    /// List FDB entries on a VXLAN interface.
+    ///
+    /// Returns `(mac, dst)` pairs from `bridge fdb show dev <vxlan>`.
+    /// Used by the FDB reconciliation loop to detect drift.
+    async fn list_fdb_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>>;
+
+    /// List ARP proxy (neighbor) entries on a VXLAN interface.
+    ///
+    /// Returns `(ip, mac)` pairs from `ip neigh show dev <vxlan>` where
+    /// state is `PERMANENT`.
+    async fn list_arp_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>>;
 }

--- a/layers/overlay/src/lib.rs
+++ b/layers/overlay/src/lib.rs
@@ -27,8 +27,8 @@ pub use fdb::{
 pub use linux::LinuxBackend;
 pub use mock::MockBackend;
 pub use reconcile::{
-    reconcile_network, AllocationState, ExpectedBridge, ExpectedVm, IpAllocation, NetworkState,
-    ReconcileReport,
+    reconcile_network, AllocationState, ExpectedBridge, ExpectedFdbEntry, ExpectedVm, IpAllocation,
+    NetworkState, ReconcileReport,
 };
 pub use recovery::{
     recover_network, RecoveryPlacement, RecoveryReport, RecoverySubnet, RecoveryVpc,

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -600,4 +600,34 @@ impl NetworkBackend for LinuxBackend {
         names.sort();
         Ok(names)
     }
+
+    async fn list_fdb_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>> {
+        let output = Self::run("bridge", &["fdb", "show", "dev", vxlan]).await?;
+        let mut entries = Vec::new();
+        for line in output.lines() {
+            // Format: "02:00:0a:01:00:03 dst fd12::1 self permanent"
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 3 && parts[1] == "dst" {
+                let mac = parts[0].to_string();
+                let dst = parts[2].to_string();
+                entries.push((mac, dst));
+            }
+        }
+        Ok(entries)
+    }
+
+    async fn list_arp_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>> {
+        let output = Self::run("ip", &["neigh", "show", "dev", vxlan, "nud", "permanent"]).await?;
+        let mut entries = Vec::new();
+        for line in output.lines() {
+            // Format: "10.1.0.3 lladdr 02:00:0a:01:00:03 PERMANENT"
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 3 && parts[1] == "lladdr" {
+                let ip = parts[0].to_string();
+                let mac = parts[2].to_string();
+                entries.push((ip, mac));
+            }
+        }
+        Ok(entries)
+    }
 }

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -14,6 +14,10 @@ pub struct MockBackend {
     fail_methods: Mutex<HashSet<String>>,
     /// Simulated kernel interfaces (bridges, TAPs, VXLANs).
     interfaces: Mutex<HashSet<String>>,
+    /// Simulated FDB entries per VXLAN: (mac, dst).
+    fdb_entries: Mutex<Vec<(String, String, String)>>,
+    /// Simulated ARP proxy entries per VXLAN: (ip, mac).
+    arp_entries: Mutex<Vec<(String, String, String)>>,
 }
 
 impl MockBackend {
@@ -22,6 +26,8 @@ impl MockBackend {
             calls: Mutex::new(Vec::new()),
             fail_methods: Mutex::new(HashSet::new()),
             interfaces: Mutex::new(HashSet::new()),
+            fdb_entries: Mutex::new(Vec::new()),
+            arp_entries: Mutex::new(Vec::new()),
         }
     }
 
@@ -59,6 +65,24 @@ impl MockBackend {
         for iface in ifaces {
             guard.insert(iface);
         }
+    }
+
+    /// Add a simulated FDB entry for testing list_fdb_entries.
+    pub fn add_fdb(&self, vxlan: &str, mac: &str, dst: &str) {
+        self.fdb_entries.lock().expect("lock poisoned").push((
+            vxlan.to_string(),
+            mac.to_string(),
+            dst.to_string(),
+        ));
+    }
+
+    /// Add a simulated ARP proxy entry for testing list_arp_entries.
+    pub fn add_arp(&self, vxlan: &str, ip: &str, mac: &str) {
+        self.arp_entries.lock().expect("lock poisoned").push((
+            vxlan.to_string(),
+            ip.to_string(),
+            mac.to_string(),
+        ));
     }
 
     fn record(&self, call: String) {
@@ -239,6 +263,26 @@ impl NetworkBackend for MockBackend {
         matched.sort();
         Ok(matched)
     }
+
+    async fn list_fdb_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>> {
+        self.record(format!("list_fdb_entries({vxlan})"));
+        let entries = self.fdb_entries.lock().expect("lock poisoned");
+        Ok(entries
+            .iter()
+            .filter(|(v, _, _)| v == vxlan)
+            .map(|(_, mac, dst)| (mac.clone(), dst.clone()))
+            .collect())
+    }
+
+    async fn list_arp_entries(&self, vxlan: &str) -> Result<Vec<(String, String)>> {
+        self.record(format!("list_arp_entries({vxlan})"));
+        let entries = self.arp_entries.lock().expect("lock poisoned");
+        Ok(entries
+            .iter()
+            .filter(|(v, _, _)| v == vxlan)
+            .map(|(_, ip, mac)| (ip.clone(), mac.clone()))
+            .collect())
+    }
 }
 
 #[cfg(test)]
@@ -304,9 +348,11 @@ mod tests {
         b.list_interfaces(crate::naming::BRIDGE_PREFIX)
             .await
             .unwrap();
+        b.list_fdb_entries(&vx100).await.unwrap();
+        b.list_arp_entries(&vx100).await.unwrap();
 
         let calls = b.calls();
-        assert_eq!(calls.len(), 23, "expected one call per trait method");
+        assert_eq!(calls.len(), 25, "expected one call per trait method");
 
         // Verify each method was recorded
         assert!(calls[0].starts_with("create_vxlan("));

--- a/layers/overlay/src/reconcile.rs
+++ b/layers/overlay/src/reconcile.rs
@@ -69,6 +69,19 @@ pub struct ExpectedSgAssignment {
     pub security_groups: Vec<String>,
 }
 
+/// Expected FDB entry for a remote VM.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExpectedFdbEntry {
+    /// VXLAN interface name (e.g. `syfx-abcdef`).
+    pub vxlan: String,
+    /// VM MAC address.
+    pub mac: String,
+    /// Remote hypervisor's fabric IPv6 (VTEP destination).
+    pub dst: String,
+    /// VM IP address (for ARP proxy).
+    pub ip: String,
+}
+
 /// Snapshot of expected network state gathered from redb.
 ///
 /// Passed to [`reconcile_network`] so it can compare against the kernel.
@@ -87,6 +100,10 @@ pub struct NetworkState {
     /// Expected SG assignments for each VM (used for SG drift detection).
     #[serde(default)]
     pub sg_assignments: Vec<ExpectedSgAssignment>,
+    /// Expected FDB entries derived from Raft placement state.
+    /// Only entries for REMOTE VMs (not local) should be listed here.
+    #[serde(default)]
+    pub fdb_entries: Vec<ExpectedFdbEntry>,
 }
 
 // ── Reconcile report ───────────────────────────────────────────────────
@@ -103,6 +120,12 @@ pub struct ReconcileReport {
     /// SG chains that were detected as drifted and re-applied.
     #[serde(default)]
     pub sg_chains_reapplied: usize,
+    /// FDB entries that were missing and re-added.
+    #[serde(default)]
+    pub fdb_entries_added: usize,
+    /// Stale FDB entries that were removed.
+    #[serde(default)]
+    pub fdb_entries_removed: usize,
     /// Warnings emitted (orphaned TAPs, orphaned kernel interfaces, etc.).
     pub warnings: Vec<String>,
 }
@@ -157,10 +180,15 @@ pub async fn reconcile_network(
     // 6. Detect SG drift — re-apply SG chains for VMs with assigned SGs.
     reconcile_sg_chains(expected_state, &mut report);
 
+    // 7. Reconcile FDB entries — add missing, remove stale.
+    reconcile_fdb_entries(backend, expected_state, &mut report).await;
+
     if report.bridges_fixed > 0
         || report.rules_reapplied > 0
         || report.orphans_reclaimed > 0
         || report.sg_chains_reapplied > 0
+        || report.fdb_entries_added > 0
+        || report.fdb_entries_removed > 0
         || !report.warnings.is_empty()
     {
         info!(
@@ -168,6 +196,8 @@ pub async fn reconcile_network(
             rules_reapplied = report.rules_reapplied,
             orphans_reclaimed = report.orphans_reclaimed,
             sg_chains_reapplied = report.sg_chains_reapplied,
+            fdb_added = report.fdb_entries_added,
+            fdb_removed = report.fdb_entries_removed,
             warnings = report.warnings.len(),
             "reconciliation complete"
         );
@@ -346,6 +376,133 @@ fn reconcile_sg_chains(state: &NetworkState, report: &mut ReconcileReport) {
             "re-applying SG chains for VM"
         );
         report.sg_chains_reapplied += 1;
+    }
+}
+
+/// Reconcile FDB entries: add missing entries, remove stale ones.
+///
+/// Compares expected FDB entries (derived from Raft placement state) against
+/// actual kernel FDB entries. Only touches drifted entries — not a full rebuild.
+async fn reconcile_fdb_entries(
+    backend: &dyn NetworkBackend,
+    state: &NetworkState,
+    report: &mut ReconcileReport,
+) {
+    use std::collections::{HashMap, HashSet};
+
+    if state.fdb_entries.is_empty() {
+        return;
+    }
+
+    // Group expected entries by VXLAN interface for efficient lookups.
+    let mut expected_by_vxlan: HashMap<&str, Vec<&ExpectedFdbEntry>> = HashMap::new();
+    for entry in &state.fdb_entries {
+        expected_by_vxlan
+            .entry(entry.vxlan.as_str())
+            .or_default()
+            .push(entry);
+    }
+
+    for (vxlan, expected_entries) in &expected_by_vxlan {
+        // Read actual FDB entries from the kernel.
+        let actual_fdb = match backend.list_fdb_entries(vxlan).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                report
+                    .warnings
+                    .push(format!("failed to list FDB entries for {vxlan}: {e}"));
+                continue;
+            }
+        };
+        let actual_fdb_set: HashSet<(&str, &str)> = actual_fdb
+            .iter()
+            .map(|(mac, dst)| (mac.as_str(), dst.as_str()))
+            .collect();
+
+        // Read actual ARP entries from the kernel.
+        let actual_arp = match backend.list_arp_entries(vxlan).await {
+            Ok(entries) => entries,
+            Err(e) => {
+                report
+                    .warnings
+                    .push(format!("failed to list ARP entries for {vxlan}: {e}"));
+                continue;
+            }
+        };
+        let actual_arp_set: HashSet<(&str, &str)> = actual_arp
+            .iter()
+            .map(|(ip, mac)| (ip.as_str(), mac.as_str()))
+            .collect();
+
+        // Build expected sets.
+        let expected_fdb_set: HashSet<(&str, &str)> = expected_entries
+            .iter()
+            .map(|e| (e.mac.as_str(), e.dst.as_str()))
+            .collect();
+        let expected_arp_set: HashSet<(&str, &str)> = expected_entries
+            .iter()
+            .map(|e| (e.ip.as_str(), e.mac.as_str()))
+            .collect();
+
+        // Add missing FDB entries.
+        for entry in expected_entries {
+            if !actual_fdb_set.contains(&(entry.mac.as_str(), entry.dst.as_str())) {
+                let bridge =
+                    vxlan.replace(crate::naming::VXLAN_PREFIX, crate::naming::BRIDGE_PREFIX);
+                if let Err(e) = backend.add_fdb_entry(&bridge, &entry.mac, &entry.dst).await {
+                    report
+                        .warnings
+                        .push(format!("FDB reconcile: add failed for {}: {e}", entry.mac));
+                } else {
+                    report.fdb_entries_added += 1;
+                }
+            }
+            if !actual_arp_set.contains(&(entry.ip.as_str(), entry.mac.as_str())) {
+                if let Err(e) = backend.add_arp_proxy(vxlan, &entry.ip, &entry.mac).await {
+                    report
+                        .warnings
+                        .push(format!("ARP reconcile: add failed for {}: {e}", entry.ip));
+                } else {
+                    // Count ARP adds with FDB adds for simplicity.
+                    report.fdb_entries_added += 1;
+                }
+            }
+        }
+
+        // Remove stale FDB entries (entries in kernel but not in expected state).
+        for (mac, _dst) in &actual_fdb {
+            // Only manage syfrah-derived MACs (02:00:0a:...).
+            if !mac.starts_with("02:00:") {
+                continue;
+            }
+            if !expected_fdb_set.iter().any(|(m, _)| *m == mac.as_str()) {
+                let bridge =
+                    vxlan.replace(crate::naming::VXLAN_PREFIX, crate::naming::BRIDGE_PREFIX);
+                if let Err(e) = backend.remove_fdb_entry(&bridge, mac).await {
+                    report
+                        .warnings
+                        .push(format!("FDB reconcile: remove failed for {mac}: {e}"));
+                } else {
+                    report.fdb_entries_removed += 1;
+                }
+            }
+        }
+
+        // Remove stale ARP entries.
+        for (ip, mac) in &actual_arp {
+            if !mac.starts_with("02:00:") {
+                continue;
+            }
+            if !expected_arp_set.iter().any(|(i, _)| *i == ip.as_str()) {
+                if let Err(e) = backend.remove_arp_proxy(vxlan, ip).await {
+                    report
+                        .warnings
+                        .push(format!("ARP reconcile: remove failed for {ip}: {e}"));
+                } else {
+                    report.fdb_entries_removed += 1;
+                }
+            }
+        }
     }
 }
 

--- a/tests/e2e/scenarios/522_cp_fdb_reconcile.md
+++ b/tests/e2e/scenarios/522_cp_fdb_reconcile.md
@@ -1,0 +1,54 @@
+# 522 — FDB reconciliation — drift detection and correction
+
+## Objective
+
+Verify that the periodic reconciliation loop (every 5s) detects and corrects
+FDB drift without a full rebuild.
+
+## Preconditions
+
+- Two-node mesh with Raft and VMs on different nodes in the same VPC/subnet.
+- FDB entries exist on both nodes.
+
+## Steps
+
+1. **Manually delete an FDB entry** to simulate drift:
+   ```bash
+   # Get the MAC of web-2 on server 1
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00'"
+   # Delete it
+   ssh root@hv-eu-1 "bridge fdb del 02:00:xx:xx:xx:xx dev syfx-HASH"
+   ```
+
+2. **Wait 10 seconds** for reconciliation to detect drift.
+
+3. **Verify the FDB entry is restored**:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00'"
+   ```
+
+4. **Manually add a stale FDB entry** to simulate an old placement:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb add 02:00:ff:ff:ff:ff dev syfx-HASH dst fd12::99"
+   ```
+
+5. **Wait 10 seconds** for reconciliation.
+
+6. **Verify the stale entry is removed**:
+   ```bash
+   ssh root@hv-eu-1 "bridge fdb show | grep '02:00:ff'"
+   ```
+   Should be empty.
+
+## Expected results
+
+- Missing FDB entries are re-added within one reconciliation cycle (5s).
+- Stale FDB entries (for MACs not in the expected set) are removed.
+- Only drifted entries are touched — not the entire FDB table.
+- Reconciliation logs: `fdb_added`, `fdb_removed` counts.
+
+## Pass criteria
+
+- Deleted FDB entry is restored within 10 seconds.
+- Stale FDB entry is removed within 10 seconds.
+- No spurious re-application of existing correct entries.


### PR DESCRIPTION
## Summary

Add FDB drift detection and correction to the periodic reconciliation loop. Expected FDB entries (derived from Raft placement state) are compared against actual kernel state. Only drifted entries are touched.

### Changes
- `layers/overlay/src/backend.rs`: Add `list_fdb_entries()` and `list_arp_entries()` to NetworkBackend trait
- `layers/overlay/src/linux.rs`: Implement via `bridge fdb show` and `ip neigh show`
- `layers/overlay/src/mock.rs`: Mock implementations with simulated entries
- `layers/overlay/src/reconcile.rs`: `ExpectedFdbEntry` type, `reconcile_fdb_entries()` function, updated report
- `tests/e2e/scenarios/522_cp_fdb_reconcile.md`: E2E test plan

Closes #1056