### PR TITLE
Fix SG nftables: add base forward chain and vmap dispatch

### DIFF
--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -369,6 +369,7 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
                         .iter()
                         .map(|id| syfrah_overlay::sg::SecurityGroupId(id.0.clone()))
                         .collect(),
+                    iface_name: host_iface.clone(),
                 };
 
                 let sg_ip_map = std::collections::HashMap::new();

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1208,6 +1208,13 @@ pub async fn run_daemon(
                             warn!("compute: failed to apply infra protection rules: {e}");
                         }
 
+                        // Initialize the SG nftables table with the base
+                        // forward chain and dispatch vmaps so that per-VM
+                        // chains are reachable once VMs are created.
+                        if let Err(e) = backend.apply_sg_base_chain().await {
+                            warn!("compute: failed to apply SG base chain: {e}");
+                        }
+
                         vm_manager.set_network(
                             Arc::clone(&backend),
                             bridge_counter,

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -257,6 +257,9 @@ pub struct ApplySgRequest {
     /// Map of SG name -> list of IPs for SG reference resolution.
     #[serde(default)]
     pub sg_ip_map: HashMap<String, Vec<String>>,
+    /// Host-side interface name (TAP or veth). Defaults to tap_name(vm_id).
+    #[serde(default)]
+    pub iface_name: Option<String>,
 }
 
 /// Input format for a security group rule.
@@ -284,6 +287,9 @@ fn default_priority() -> u32 {
 pub struct RemoveSgRequest {
     /// VM identifier whose chains should be flushed.
     pub vm_id: String,
+    /// Host-side interface name (TAP or veth). Defaults to tap_name(vm_id).
+    #[serde(default)]
+    pub iface_name: Option<String>,
 }
 
 /// NAT gateway state.
@@ -1967,6 +1973,10 @@ async fn apply_sg_handler(
         }
     };
 
+    let iface_name = req
+        .iface_name
+        .clone()
+        .unwrap_or_else(|| syfrah_overlay::naming::tap_name(&req.vm_id));
     let nic = syfrah_overlay::sg_nft::NetworkInterface {
         id: syfrah_overlay::sg_nft::NicId(format!("nic-{}", req.vm_id)),
         vm_id: req.vm_id.clone(),
@@ -1988,6 +1998,7 @@ async fn apply_sg_handler(
             .iter()
             .map(|s| syfrah_overlay::sg::SecurityGroupId(s.clone()))
             .collect(),
+        iface_name,
     };
 
     let rules: Vec<syfrah_overlay::sg::SecurityGroupRule> =
@@ -2040,7 +2051,12 @@ async fn remove_sg_handler(
         }
     };
 
-    if let Err(e) = syfrah_overlay::sg_nft::remove_sg_for_vm(&req.vm_id) {
+    let iface_name = req
+        .iface_name
+        .as_deref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| syfrah_overlay::naming::tap_name(&req.vm_id));
+    if let Err(e) = syfrah_overlay::sg_nft::remove_sg_for_vm(&req.vm_id, &iface_name) {
         warn!(vm_id = %req.vm_id, error = %e, "failed to remove SG chains");
         return (
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -79,6 +79,10 @@ pub trait NetworkBackend: Send + Sync {
     /// Must be called once during init, before any per-VM rules are applied.
     async fn apply_infra_protection(&self) -> Result<()>;
 
+    /// Initialize the SG nftables table with a base forward chain and
+    /// dispatch vmaps. Idempotent — safe to call multiple times.
+    async fn apply_sg_base_chain(&self) -> Result<()>;
+
     /// Apply anti-spoofing + default ingress/egress rules for a VM.
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()>;
 

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -340,6 +340,13 @@ impl NetworkBackend for LinuxBackend {
         Ok(())
     }
 
+    async fn apply_sg_base_chain(&self) -> Result<()> {
+        let ruleset = crate::sg_nft::build_sg_base_chain();
+        crate::nft::apply_ruleset(&ruleset)
+            .map_err(|e| OverlayError::CommandFailed(e.to_string()))?;
+        Ok(())
+    }
+
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
         // Ensure table and chain exist (ignore errors if already present)
         Self::run("nft", &["add", "table", "inet", "syfrah"])

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -221,6 +221,11 @@ impl NetworkBackend for MockBackend {
         Ok(())
     }
 
+    async fn apply_sg_base_chain(&self) -> Result<()> {
+        self.record("apply_sg_base_chain()".to_string());
+        Ok(())
+    }
+
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
         self.record(format!("apply_vm_rules({tap}, {mac}, {ip})"));
         Ok(())

--- a/layers/overlay/src/reconcile.rs
+++ b/layers/overlay/src/reconcile.rs
@@ -187,6 +187,13 @@ pub async fn reconcile_network(
             .push(format!("infra protection re-apply failed: {e}"));
     }
 
+    // 3a-bis. Re-apply SG base chain (forward chain + dispatch vmaps)
+    if let Err(e) = backend.apply_sg_base_chain().await {
+        report
+            .warnings
+            .push(format!("SG base chain re-apply failed: {e}"));
+    }
+
     // 3b. Re-apply nftables rules (they don't survive reboot)
     reapply_rules(backend, expected_state, &mut report).await;
 

--- a/layers/overlay/src/sg_nft.rs
+++ b/layers/overlay/src/sg_nft.rs
@@ -33,6 +33,8 @@ pub struct NetworkInterface {
     pub private_ip: Ipv4Addr,
     pub mac: String,
     pub security_groups: Vec<SecurityGroupId>,
+    /// Host-side interface name (TAP or veth) used for vmap dispatch.
+    pub iface_name: String,
 }
 
 // ── nftables rule generation ───────────────────────────────────────
@@ -203,13 +205,83 @@ pub fn render_egress_chain(vm_id: &str, rules: &[NftRule]) -> String {
 /// The nftables table name used for SG chains.
 const SG_TABLE: &str = "syfrah_sg";
 
+/// Name of the base forward chain in the SG table.
+const SG_FORWARD_CHAIN: &str = "forward";
+
+/// Name of the ingress dispatch vmap (oif -> per-VM ingress chain).
+const INGRESS_DISPATCH_MAP: &str = "ingress_dispatch";
+
+/// Name of the egress dispatch vmap (iif -> per-VM egress chain).
+const EGRESS_DISPATCH_MAP: &str = "egress_dispatch";
+
+/// Generate the SG table infrastructure: base forward chain + dispatch vmaps.
+///
+/// This must be applied once at startup (or before the first VM). All
+/// statements are idempotent (`add` is a no-op if the object exists).
+///
+/// Produces:
+/// ```text
+/// add table inet syfrah_sg
+/// add chain inet syfrah_sg forward { type filter hook forward priority 0; policy drop; }
+/// add rule inet syfrah_sg forward ct state established,related accept
+/// add rule inet syfrah_sg forward ct state invalid drop
+/// add map inet syfrah_sg ingress_dispatch { type ifname : verdict; }
+/// add map inet syfrah_sg egress_dispatch { type ifname : verdict; }
+/// add rule inet syfrah_sg forward oifname vmap @ingress_dispatch
+/// add rule inet syfrah_sg forward iifname vmap @egress_dispatch
+/// ```
+pub fn build_sg_base_chain() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "add table inet {SG_TABLE}").unwrap();
+    writeln!(
+        buf,
+        "add chain inet {SG_TABLE} {SG_FORWARD_CHAIN} {{ type filter hook forward priority 0; policy drop; }}"
+    )
+    .unwrap();
+    // Conntrack: allow established/related, drop invalid.
+    writeln!(
+        buf,
+        "add rule inet {SG_TABLE} {SG_FORWARD_CHAIN} ct state established,related accept"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "add rule inet {SG_TABLE} {SG_FORWARD_CHAIN} ct state invalid drop"
+    )
+    .unwrap();
+    // Dispatch vmaps (idempotent creation).
+    writeln!(
+        buf,
+        "add map inet {SG_TABLE} {INGRESS_DISPATCH_MAP} {{ type ifname : verdict; }}"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "add map inet {SG_TABLE} {EGRESS_DISPATCH_MAP} {{ type ifname : verdict; }}"
+    )
+    .unwrap();
+    // Vmap lookup rules — these dispatch to per-VM chains based on interface.
+    writeln!(
+        buf,
+        "add rule inet {SG_TABLE} {SG_FORWARD_CHAIN} oifname vmap @{INGRESS_DISPATCH_MAP}"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "add rule inet {SG_TABLE} {SG_FORWARD_CHAIN} iifname vmap @{EGRESS_DISPATCH_MAP}"
+    )
+    .unwrap();
+    buf
+}
+
 /// Build a complete nftables ruleset for a VM's security groups.
 ///
 /// The ruleset includes:
-/// 1. Table creation (`add table inet syfrah_sg` -- idempotent)
+/// 1. Table + base forward chain + dispatch vmaps (idempotent)
 /// 2. Named sets for any SG references
 /// 3. Ingress chain (`vm_{hash}_in`)
 /// 4. Egress chain (`vm_{hash}_out`)
+/// 5. Vmap entries mapping the NIC's interface to the per-VM chains
 ///
 /// `sg_ip_map` provides the IP addresses for each referenced SG name.
 pub fn build_sg_ruleset(
@@ -219,8 +291,8 @@ pub fn build_sg_ruleset(
 ) -> String {
     let mut buf = String::new();
 
-    // Idempotent table creation.
-    writeln!(buf, "add table inet {SG_TABLE}").unwrap();
+    // Idempotent base infrastructure (table, forward chain, vmaps).
+    write!(buf, "{}", build_sg_base_chain()).unwrap();
 
     // Named sets for SG references.
     for (sg_name, ips) in sg_ip_map {
@@ -244,6 +316,19 @@ pub fn build_sg_ruleset(
     for rule in &egress_rules {
         writeln!(buf, "add rule inet {SG_TABLE} {out_chain} {}", rule.text).unwrap();
     }
+
+    // Vmap entries: map the NIC's interface to the per-VM chains.
+    let iface = &nic.iface_name;
+    writeln!(
+        buf,
+        "add element inet {SG_TABLE} {INGRESS_DISPATCH_MAP} {{ \"{iface}\" : jump {in_chain} }}"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "add element inet {SG_TABLE} {EGRESS_DISPATCH_MAP} {{ \"{iface}\" : jump {out_chain} }}"
+    )
+    .unwrap();
 
     buf
 }
@@ -276,28 +361,38 @@ pub fn apply_sg_for_vm(
     crate::nft::apply_ruleset(&ruleset)
 }
 
-/// Remove all SG chains for a VM by flushing and deleting them.
+/// Remove all SG chains for a VM by removing vmap entries, flushing
+/// and deleting the per-VM chains from the SG table.
 ///
-/// Produces an nftables script that flushes the ingress/egress chains
-/// and deletes them from the SG table.
-pub fn remove_sg_for_vm(vm_id: &str) -> std::io::Result<()> {
-    let in_chain = ingress_chain_name(vm_id);
-    let out_chain = egress_chain_name(vm_id);
-    let mut buf = String::new();
-    // Flush then delete — both are idempotent-safe with `delete` (nft
-    // returns success if chain does not exist when using -f batch).
-    writeln!(buf, "flush chain inet {SG_TABLE} {in_chain}").unwrap();
-    writeln!(buf, "delete chain inet {SG_TABLE} {in_chain}").unwrap();
-    writeln!(buf, "flush chain inet {SG_TABLE} {out_chain}").unwrap();
-    writeln!(buf, "delete chain inet {SG_TABLE} {out_chain}").unwrap();
-    crate::nft::apply_ruleset(&buf)
+/// `iface_name` is the host-side interface (TAP or veth) used in the
+/// dispatch vmaps.
+pub fn remove_sg_for_vm(vm_id: &str, iface_name: &str) -> std::io::Result<()> {
+    let ruleset = build_remove_ruleset(vm_id, iface_name);
+    crate::nft::apply_ruleset(&ruleset)
 }
 
 /// Build the removal ruleset for a VM (for testing without executing).
-pub fn build_remove_ruleset(vm_id: &str) -> String {
+///
+/// Removes vmap dispatch entries first, then flushes and deletes the
+/// per-VM chains.
+pub fn build_remove_ruleset(vm_id: &str, iface_name: &str) -> String {
     let in_chain = ingress_chain_name(vm_id);
     let out_chain = egress_chain_name(vm_id);
     let mut buf = String::new();
+    // Remove vmap entries before deleting chains (chains must have no
+    // references before they can be deleted).
+    writeln!(
+        buf,
+        "delete element inet {SG_TABLE} {INGRESS_DISPATCH_MAP} {{ \"{iface_name}\" }}"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "delete element inet {SG_TABLE} {EGRESS_DISPATCH_MAP} {{ \"{iface_name}\" }}"
+    )
+    .unwrap();
+    // Flush then delete — both are idempotent-safe with `delete` (nft
+    // returns success if chain does not exist when using -f batch).
     writeln!(buf, "flush chain inet {SG_TABLE} {in_chain}").unwrap();
     writeln!(buf, "delete chain inet {SG_TABLE} {in_chain}").unwrap();
     writeln!(buf, "flush chain inet {SG_TABLE} {out_chain}").unwrap();
@@ -438,6 +533,7 @@ mod tests {
             private_ip: Ipv4Addr::new(10, 1, 0, 5),
             mac: "02:00:0a:01:00:05".to_string(),
             security_groups: vec![SecurityGroupId("sg-default".to_string())],
+            iface_name: "syft-abcd1234".to_string(),
         }
     }
 
@@ -975,12 +1071,84 @@ mod tests {
 
     #[test]
     fn test_build_remove_ruleset() {
-        let ruleset = build_remove_ruleset("vm-1");
+        let ruleset = build_remove_ruleset("vm-1", "syft-abcd1234");
         let in_chain = ingress_chain_name("vm-1");
         let out_chain = egress_chain_name("vm-1");
+        // Vmap entries must be removed before chains.
+        assert!(ruleset
+            .contains("delete element inet syfrah_sg ingress_dispatch { \"syft-abcd1234\" }"));
+        assert!(
+            ruleset.contains("delete element inet syfrah_sg egress_dispatch { \"syft-abcd1234\" }")
+        );
         assert!(ruleset.contains(&format!("flush chain inet syfrah_sg {in_chain}")));
         assert!(ruleset.contains(&format!("delete chain inet syfrah_sg {in_chain}")));
         assert!(ruleset.contains(&format!("flush chain inet syfrah_sg {out_chain}")));
         assert!(ruleset.contains(&format!("delete chain inet syfrah_sg {out_chain}")));
+    }
+
+    // ── Base chain + vmap dispatch tests ─────────────────────────────
+
+    #[test]
+    fn test_build_sg_base_chain() {
+        let base = build_sg_base_chain();
+        assert!(base.contains("add table inet syfrah_sg"));
+        assert!(base.contains("add chain inet syfrah_sg forward { type filter hook forward priority 0; policy drop; }"));
+        assert!(base.contains("ct state established,related accept"));
+        assert!(base.contains("ct state invalid drop"));
+        assert!(base.contains("add map inet syfrah_sg ingress_dispatch { type ifname : verdict; }"));
+        assert!(base.contains("add map inet syfrah_sg egress_dispatch { type ifname : verdict; }"));
+        assert!(base.contains("oifname vmap @ingress_dispatch"));
+        assert!(base.contains("iifname vmap @egress_dispatch"));
+    }
+
+    #[test]
+    fn test_build_sg_ruleset_includes_base_chain() {
+        let nic = test_nic();
+        let rules = vec![ingress_rule(
+            Protocol::Tcp,
+            Some(PortRange { from: 22, to: 22 }),
+            TrafficSource::Cidr("0.0.0.0/0".to_string()),
+            100,
+        )];
+        let sg_map = std::collections::HashMap::new();
+        let ruleset = build_sg_ruleset(&nic, &rules, &sg_map);
+        // Must include the base forward chain with hook.
+        assert!(ruleset.contains("type filter hook forward priority 0; policy drop;"));
+        // Must include dispatch vmaps.
+        assert!(ruleset.contains("add map inet syfrah_sg ingress_dispatch"));
+        assert!(ruleset.contains("add map inet syfrah_sg egress_dispatch"));
+    }
+
+    #[test]
+    fn test_build_sg_ruleset_includes_vmap_entries() {
+        let nic = test_nic();
+        let rules = vec![ingress_rule(
+            Protocol::Tcp,
+            Some(PortRange { from: 22, to: 22 }),
+            TrafficSource::Cidr("0.0.0.0/0".to_string()),
+            100,
+        )];
+        let sg_map = std::collections::HashMap::new();
+        let ruleset = build_sg_ruleset(&nic, &rules, &sg_map);
+        let in_chain = ingress_chain_name(&nic.vm_id);
+        let out_chain = egress_chain_name(&nic.vm_id);
+        // Vmap entries must map the interface to the per-VM chains.
+        assert!(ruleset.contains(&format!(
+            "add element inet syfrah_sg ingress_dispatch {{ \"syft-abcd1234\" : jump {in_chain} }}"
+        )));
+        assert!(ruleset.contains(&format!(
+            "add element inet syfrah_sg egress_dispatch {{ \"syft-abcd1234\" : jump {out_chain} }}"
+        )));
+    }
+
+    #[test]
+    fn test_vmap_entries_removed_before_chains() {
+        let ruleset = build_remove_ruleset("vm-1", "syft-abcd1234");
+        let vmap_pos = ruleset.find("delete element").unwrap();
+        let chain_pos = ruleset.find("flush chain").unwrap();
+        assert!(
+            vmap_pos < chain_pos,
+            "vmap entries must be removed before chains are deleted"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- The SG nftables system created per-VM chains (`vm_{hash}_in`, `vm_{hash}_out`) in the `syfrah_sg` table but never created a base chain with `type filter hook forward` to dispatch into them — the chains were orphaned and never evaluated by nftables
- Added a base forward chain with `policy drop`, conntrack rules (`established,related` accept, `invalid` drop), and `oifname vmap` / `iifname vmap` dispatch rules that jump into per-VM chains based on interface name
- Added `ingress_dispatch` and `egress_dispatch` vmap tables that map TAP/veth interface names to per-VM chain jump verdicts, with entries added on VM SG apply and removed on VM SG teardown
- Base chain is initialized at daemon startup and during reconciliation

## Test plan

- [x] All 38 SG nftables unit tests pass (including 4 new tests for base chain, vmap entries, and removal ordering)
- [x] Full workspace builds clean (`cargo build --workspace`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt` applied
- [ ] Deploy to Hetzner test servers: create VM with restrictive SG (ICMP only), verify ping works but SSH is blocked