### PR TITLE
feat(compute): replicate VM placements via Raft for FDB

### DIFF
--- a/layers/compute/src/manager.rs
+++ b/layers/compute/src/manager.rs
@@ -241,6 +241,12 @@ pub struct VmManager {
     hypervisor_store: Option<Arc<syfrah_org::HypervisorStore>>,
     /// Name of this node (used to look up the local hypervisor record).
     local_node_name: Option<String>,
+    /// Optional callback to replicate VM placements through Raft.
+    /// Called after local placement store update so other nodes learn about
+    /// this VM and can populate FDB entries.
+    /// Args: (vm_id, hypervisor_id, subnet_id, ip, mac, generation, is_add).
+    #[allow(clippy::type_complexity)]
+    raft_placement_hook: Option<Arc<dyn Fn(&str, &str, &str, &str, &str, u64, bool) + Send + Sync>>,
 }
 
 impl VmManager {
@@ -332,6 +338,7 @@ impl VmManager {
             sg_rule_store: None,
             hypervisor_store: None,
             local_node_name: None,
+            raft_placement_hook: None,
         })
     }
 
@@ -371,6 +378,18 @@ impl VmManager {
         self.ipam_store = Some(ipam_store);
         self.placement_store = Some(placement_store);
         self.local_node = Some(local_node);
+    }
+
+    /// Set the Raft placement hook for cross-node FDB distribution.
+    ///
+    /// When set, VM creation and deletion will replicate placement records
+    /// through Raft so that all nodes can populate FDB entries for remote VMs.
+    #[allow(clippy::type_complexity)]
+    pub fn set_raft_placement_hook(
+        &mut self,
+        hook: Arc<dyn Fn(&str, &str, &str, &str, &str, u64, bool) + Send + Sync>,
+    ) {
+        self.raft_placement_hook = Some(hook);
     }
 
     /// Set the SG rule store so that SG-based nftables rules are applied
@@ -535,6 +554,9 @@ impl VmManager {
                 );
                 if let Some(ref rs) = self.sg_rule_store {
                     ns = ns.with_sg_rule_store(Arc::clone(rs));
+                }
+                if let Some(ref hook) = self.raft_placement_hook {
+                    ns = ns.with_raft_placement_hook(Arc::clone(hook));
                 }
                 let is_container = self.runtime.name().starts_with("container");
                 match ns

--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -77,6 +77,10 @@ pub struct NetworkSetup<B: NetworkBackend + ?Sized> {
     local_node: String,
     /// SG rule store — when present, SG-based nftables rules are applied.
     sg_rule_store: Option<Arc<SgRuleStore>>,
+    /// Optional Raft placement hook for cross-node FDB distribution.
+    /// Args: (vm_id, hypervisor_id, subnet_id, ip, mac, generation, is_add).
+    #[allow(clippy::type_complexity)]
+    raft_placement_hook: Option<Arc<dyn Fn(&str, &str, &str, &str, &str, u64, bool) + Send + Sync>>,
 }
 
 impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
@@ -95,6 +99,7 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
             backend,
             local_node,
             sg_rule_store: None,
+            raft_placement_hook: None,
         }
     }
 
@@ -102,6 +107,16 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
     /// for VMs with security groups.
     pub fn with_sg_rule_store(mut self, store: Arc<SgRuleStore>) -> Self {
         self.sg_rule_store = Some(store);
+        self
+    }
+
+    /// Set the Raft placement hook for cross-node FDB distribution.
+    #[allow(clippy::type_complexity)]
+    pub fn with_raft_placement_hook(
+        mut self,
+        hook: Arc<dyn Fn(&str, &str, &str, &str, &str, u64, bool) + Send + Sync>,
+    ) -> Self {
+        self.raft_placement_hook = Some(hook);
         self
     }
 
@@ -386,6 +401,11 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
         self.placement_store
             .add_placement(&placement)
             .map_err(|e| ComputeError::NetworkSetup(format!("placement store failed: {e}")))?;
+
+        // Replicate placement through Raft so remote nodes can populate FDB.
+        if let Some(ref hook) = self.raft_placement_hook {
+            hook(vm_id, &self.local_node, subnet_id, ip, mac, 1, true);
+        }
 
         // -- 9. Create NIC record ------------------------------------------------
         // Build security group list: use specified SGs or default to "default".

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1091,6 +1091,13 @@ pub async fn run_daemon(
             }
         };
 
+    // -- Raft placement hook (for cross-node FDB distribution) ----------------
+    //
+    // Created early so the compute layer can reference it. The actual Raft
+    // client is injected later when the control plane is initialized.
+    let raft_client_holder: Arc<std::sync::Mutex<Option<syfrah_controlplane::RaftClient>>> =
+        Arc::new(std::sync::Mutex::new(None));
+
     // -- Compute layer integration ------------------------------------------
     //
     // Initialise VmManager, reconnect existing VMs, start the monitor loop,
@@ -1198,6 +1205,57 @@ pub async fn run_daemon(
                         // from actual SG rules instead of hardcoded defaults.
                         if let Some(ref sg_rs) = shared_sg_rule_store {
                             vm_manager.set_sg_rule_store(Arc::clone(sg_rs));
+                        }
+
+                        // Wire Raft placement hook so VM creations are
+                        // replicated to all nodes for FDB distribution.
+                        {
+                            let raft_holder = Arc::clone(&raft_client_holder);
+                            #[allow(clippy::type_complexity)]
+                            let hook: Arc<
+                                dyn Fn(&str, &str, &str, &str, &str, u64, bool) + Send + Sync,
+                            > = Arc::new(
+                                move |vm_id,
+                                      hypervisor_id,
+                                      subnet_id,
+                                      ip,
+                                      mac,
+                                      generation,
+                                      is_add| {
+                                    let client = raft_holder.lock().unwrap().clone();
+                                    if let Some(client) = client {
+                                        let cmd = if is_add {
+                                            syfrah_controlplane::StateMachineCommand::PlaceVm {
+                                                vm_id: vm_id.to_string(),
+                                                hypervisor_id: hypervisor_id.to_string(),
+                                                subnet_id: subnet_id.to_string(),
+                                                ip: ip.to_string(),
+                                                mac: mac.to_string(),
+                                                generation,
+                                            }
+                                        } else {
+                                            syfrah_controlplane::StateMachineCommand::RemoveVm {
+                                                vm_id: vm_id.to_string(),
+                                            }
+                                        };
+                                        // Fire and forget — the Raft client submit is async,
+                                        // so we spawn a task. Errors are non-fatal.
+                                        let vm_id_owned = vm_id.to_string();
+                                        let rt = tokio::runtime::Handle::try_current();
+                                        if let Ok(handle) = rt {
+                                            handle.spawn(async move {
+                                                if let Err(e) = client.write(cmd).await {
+                                                    tracing::warn!(
+                                                        vm_id = %vm_id_owned,
+                                                        "Raft placement replication failed: {e}"
+                                                    );
+                                                }
+                                            });
+                                        }
+                                    }
+                                },
+                            );
+                            vm_manager.set_raft_placement_hook(hook);
                         }
 
                         info!("compute: networking wired (IPAM, bridge, VXLAN, TAP, nftables)");
@@ -1442,6 +1500,14 @@ pub async fn run_daemon(
 
             // Create a Raft client for routing mutations through the cluster.
             let raft_client = syfrah_controlplane::RaftClient::new(raft.clone());
+
+            // Inject the Raft client into the placement hook so VM creations
+            // are replicated to all nodes for FDB distribution.
+            {
+                let mut holder = raft_client_holder.lock().unwrap();
+                *holder = Some(raft_client.clone());
+                info!("raft: injected Raft client into placement hook");
+            }
 
             // Inject the Raft client into the org handler so mutations go through Raft.
             if let Some(ref handler) = raft_org_handler {


### PR DESCRIPTION
## Summary

Wire the compute layer to replicate VM placement records through Raft when VMs are created. Without this, each node only knows about its own local VMs and cannot populate FDB entries for remote VMs.

### Changes
- `layers/compute/src/manager.rs`: Add `raft_placement_hook` field and setter
- `layers/compute/src/network_setup.rs`: Add optional Raft hook, call it after local placement store update
- `layers/fabric/src/daemon.rs`: Create shared Raft client holder, wire it into compute layer, inject Raft client when available

This is the critical integration piece for cross-node VXLAN connectivity.

Closes #1057