### PR TITLE
Fix Raft multi-node join: 503 on 3rd member + follower restart

### DIFF
--- a/bin/syfrah/src/controlplane/join.rs
+++ b/bin/syfrah/src/controlplane/join.rs
@@ -104,9 +104,68 @@ pub async fn run() -> Result<()> {
     std::fs::write(&sentinel, format!("{node_id}"))
         .context("Failed to write raft_initialized sentinel")?;
 
+    // Automatically restart the daemon so the Raft server starts immediately.
+    // Without this, the daemon's one-shot sentinel check at startup misses
+    // the newly created file and Raft never starts until a manual restart.
     println!();
-    println!("Control plane joined. Restart the daemon to activate:");
-    println!("  syfrah fabric stop && syfrah fabric start");
+    println!("Restarting daemon to activate Raft...");
+
+    // Stop the running daemon via SIGTERM.
+    if let Some(pid) = syfrah_fabric::store::daemon_running() {
+        if syfrah_fabric::store::is_syfrah_process(pid) {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid as i32, libc::SIGTERM);
+            }
+            // Wait for graceful shutdown (up to 10s).
+            for _ in 0..100 {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                if syfrah_fabric::store::daemon_running().is_none() {
+                    break;
+                }
+            }
+            if syfrah_fabric::store::daemon_running().is_some() {
+                #[cfg(unix)]
+                unsafe {
+                    libc::kill(pid as i32, libc::SIGKILL);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+            syfrah_fabric::store::remove_pid();
+            println!("  Daemon stopped (pid {pid}).");
+        }
+    }
+
+    // Re-exec the daemon in the background via the syfrah binary.
+    // This mirrors the double-fork pattern used by `syfrah fabric start`.
+    let exe = std::env::current_exe().context("Failed to find syfrah binary")?;
+    let child = std::process::Command::new(&exe)
+        .args(["fabric", "start"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    match child {
+        Ok(_) => {
+            // Wait briefly for the daemon to start and write its PID file.
+            for _ in 0..50 {
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                if syfrah_fabric::store::daemon_running().is_some() {
+                    break;
+                }
+            }
+            if syfrah_fabric::store::daemon_running().is_some() {
+                println!("  Daemon restarted with Raft enabled.");
+            } else {
+                println!("  Daemon spawned but not yet ready. Check: syfrah fabric status");
+            }
+        }
+        Err(e) => {
+            eprintln!("  Warning: failed to restart daemon: {e}");
+            println!("  Restart manually: syfrah fabric stop && syfrah fabric start");
+        }
+    }
 
     Ok(())
 }

--- a/layers/controlplane/src/server.rs
+++ b/layers/controlplane/src/server.rs
@@ -181,6 +181,33 @@ async fn join_handler(
     info!("raft: node {} added as learner", req.node_id);
 
     // Auto-promote to voter if under the max_voters limit.
+    // First, wait for any pending membership changes to be fully applied.
+    // Without this, the 3rd node join fails with 503 because
+    // change_membership rejects when last_applied < last_log (pending config).
+    {
+        use openraft::rt::watch::WatchReceiver;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let metrics = state.raft.metrics().borrow_watched().clone();
+            let last_log = metrics.last_log_index.unwrap_or(0);
+            let last_applied = metrics
+                .last_applied
+                .map(|l: openraft::alias::LogIdOf<SyfrahRaftConfig>| l.index())
+                .unwrap_or(0);
+            if last_applied >= last_log {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                warn!(
+                    "raft: timed out waiting for log to be applied (applied={}, log={})",
+                    last_applied, last_log
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
     let current_voters = {
         use openraft::rt::watch::WatchReceiver;
         let metrics = state.raft.metrics().borrow_watched().clone();


### PR DESCRIPTION
## Summary

- **Bug #1123**: 3rd Raft member join fails with 503 because `change_membership()` is called while a previous membership change is still being applied. Added a wait loop in the `/raft/join` handler that blocks until `last_applied_index >= last_log_index` before promoting a learner to voter.
- **Bug #1124**: After `controlplane join` succeeds, the running daemon never starts Raft because it already passed the one-shot `raft_initialized` sentinel check at startup. Now `controlplane join` automatically stops the daemon and re-spawns it so Raft activates immediately without manual restart.

## Test plan

- [ ] Build and deploy to 3 Hetzner servers
- [ ] Init fabric mesh across 3 nodes
- [ ] Bootstrap Raft on node 1
- [ ] Join node 2 to Raft (should succeed)
- [ ] Join node 3 to Raft (should succeed — no 503)
- [ ] Verify all 3 nodes show as voters in `controlplane members`
- [ ] Restart followers and verify they rejoin automatically
- [ ] Test data replication across all nodes
- [ ] Test leader failover

Closes #1123
Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)