### PR TITLE
fix(controlplane): correct remote create URL

### DIFF
--- a/layers/controlplane/src/remote_create.rs
+++ b/layers/controlplane/src/remote_create.rs
@@ -37,7 +37,10 @@ pub async fn create_vm_on_remote(
     target_addr: &str,
     request: &RemoteCreateVmRequest,
 ) -> Result<RemoteCreateVmResponse, String> {
-    let url = format!("http://{target_addr}/v1/forge/instances");
+    // The ?direct=true parameter tells the target Forge to skip leader
+    // forwarding and create the VM locally. Without it, the target would
+    // forward the request back to the leader (since it's not the leader).
+    let url = format!("http://{target_addr}/v1/instances?direct=true");
     info!(
         "remote_create: sending VM '{}' to Forge at {}",
         request.name, target_addr

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -102,6 +102,25 @@ impl ConsistencyQuery {
     }
 }
 
+/// Query parameters for direct placement (skips leader forwarding).
+#[derive(Deserialize, Debug, Default)]
+pub struct DirectPlacementQuery {
+    /// When set to "true", the request is processed locally without
+    /// leader forwarding. Used by the scheduler when placing VMs on
+    /// remote hypervisors — the target node must create locally.
+    pub direct: Option<String>,
+}
+
+impl DirectPlacementQuery {
+    /// Returns true if this is a direct placement (skip leader forwarding).
+    fn is_direct(&self) -> bool {
+        self.direct
+            .as_deref()
+            .map(|s| s.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+}
+
 /// Request body for creating an instance.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CreateInstanceRequest {
@@ -785,15 +804,19 @@ async fn list_tasks_handler(
 /// POST /v1/instances — create a new VM instance.
 async fn create_instance_handler(
     State(state): State<Arc<ForgeState>>,
+    Query(params): Query<DirectPlacementQuery>,
     Json(req): Json<CreateInstanceRequest>,
 ) -> impl IntoResponse {
     // Leader forwarding: if Raft is active and we are NOT the leader,
     // forward the entire request to the leader's Forge API.
-    if let Some(leader_addr) = should_forward_to_leader(&state).await {
-        debug!("create_instance: not leader, forwarding to leader at {leader_addr}");
-        match forward_post_to_leader(&leader_addr, "/v1/instances", &req).await {
-            Ok(resp) => return resp,
-            Err(resp) => return resp,
+    // Skip forwarding if this is a direct placement from the scheduler.
+    if !params.is_direct() {
+        if let Some(leader_addr) = should_forward_to_leader(&state).await {
+            debug!("create_instance: not leader, forwarding to leader at {leader_addr}");
+            match forward_post_to_leader(&leader_addr, "/v1/instances", &req).await {
+                Ok(resp) => return resp,
+                Err(resp) => return resp,
+            }
         }
     }
 


### PR DESCRIPTION
Fix: remote_create used /v1/forge/instances but Forge exposes /v1/instances.