### PR TITLE
docs: multi-zone E2E test scenarios

### DIFF
--- a/tests/e2e/scenarios/600_multi_vpc_isolation.md
+++ b/tests/e2e/scenarios/600_multi_vpc_isolation.md
@@ -1,0 +1,77 @@
+# 600 — Multi-VPC Isolation
+
+Verify that VMs in different VPCs on the same zone CANNOT communicate (different VNI = total isolation).
+
+## Prerequisites
+
+- Cluster bootstrapped with Raft leader elected
+- At least 1 hypervisor registered in zone `fsn1`
+- Org `acme`, project `backend`, env `prod` exist
+
+## Setup
+
+```bash
+# Create two isolated VPCs
+syfrah vpc create vpc-a --project backend --org acme --cidr 10.1.0.0/16
+syfrah subnet create web-a --env prod --project backend --org acme --vpc vpc-a
+
+syfrah vpc create vpc-b --project backend --org acme --cidr 10.2.0.0/16
+syfrah subnet create web-b --env prod --project backend --org acme --vpc vpc-b
+
+# Security groups for both VPCs (allow SSH + ICMP for testing)
+syfrah sg create sg-a --vpc vpc-a
+syfrah sg add-rule sg-a --direction ingress --protocol tcp --port 22 --source 0.0.0.0/0
+syfrah sg add-rule sg-a --direction ingress --protocol icmp --source 0.0.0.0/0
+
+syfrah sg create sg-b --vpc vpc-b
+syfrah sg add-rule sg-b --direction ingress --protocol tcp --port 22 --source 0.0.0.0/0
+syfrah sg add-rule sg-b --direction ingress --protocol icmp --source 0.0.0.0/0
+
+# NAT gateways for internet egress
+syfrah nat-gw create gw-a --vpc vpc-a --subnet web-a
+syfrah nat-gw create gw-b --vpc vpc-b --subnet web-b
+
+# Create VMs in the SAME zone but DIFFERENT VPCs
+syfrah compute vm create --name iso-a --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web-a --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg sg-a --zone fsn1
+
+syfrah compute vm create --name iso-b --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web-b --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg sg-b --zone fsn1
+```
+
+## Assertions
+
+1. **VM-A CANNOT ping VM-B** — different VPCs have different VNIs, so VXLAN traffic is completely isolated even on the same physical host.
+   ```bash
+   # From the hypervisor hosting iso-a, exec into the VM network namespace:
+   # ping <iso-b-ip> -c 4 -W 2
+   # Expected: 100% packet loss, exit code != 0
+   ```
+
+2. **VM-A CAN ping its own gateway** — intra-VPC connectivity works.
+   ```bash
+   # ping 10.1.0.1 -c 4 -W 2
+   # Expected: 0% packet loss
+   ```
+
+3. **VM-B CAN ping its own gateway** — second VPC also functional.
+   ```bash
+   # ping 10.2.0.1 -c 4 -W 2
+   # Expected: 0% packet loss
+   ```
+
+## Expected results
+
+| Check                        | Expected        |
+|------------------------------|-----------------|
+| iso-a ping iso-b             | TIMEOUT / 100% loss |
+| iso-a ping 10.1.0.1 (gw)    | 0% loss         |
+| iso-b ping 10.2.0.1 (gw)    | 0% loss         |
+
+## Pass criteria
+
+- Cross-VPC ping MUST fail with 100% packet loss
+- Intra-VPC gateway ping MUST succeed
+- No nftables leaks between VNIs

--- a/tests/e2e/scenarios/601_vpc_peering_connectivity.md
+++ b/tests/e2e/scenarios/601_vpc_peering_connectivity.md
@@ -1,0 +1,61 @@
+# 601 — VPC Peering Connectivity
+
+Verify that VMs in peered VPCs CAN communicate, and that unpeering restores isolation.
+
+## Prerequisites
+
+- Test 600 setup completed (vpc-a, vpc-b, iso-a, iso-b all exist and running)
+- iso-a and iso-b confirmed isolated (test 600 passed)
+
+## Steps
+
+### Step 1 — Peer the two VPCs
+
+```bash
+syfrah vpc peer --from vpc-a --to vpc-b
+```
+
+### Step 2 — Verify connectivity after peering
+
+```bash
+# From iso-a, ping iso-b's IP
+# ping <iso-b-ip> -c 4 -W 2
+# Expected: 0% packet loss — peering bridges the two VNIs
+```
+
+### Step 3 — Verify latency
+
+```bash
+# Same-zone peering (both fsn1): latency should be <5ms
+# Cross-zone peering (fsn1 ↔ hel1): latency should be <30ms
+# ping <iso-b-ip> -c 10 | tail -1
+# Expected: avg < 5ms for same-zone
+```
+
+### Step 4 — Unpeer the VPCs
+
+```bash
+syfrah vpc unpeer --from vpc-a --to vpc-b
+```
+
+### Step 5 — Verify isolation restored
+
+```bash
+# From iso-a, ping iso-b's IP again
+# ping <iso-b-ip> -c 4 -W 2
+# Expected: 100% packet loss — isolation restored
+```
+
+## Assertions
+
+| Check                              | Expected          |
+|------------------------------------|--------------------|
+| Ping after peering                 | 0% loss            |
+| Latency (same zone)               | < 5ms avg          |
+| Ping after unpeering               | 100% loss (timeout)|
+
+## Pass criteria
+
+- Peering MUST enable cross-VPC communication
+- Latency MUST be reasonable for the zone topology
+- Unpeering MUST fully restore isolation (no residual routes or FDB entries)

--- a/tests/e2e/scenarios/602_cross_zone_vxlan_ping.md
+++ b/tests/e2e/scenarios/602_cross_zone_vxlan_ping.md
@@ -1,0 +1,70 @@
+# 602 — Cross-Zone VXLAN Ping
+
+Verify that VMs in the same subnet but different zones can communicate over VXLAN tunnels (WireGuard-backed).
+
+## Prerequisites
+
+- Cluster bootstrapped with Raft leader elected
+- Hypervisors registered in at least 2 zones (fsn1 and hel1)
+- Default VPC and subnet `web` exist under org `acme`, project `backend`, env `prod`
+- Security group `web-sg` allows ICMP and SSH
+
+## Setup
+
+```bash
+# Create two VMs in different zones, same subnet
+syfrah compute vm create --name xzone-1 --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg --zone fsn1
+
+syfrah compute vm create --name xzone-2 --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg --zone hel1
+```
+
+## Assertions
+
+1. **Different IPs assigned** — distributed IPAM must not collide.
+   ```bash
+   syfrah compute vm list --project backend --org acme
+   # xzone-1 and xzone-2 have different IPs in the same subnet range
+   ```
+
+2. **Bidirectional ping works** — VXLAN over WireGuard mesh.
+   ```bash
+   # From xzone-1: ping <xzone-2-ip> -c 10
+   # Expected: 0% packet loss
+   
+   # From xzone-2: ping <xzone-1-ip> -c 10
+   # Expected: 0% packet loss
+   ```
+
+3. **Latency is reasonable** — fsn1 ↔ hel1 physical distance adds ~20-30ms.
+   ```bash
+   # ping <xzone-2-ip> -c 10 | tail -1
+   # Expected: rtt avg ~20-30ms (reflecting Falkenstein ↔ Helsinki distance)
+   ```
+
+4. **FDB entries present on both nodes**.
+   ```bash
+   # On the hypervisor hosting xzone-1:
+   # bridge fdb show dev vxlan-<vni> | grep <xzone-2-mac>
+   # Expected: MAC entry pointing to remote hypervisor's WireGuard IP
+   ```
+
+## Expected results
+
+| Check                        | Expected              |
+|------------------------------|-----------------------|
+| Unique IPs                   | Yes (different IPs)   |
+| xzone-1 → xzone-2 ping      | 0% loss               |
+| xzone-2 → xzone-1 ping      | 0% loss               |
+| Latency (fsn1 ↔ hel1)       | ~20-30ms avg          |
+| FDB entries                  | Present on both nodes |
+
+## Pass criteria
+
+- Both VMs get unique IPs from the same subnet
+- Bidirectional ping succeeds with 0% loss
+- Latency reflects physical distance (not local loopback)
+- FDB entries are correctly populated on both hypervisors

--- a/tests/e2e/scenarios/603_security_group_enforcement.md
+++ b/tests/e2e/scenarios/603_security_group_enforcement.md
@@ -1,0 +1,77 @@
+# 603 — Security Group Enforcement
+
+Verify that security group rules are enforced at the network level — allowed traffic passes, denied traffic is blocked.
+
+## Prerequisites
+
+- Cluster bootstrapped with Raft leader elected
+- Default VPC and subnet `web` exist under org `acme`, project `backend`, env `prod`
+- At least one other VM exists for sending test traffic
+
+## Setup
+
+```bash
+# Create a restrictive SG: only HTTP (TCP 80) and ICMP — NO SSH (TCP 22)
+syfrah sg create http-only --vpc acme-backend-default
+syfrah sg add-rule http-only --direction ingress --protocol tcp --port 80 --source 0.0.0.0/0
+syfrah sg add-rule http-only --direction ingress --protocol icmp --source 0.0.0.0/0
+# NOTE: No port 22 rule — SSH must be blocked
+
+# Create a VM with the restrictive SG
+syfrah compute vm create --name sg-test --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg http-only
+```
+
+## Assertions
+
+1. **ICMP (ping) works** — ICMP rule is present.
+   ```bash
+   # From another VM in the same subnet:
+   # ping <sg-test-ip> -c 4 -W 2
+   # Expected: 0% packet loss
+   ```
+
+2. **SSH (TCP 22) is BLOCKED** — no port 22 rule in the SG.
+   ```bash
+   # From another VM:
+   # ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no root@<sg-test-ip>
+   # Expected: Connection refused or timeout (exit code != 0)
+   ```
+
+3. **SG check CLI confirms denial**.
+   ```bash
+   syfrah sg check --vm sg-test --port 22 --protocol tcp
+   # Expected output: DENIED
+   
+   syfrah sg check --vm sg-test --port 80 --protocol tcp
+   # Expected output: ALLOWED
+   
+   syfrah sg check --vm sg-test --port 443 --protocol tcp
+   # Expected output: DENIED (no rule for 443)
+   ```
+
+4. **nftables rules are correctly applied**.
+   ```bash
+   # On the hypervisor hosting sg-test:
+   # nft list chain inet syfrah vm-sg-test-ingress
+   # Expected: TCP dport 80 accept, ICMP accept, no TCP dport 22 rule
+   ```
+
+## Expected results
+
+| Check                           | Expected           |
+|---------------------------------|--------------------|
+| Ping sg-test                    | 0% loss (ALLOWED)  |
+| SSH to sg-test                  | REFUSED/TIMEOUT    |
+| sg check --port 22 --protocol tcp | DENIED           |
+| sg check --port 80 --protocol tcp | ALLOWED          |
+| sg check --port 443 --protocol tcp | DENIED          |
+| nftables chain                  | Correct rules      |
+
+## Pass criteria
+
+- Allowed protocols (ICMP, TCP 80) pass through
+- Denied protocols (TCP 22, TCP 443) are blocked
+- `syfrah sg check` returns correct ALLOWED/DENIED verdicts
+- nftables rules match the SG definition exactly

--- a/tests/e2e/scenarios/604_drain_reject_placement.md
+++ b/tests/e2e/scenarios/604_drain_reject_placement.md
@@ -1,0 +1,80 @@
+# 604 — Drain Reject Placement
+
+Verify that a drained hypervisor is excluded from VM placement, and that activating it re-enables placement.
+
+## Prerequisites
+
+- Cluster bootstrapped with Raft leader elected
+- Multiple hypervisors registered, including at least 2 in zone `nbg1`
+- Default VPC, subnet, and security group configured
+
+## Steps
+
+### Step 1 — Verify initial state
+
+```bash
+syfrah hypervisor list
+# All hypervisors should be in "active" state
+# Note which hypervisors are in zone nbg1
+```
+
+### Step 2 — Drain one nbg1 hypervisor
+
+```bash
+syfrah hypervisor drain hv-nbg1-01
+syfrah hypervisor list
+# hv-nbg1-01 should now show status "draining" or "drained"
+```
+
+### Step 3 — Create a VM targeting nbg1
+
+```bash
+syfrah compute vm create --name drain-test --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg --zone nbg1
+```
+
+### Step 4 — Verify placement avoided drained node
+
+```bash
+syfrah compute vm get drain-test --project backend --org acme
+# Expected: VM placed on hv-nbg1-02 (or another active nbg1 hypervisor), NOT hv-nbg1-01
+```
+
+### Step 5 — Edge case: drain all nbg1 hypervisors
+
+```bash
+syfrah hypervisor drain hv-nbg1-02
+syfrah compute vm create --name drain-test-2 --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg --zone nbg1
+# Expected: FAIL with error "no hypervisor available in zone nbg1" or similar
+```
+
+### Step 6 — Re-activate and verify placement works again
+
+```bash
+syfrah hypervisor activate hv-nbg1-01
+syfrah hypervisor activate hv-nbg1-02
+
+syfrah compute vm create --name drain-test-3 --image alpine-3.20 --vcpus 1 --memory 512 \
+  --env prod --subnet web --project backend --org acme \
+  --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg --zone nbg1
+# Expected: SUCCESS — VM placed on one of the now-active nbg1 hypervisors
+```
+
+## Assertions
+
+| Check                                      | Expected                              |
+|--------------------------------------------|---------------------------------------|
+| Drain hv-nbg1-01                           | Status changes to drained             |
+| VM with --zone nbg1 (one drained)         | Placed on hv-nbg1-02                 |
+| VM with --zone nbg1 (all drained)         | Error: no hypervisor available        |
+| Activate both, then create VM              | SUCCESS, placed on active hypervisor  |
+
+## Pass criteria
+
+- Drained hypervisors MUST NOT receive new VMs
+- When all hypervisors in a zone are drained, VM creation MUST fail with a clear error
+- Re-activating a hypervisor MUST allow it to receive VMs again
+- Existing VMs on a drained hypervisor MUST NOT be affected (drain only blocks new placement)

--- a/tests/e2e/scenarios/605_burst_create_10_vms.md
+++ b/tests/e2e/scenarios/605_burst_create_10_vms.md
@@ -1,0 +1,89 @@
+# 605 — Burst Create 10 VMs
+
+Verify that creating 10 VMs in rapid succession results in unique IPs, distributed placement, and clean cleanup.
+
+## Prerequisites
+
+- Cluster bootstrapped with Raft leader elected
+- Multiple hypervisors registered across zones
+- Default VPC, subnet `web`, security group `web-sg` configured
+- Subnet has sufficient IP space for 10 allocations
+
+## Setup
+
+```bash
+# Create 10 VMs in rapid sequence (no --zone constraint, let scheduler distribute)
+for i in $(seq 1 10); do
+  syfrah compute vm create --name burst-$i --image alpine-3.20 --vcpus 1 --memory 512 \
+    --env prod --subnet web --project backend --org acme \
+    --ssh-key ~/.ssh/id_ed25519.pub --sg web-sg
+done
+```
+
+## Assertions
+
+1. **All 10 VMs created successfully**.
+   ```bash
+   syfrah compute vm list --project backend --org acme | grep burst-
+   # Expected: 10 entries, all in "Running" state
+   ```
+
+2. **All 10 have unique IPs** — no IPAM collision.
+   ```bash
+   syfrah compute vm list --project backend --org acme --format json | jq '[.[] | select(.name | startswith("burst-")) | .ip] | unique | length'
+   # Expected: 10 (all unique)
+   ```
+
+3. **Distributed across hypervisors** — not all on one node.
+   ```bash
+   syfrah compute vm list --project backend --org acme --format json | jq '[.[] | select(.name | startswith("burst-")) | .hypervisor] | unique | length'
+   # Expected: >= 2 (at least 2 different hypervisors used)
+   ```
+
+4. **All VMs are Running**.
+   ```bash
+   syfrah compute vm list --project backend --org acme --format json | jq '[.[] | select(.name | startswith("burst-")) | .status] | unique'
+   # Expected: ["Running"]
+   ```
+
+## Cleanup
+
+```bash
+# Delete all 10 VMs
+for i in $(seq 1 10); do
+  syfrah compute vm delete burst-$i --project backend --org acme --force
+done
+```
+
+## Post-cleanup assertions
+
+5. **All IPs released** — no leaked allocations.
+   ```bash
+   syfrah ipam list --subnet web --env prod --project backend --org acme
+   # Expected: burst-* IPs no longer allocated
+   ```
+
+6. **No leaked interfaces** — tap devices and veth pairs cleaned up.
+   ```bash
+   # On each hypervisor:
+   # ip link show | grep burst
+   # Expected: no interfaces matching "burst-*"
+   ```
+
+## Expected results
+
+| Check                          | Expected                    |
+|--------------------------------|-----------------------------|
+| VMs created                    | 10/10 success               |
+| Unique IPs                     | 10 unique IPs               |
+| Hypervisor distribution        | >= 2 hypervisors used       |
+| All Running                    | Yes                         |
+| IPs released after delete      | All freed                   |
+| Interfaces cleaned after delete| No leaked tap/veth devices  |
+
+## Pass criteria
+
+- All 10 VMs must be created without IPAM collisions
+- Scheduler must distribute across at least 2 hypervisors
+- All VMs reach Running state
+- Deletion must cleanly release all IPs and network interfaces


### PR DESCRIPTION
## Summary

- Add 6 E2E test scenarios (600-605) covering multi-zone networking features
- **600** — Multi-VPC isolation: VMs in different VPCs on the same zone cannot communicate
- **601** — VPC peering connectivity: peered VPCs enable cross-VPC communication, unpeering restores isolation
- **602** — Cross-zone VXLAN ping: VMs in different zones (fsn1 ↔ hel1) communicate over VXLAN/WireGuard
- **603** — Security group enforcement: SG rules block/allow traffic at the nftables level
- **604** — Drain reject placement: drained hypervisors are excluded from VM placement
- **605** — Burst create 10 VMs: rapid creation yields unique IPs, distributed placement, clean cleanup

## Test plan

- [ ] Review each scenario for completeness and correct CLI syntax
- [ ] Verify scenario numbering does not conflict with existing tests
- [ ] Execute all 6 scenarios on Hetzner infrastructure