### PR TITLE
feat(controlplane): enhanced cluster status CLI

### DIFF
--- a/bin/syfrah/src/controlplane/status.rs
+++ b/bin/syfrah/src/controlplane/status.rs
@@ -1,4 +1,4 @@
-//! `syfrah controlplane status` — show Raft cluster status.
+//! `syfrah controlplane status` — show enhanced Raft cluster status.
 
 use anyhow::{Context, Result};
 
@@ -31,37 +31,121 @@ pub async fn run(json: bool) -> Result<()> {
         .await
         .context("Failed to parse status response")?;
 
+    // Also try to query gossip info from members endpoint for member names.
+    let members_url = format!("http://[{fabric_ipv6}]:7200/raft/members");
+    let members_resp = client.get(&members_url).send().await.ok();
+    let _member_names: std::collections::HashMap<u64, String> = if let Some(resp) = members_resp {
+        if resp.status().is_success() {
+            if let Ok(members) = resp
+                .json::<syfrah_controlplane::server::MembersResponse>()
+                .await
+            {
+                members
+                    .members
+                    .into_iter()
+                    .map(|m| (m.node_id, m.addr.clone()))
+                    .collect()
+            } else {
+                std::collections::HashMap::new()
+            }
+        } else {
+            std::collections::HashMap::new()
+        }
+    } else {
+        std::collections::HashMap::new()
+    };
+
     if json {
         println!("{}", serde_json::to_string_pretty(&status)?);
     } else {
+        // Determine if we are the leader.
+        let our_role = if status.current_leader == Some(status.id) {
+            "Leader"
+        } else {
+            "Follower"
+        };
+        let total_members = status.voter_count + status.learner_count;
+
         println!("Control Plane Status");
-        println!("--------------------");
+        println!("====================");
+        println!(
+            "  Raft:       {} (term {}, commit {})",
+            our_role,
+            status.current_term,
+            status
+                .commit_index
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "0".to_string())
+        );
+        println!(
+            "  Members:    {} ({} voter, {} learner)",
+            total_members, status.voter_count, status.learner_count
+        );
+
+        // Log entries info.
+        if let Some(log_entries) = status.log_entries {
+            println!("  Log:        {} entries", log_entries);
+        }
+
+        // Members table.
+        if !status.member_details.is_empty() {
+            println!();
+            println!("Members:");
+            for member in &status.member_details {
+                let role_label = if member.is_leader {
+                    "Leader"
+                } else if member.role == "voter" {
+                    "Voter"
+                } else {
+                    "Learner"
+                };
+
+                // Try to extract a readable address — strip brackets and port.
+                let addr_display = member.addr.replace("[", "").replace("]", "");
+                let addr_clean = addr_display
+                    .rsplit_once(':')
+                    .map(|(ip, _port)| ip)
+                    .unwrap_or(&addr_display);
+
+                // Look up a friendly name (node_id -> name mapping from peers).
+                let name = node_id_to_name(member.node_id, &fabric_state);
+
+                println!(
+                    "  {:<14} {:<8} {:<10} {}",
+                    name, member.role, role_label, addr_clean
+                );
+            }
+        }
+
+        println!();
         println!("Node ID:      {}", status.id);
-        println!("State:        {}", status.state);
-        println!(
-            "Leader:       {}",
-            status
-                .current_leader
-                .map(|l| l.to_string())
-                .unwrap_or_else(|| "none".to_string())
-        );
-        println!("Term:         {}", status.current_term);
-        println!(
-            "Last log:     {}",
-            status
-                .last_log_index
-                .map(|i| i.to_string())
-                .unwrap_or_else(|| "none".to_string())
-        );
-        println!(
-            "Last applied: {}",
-            status
-                .last_applied_index
-                .map(|i| i.to_string())
-                .unwrap_or_else(|| "none".to_string())
-        );
-        println!("Members:      {:?}", status.members);
     }
 
     Ok(())
+}
+
+/// Try to map a Raft node_id back to a human-readable node name.
+/// The node_id is derived from `hash(node_name)` during Raft init,
+/// so we hash known names and compare.
+fn node_id_to_name(node_id: u64, state: &syfrah_fabric::store::NodeState) -> String {
+    use std::hash::{Hash, Hasher};
+
+    // Check our own name.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    state.node_name.hash(&mut hasher);
+    if hasher.finish() == node_id {
+        return state.node_name.clone();
+    }
+
+    // Check peer names.
+    for peer in &state.peers {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        peer.name.hash(&mut hasher);
+        if hasher.finish() == node_id {
+            return peer.name.clone();
+        }
+    }
+
+    // Fallback: show truncated node_id.
+    format!("node-{}", node_id % 10000)
 }

--- a/layers/controlplane/src/server.rs
+++ b/layers/controlplane/src/server.rs
@@ -256,6 +256,30 @@ pub struct RaftStatusResponse {
     pub last_log_index: Option<u64>,
     pub last_applied_index: Option<u64>,
     pub members: Vec<u64>,
+    /// Enhanced member details with roles and addresses.
+    #[serde(default)]
+    pub member_details: Vec<ClusterMemberDetail>,
+    /// Commit index (same as last_applied_index for leader).
+    #[serde(default)]
+    pub commit_index: Option<u64>,
+    /// Total number of log entries.
+    #[serde(default)]
+    pub log_entries: Option<u64>,
+    /// Number of voters.
+    #[serde(default)]
+    pub voter_count: u32,
+    /// Number of learners.
+    #[serde(default)]
+    pub learner_count: u32,
+}
+
+/// Detailed cluster member information.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ClusterMemberDetail {
+    pub node_id: u64,
+    pub addr: String,
+    pub role: String, // "voter" or "learner"
+    pub is_leader: bool,
 }
 
 async fn status_handler(
@@ -264,7 +288,32 @@ async fn status_handler(
     use openraft::rt::watch::WatchReceiver;
     let metrics = state.raft.metrics().borrow_watched().clone();
 
-    let members: Vec<u64> = metrics.membership_config.membership().voter_ids().collect();
+    let voter_ids: std::collections::HashSet<u64> =
+        metrics.membership_config.membership().voter_ids().collect();
+    let members: Vec<u64> = voter_ids.iter().copied().collect();
+    let leader_id = metrics.current_leader;
+
+    let member_details: Vec<ClusterMemberDetail> = metrics
+        .membership_config
+        .membership()
+        .nodes()
+        .map(|(id, node)| {
+            let role = if voter_ids.contains(id) {
+                "voter"
+            } else {
+                "learner"
+            };
+            ClusterMemberDetail {
+                node_id: *id,
+                addr: node.addr.clone(),
+                role: role.to_string(),
+                is_leader: leader_id == Some(*id),
+            }
+        })
+        .collect();
+
+    let voter_count = voter_ids.len() as u32;
+    let learner_count = (member_details.len() as u32).saturating_sub(voter_count);
 
     let resp = RaftStatusResponse {
         id: metrics.id,
@@ -276,6 +325,13 @@ async fn status_handler(
             .last_applied
             .map(|l: openraft::alias::LogIdOf<SyfrahRaftConfig>| l.index()),
         members,
+        member_details,
+        commit_index: metrics
+            .last_applied
+            .map(|l: openraft::alias::LogIdOf<SyfrahRaftConfig>| l.index()),
+        log_entries: metrics.last_log_index,
+        voter_count,
+        learner_count,
     };
     Ok(Json(resp))
 }

--- a/tests/e2e/scenarios/543_cp_status.md
+++ b/tests/e2e/scenarios/543_cp_status.md
@@ -1,0 +1,56 @@
+# E2E 543 — Enhanced cluster status CLI
+
+## Goal
+
+Verify `syfrah controlplane status` shows Raft, Members, and log details.
+
+## Prerequisites
+
+- Two-node cluster with Raft initialized
+
+## Test steps
+
+### 1. Status on leader
+
+```bash
+ssh root@65.109.130.108 "syfrah controlplane status"
+```
+
+Expected output format:
+```
+Control Plane Status
+====================
+  Raft:       Leader (term 3, commit 47)
+  Members:    2 (1 voter, 1 learner)
+  Log:        47 entries
+
+Members:
+  hv-eu-1        voter    Leader     fd12::...
+  hv-eu-2        learner  Learner    fd12::...
+
+Node ID:      12345678
+```
+
+### 2. Status on follower
+
+```bash
+ssh root@37.27.12.205 "syfrah controlplane status"
+```
+
+Expected: shows Follower role, same members list.
+
+### 3. JSON output
+
+```bash
+ssh root@65.109.130.108 "syfrah controlplane status --json"
+```
+
+Expected: full JSON with `member_details`, `voter_count`, `learner_count`, `commit_index`.
+
+## Pass criteria
+
+- Status shows Leader/Follower role correctly
+- Members table shows all cluster nodes with roles
+- Term, commit index, and log entries displayed
+- JSON output includes all enhanced fields
+- Node names resolved from fabric state (not raw IDs)


### PR DESCRIPTION
## Summary
- `syfrah controlplane status` now shows: Raft role (Leader/Follower), term, commit index, members table with roles, log entry count
- Enhanced `RaftStatusResponse` with `member_details`, `voter_count`, `learner_count`, `commit_index`
- Node name resolution from fabric peer state (hashes match Raft node IDs)
- JSON output includes all enhanced fields

## Test plan
- [ ] Status on leader shows "Leader" with correct term/commit
- [ ] Status on follower shows "Follower"
- [ ] Members table lists all nodes with voter/learner roles
- [ ] `--json` returns full enhanced response
- [ ] Node names resolved correctly from fabric state

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)