### PR TITLE
fix: create dispatch chains before forward chain goto rules

### DIFF
--- a/layers/overlay/src/sg_nft.rs
+++ b/layers/overlay/src/sg_nft.rs
@@ -241,6 +241,11 @@ const EGRESS_DISPATCH_CHAIN: &str = "dispatch_egress";
 pub fn build_sg_base_chain() -> String {
     let mut buf = String::new();
     writeln!(buf, "add table inet {SG_TABLE}").unwrap();
+    // Dispatch chains must be created before the forward chain rules that
+    // reference them via `goto`, otherwise `nft -f -` will reject the rules.
+    writeln!(buf, "add chain inet {SG_TABLE} {INGRESS_DISPATCH_CHAIN}").unwrap();
+    writeln!(buf, "add chain inet {SG_TABLE} {EGRESS_DISPATCH_CHAIN}").unwrap();
+    // Base forward chain with default-drop policy.
     writeln!(
         buf,
         "add chain inet {SG_TABLE} {SG_FORWARD_CHAIN} {{ type filter hook forward priority 0; policy drop; }}"
@@ -268,9 +273,6 @@ pub fn build_sg_base_chain() -> String {
         r#"add rule inet {SG_TABLE} {SG_FORWARD_CHAIN} iifname != "lo" goto {EGRESS_DISPATCH_CHAIN}"#
     )
     .unwrap();
-    // Dispatch chains: created idempotently; populated per-VM.
-    writeln!(buf, "add chain inet {SG_TABLE} {INGRESS_DISPATCH_CHAIN}").unwrap();
-    writeln!(buf, "add chain inet {SG_TABLE} {EGRESS_DISPATCH_CHAIN}").unwrap();
     buf
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1144. The `nft -f -` processor evaluates statements in order, so `dispatch_ingress`/`dispatch_egress` chains must be declared before any `goto` rule in the forward chain references them. Previously these were declared after the goto rules, causing `nft` to reject the ruleset with ENOENT.

- Move `add chain ... dispatch_ingress` and `add chain ... dispatch_egress` to immediately after `add table`, before the forward chain and its goto rules.

Caught during live testing on Hetzner servers.