### PR TITLE
Gossip metrics on /metrics endpoint

### DIFF
--- a/layers/controlplane/src/gossip.rs
+++ b/layers/controlplane/src/gossip.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddrV6;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -151,6 +152,21 @@ impl HypervisorGossipReport {
 // GossipCluster — the shared state
 // ---------------------------------------------------------------------------
 
+/// Snapshot of gossip metrics for Prometheus export.
+#[derive(Debug, Clone, Default)]
+pub struct GossipMetricsSnapshot {
+    /// Members in Alive state.
+    pub members_alive: u64,
+    /// Members in Suspect state.
+    pub members_suspect: u64,
+    /// Members in Down state.
+    pub members_down: u64,
+    /// Total gossip messages sent.
+    pub messages_sent: u64,
+    /// Total gossip messages received.
+    pub messages_received: u64,
+}
+
 /// Thread-safe container for gossip cluster state.
 ///
 /// The scheduler reads from this to get hypervisor reports for placement
@@ -159,6 +175,10 @@ impl HypervisorGossipReport {
 #[derive(Clone)]
 pub struct GossipCluster {
     inner: Arc<Mutex<GossipClusterInner>>,
+    /// Total messages sent counter.
+    messages_sent: Arc<AtomicU64>,
+    /// Total messages received counter.
+    messages_received: Arc<AtomicU64>,
 }
 
 struct GossipClusterInner {
@@ -176,6 +196,40 @@ impl GossipCluster {
                 reports: HashMap::new(),
                 member_states: HashMap::new(),
             })),
+            messages_sent: Arc::new(AtomicU64::new(0)),
+            messages_received: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Increment the messages sent counter.
+    pub fn inc_messages_sent(&self) {
+        self.messages_sent.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Increment the messages received counter.
+    pub fn inc_messages_received(&self) {
+        self.messages_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Get a snapshot of gossip metrics for Prometheus export.
+    pub fn metrics_snapshot(&self) -> GossipMetricsSnapshot {
+        let inner = self.inner.lock().unwrap();
+        let mut alive = 0u64;
+        let mut suspect = 0u64;
+        let mut down = 0u64;
+        for state in inner.member_states.values() {
+            match state {
+                MemberState::Alive => alive += 1,
+                MemberState::Suspect => suspect += 1,
+                MemberState::Down => down += 1,
+            }
+        }
+        GossipMetricsSnapshot {
+            members_alive: alive,
+            members_suspect: suspect,
+            members_down: down,
+            messages_sent: self.messages_sent.load(Ordering::Relaxed),
+            messages_received: self.messages_received.load(Ordering::Relaxed),
         }
     }
 
@@ -345,6 +399,7 @@ pub async fn start_gossip_agent(
             match recv_result {
                 Ok((len, src)) => {
                     debug!("gossip: received {len} bytes from {src}");
+                    recv_cluster.inc_messages_received();
                     let mut runtime = foca::AccumulatingRuntime::new();
                     {
                         let mut f = recv_foca.lock().unwrap();
@@ -437,6 +492,7 @@ async fn drain_runtime(
         if let Err(e) = socket.send_to(&data, addr).await {
             warn!("gossip: send to {addr} failed: {e}");
         }
+        cluster.inc_messages_sent();
     }
 
     // Process notifications.

--- a/layers/controlplane/src/lib.rs
+++ b/layers/controlplane/src/lib.rs
@@ -18,7 +18,10 @@ pub mod types;
 
 pub use client::{RaftClient, RaftMetricsSnapshot};
 pub use commands::{StateMachineCommand, StateMachineResponse};
-pub use gossip::{GossipCluster, GossipConfig, GossipNodeId, HypervisorGossipReport, MemberState};
+pub use gossip::{
+    GossipCluster, GossipConfig, GossipMetricsSnapshot, GossipNodeId, HypervisorGossipReport,
+    MemberState,
+};
 pub use idempotency::IdempotencyJournal;
 pub use log_storage::RedbLogStore;
 pub use network::{SyfrahNetwork, SyfrahNetworkFactory};

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1390,6 +1390,8 @@ pub async fn run_daemon(
     // the Forge HTTP API can forward mutations to the Raft leader.
     let forge_raft_client: Arc<tokio::sync::RwLock<Option<syfrah_controlplane::RaftClient>>> =
         Arc::new(tokio::sync::RwLock::new(None));
+    let forge_gossip_cluster: Arc<tokio::sync::RwLock<Option<syfrah_controlplane::GossipCluster>>> =
+        Arc::new(tokio::sync::RwLock::new(None));
 
     // -- Forge HTTP API server -----------------------------------------------
     //
@@ -1447,6 +1449,7 @@ pub async fn run_daemon(
                 syfrah_forge::metrics::MetricsCollector::new(),
             )),
             raft_client: Arc::clone(&forge_raft_client),
+            gossip_cluster: Arc::clone(&forge_gossip_cluster),
         });
 
         let bind_addr: std::net::SocketAddr =
@@ -1590,6 +1593,17 @@ pub async fn run_daemon(
                 } else {
                     syfrah_controlplane::GossipCluster::new()
                 };
+
+                // Inject gossip cluster into Forge API for metrics export.
+                {
+                    let holder = Arc::clone(&forge_gossip_cluster);
+                    let gc = gossip_cluster.clone();
+                    tokio::spawn(async move {
+                        let mut guard = holder.write().await;
+                        *guard = Some(gc);
+                        info!("gossip: injected gossip cluster into Forge API for metrics");
+                    });
+                }
 
                 let region = my_record.region.as_deref().unwrap_or("default").to_string();
                 let zone = my_record.zone.as_deref().unwrap_or("default").to_string();

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -51,6 +51,9 @@ pub struct ForgeState {
     /// Wrapped in RwLock because it's injected after Forge starts (Raft
     /// initialization happens later in the daemon startup sequence).
     pub raft_client: Arc<tokio::sync::RwLock<Option<syfrah_controlplane::RaftClient>>>,
+    /// Gossip cluster state for metrics export.
+    /// Injected after Raft init (alongside raft_client).
+    pub gossip_cluster: Arc<tokio::sync::RwLock<Option<syfrah_controlplane::GossipCluster>>>,
 }
 
 /// Stored NIC record for the in-memory registry.
@@ -668,11 +671,68 @@ async fn prometheus_metrics_handler(State(state): State<Arc<ForgeState>>) -> imp
         }
     }
 
+    // Append gossip metrics if the gossip cluster is initialized.
+    {
+        let gossip_guard = state.gossip_cluster.read().await;
+        if let Some(ref cluster) = *gossip_guard {
+            body.push_str(&render_gossip_metrics(cluster));
+        }
+    }
+
     (
         StatusCode::OK,
         [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
         body,
     )
+}
+
+/// Render gossip-specific metrics in Prometheus text exposition format.
+fn render_gossip_metrics(cluster: &syfrah_controlplane::GossipCluster) -> String {
+    use std::fmt::Write;
+
+    let snapshot = cluster.metrics_snapshot();
+    let mut out = String::with_capacity(512);
+
+    let _ = writeln!(
+        out,
+        "# HELP gossip_members_total Number of gossip members by state"
+    );
+    let _ = writeln!(out, "# TYPE gossip_members_total gauge");
+    let _ = writeln!(
+        out,
+        "gossip_members_total{{state=\"alive\"}} {}",
+        snapshot.members_alive
+    );
+    let _ = writeln!(
+        out,
+        "gossip_members_total{{state=\"suspect\"}} {}",
+        snapshot.members_suspect
+    );
+    let _ = writeln!(
+        out,
+        "gossip_members_total{{state=\"down\"}} {}",
+        snapshot.members_down
+    );
+
+    let _ = writeln!(
+        out,
+        "# HELP gossip_messages_sent_total Total gossip messages sent"
+    );
+    let _ = writeln!(out, "# TYPE gossip_messages_sent_total counter");
+    let _ = writeln!(out, "gossip_messages_sent_total {}", snapshot.messages_sent);
+
+    let _ = writeln!(
+        out,
+        "# HELP gossip_messages_received_total Total gossip messages received"
+    );
+    let _ = writeln!(out, "# TYPE gossip_messages_received_total counter");
+    let _ = writeln!(
+        out,
+        "gossip_messages_received_total {}",
+        snapshot.messages_received
+    );
+
+    out
 }
 
 /// Render Raft-specific metrics in Prometheus text exposition format.
@@ -2349,6 +2409,7 @@ mod tests {
             drain_controller: None,
             metrics_collector: None,
             raft_client: Arc::new(tokio::sync::RwLock::new(None)),
+            gossip_cluster: Arc::new(tokio::sync::RwLock::new(None)),
         })
     }
 
@@ -2374,6 +2435,7 @@ mod tests {
             drain_controller: None,
             metrics_collector: None,
             raft_client: Arc::new(tokio::sync::RwLock::new(None)),
+            gossip_cluster: Arc::new(tokio::sync::RwLock::new(None)),
         });
         (dir, state)
     }
@@ -2602,6 +2664,7 @@ mod tests {
             drain_controller: None,
             metrics_collector: None,
             raft_client: Arc::new(tokio::sync::RwLock::new(None)),
+            gossip_cluster: Arc::new(tokio::sync::RwLock::new(None)),
         });
         let app = forge_router(state);
 
@@ -2640,6 +2703,7 @@ mod tests {
             drain_controller: None,
             metrics_collector: None,
             raft_client: Arc::new(tokio::sync::RwLock::new(None)),
+            gossip_cluster: Arc::new(tokio::sync::RwLock::new(None)),
         })
     }
 


### PR DESCRIPTION
## Summary
- Add gossip metrics to existing /metrics endpoint: gossip_members_total{state}, gossip_messages_sent_total, gossip_messages_received_total
- GossipCluster tracks message counters with AtomicU64

## Test plan
- [x] `cargo build` + `cargo fmt` + `cargo clippy` clean
- [x] All tests pass
- [ ] E2E: `e2e/552_cp_gossip_metrics.md`

Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)