### PR TITLE
fix: VPC peering data plane wiring

### DIFF
--- a/layers/fabric/src/raft_handler.rs
+++ b/layers/fabric/src/raft_handler.rs
@@ -444,42 +444,93 @@ impl LayerHandler for RaftOrgHandler {
             Some(cmd) => {
                 let result = submit_raft_command(client, &req, cmd, &self.org_store).await;
 
-                // Post-Raft side effect: wire VPC peering data plane.
-                // When PeerVpc succeeds, create veth pair + nftables FORWARD rules
-                // between the two VPC bridges on this node.
-                if let OrgRequest::VpcPeer { from, to } = &req {
-                    // Check if the Raft command succeeded.
-                    let resp: OrgResponse = serde_json::from_slice(&result)
-                        .unwrap_or(OrgResponse::Error("deserialization failed".to_string()));
-                    if !matches!(resp, OrgResponse::Error(_)) {
-                        // Resolve VPC IDs to bridge names.
-                        let vpc_a = self.org_store.get_vpc(from);
-                        let vpc_b = self.org_store.get_vpc(to);
-                        if let (Ok(Some(va)), Ok(Some(vb))) = (vpc_a, vpc_b) {
-                            let bridge_a = syfrah_overlay::naming::bridge_name(&va.id.0);
-                            let bridge_b = syfrah_overlay::naming::bridge_name(&vb.id.0);
-                            let peering_id = format!("{}-{}", va.id.0, vb.id.0);
-                            let backend_guard = self.network_backend.read().await;
-                            if let Some(ref backend) = *backend_guard {
-                                if let Err(e) = syfrah_overlay::veth_peer::create_veth_peer(
-                                    backend.as_ref(),
-                                    &peering_id,
-                                    &bridge_a,
-                                    &bridge_b,
-                                )
-                                .await
-                                {
-                                    tracing::warn!(
-                                        "peering data plane wiring failed for {from}<->{to}: {e}"
-                                    );
-                                } else {
-                                    tracing::info!(
-                                        "peering data plane wired: {from}<->{to} ({bridge_a}<->{bridge_b})"
-                                    );
+                // Post-Raft side effect: wire or tear down VPC peering data plane.
+                match &req {
+                    OrgRequest::VpcPeer { from, to } => {
+                        // Only wire the data plane when Raft succeeded.
+                        let resp: OrgResponse = serde_json::from_slice(&result)
+                            .unwrap_or(OrgResponse::Error("deserialization failed".to_string()));
+                        if !matches!(resp, OrgResponse::Error(_)) {
+                            // Resolve VPC names to bridge names.
+                            let vpc_a = self.org_store.get_vpc(from);
+                            let vpc_b = self.org_store.get_vpc(to);
+                            if let (Ok(Some(va)), Ok(Some(vb))) = (vpc_a, vpc_b) {
+                                let bridge_a = syfrah_overlay::naming::bridge_name(&va.id.0);
+                                let bridge_b = syfrah_overlay::naming::bridge_name(&vb.id.0);
+                                let peering_id = format!("{}-{}", va.id.0, vb.id.0);
+                                let backend_guard = self.network_backend.read().await;
+                                if let Some(ref backend) = *backend_guard {
+                                    // Only wire data plane on hypervisors that have at
+                                    // least one of the peered VPC bridges locally. If
+                                    // neither bridge exists, no local VMs are in either
+                                    // VPC and there is nothing to connect.
+                                    let has_a = backend.link_exists(&bridge_a).await;
+                                    let has_b = backend.link_exists(&bridge_b).await;
+                                    if has_a || has_b {
+                                        if let Err(e) = syfrah_overlay::veth_peer::create_veth_peer(
+                                            backend.as_ref(),
+                                            &peering_id,
+                                            &bridge_a,
+                                            &bridge_b,
+                                        )
+                                        .await
+                                        {
+                                            tracing::warn!(
+                                                "peering data plane wiring failed for \
+                                                 {from}<->{to}: {e}"
+                                            );
+                                        } else {
+                                            tracing::info!(
+                                                "peering data plane wired: \
+                                                 {from}<->{to} ({bridge_a}<->{bridge_b})"
+                                            );
+                                        }
+                                    } else {
+                                        tracing::debug!(
+                                            "skipping peering data plane for {from}<->{to}: \
+                                             no local bridges on this hypervisor"
+                                        );
+                                    }
                                 }
                             }
                         }
                     }
+                    OrgRequest::VpcUnpeer { from, to } => {
+                        // Tear down the data plane when Raft succeeded.
+                        let resp: OrgResponse = serde_json::from_slice(&result)
+                            .unwrap_or(OrgResponse::Error("deserialization failed".to_string()));
+                        if !matches!(resp, OrgResponse::Error(_)) {
+                            let vpc_a = self.org_store.get_vpc(from);
+                            let vpc_b = self.org_store.get_vpc(to);
+                            if let (Ok(Some(va)), Ok(Some(vb))) = (vpc_a, vpc_b) {
+                                let bridge_a = syfrah_overlay::naming::bridge_name(&va.id.0);
+                                let bridge_b = syfrah_overlay::naming::bridge_name(&vb.id.0);
+                                let peering_id = format!("{}-{}", va.id.0, vb.id.0);
+                                let backend_guard = self.network_backend.read().await;
+                                if let Some(ref backend) = *backend_guard {
+                                    if let Err(e) = syfrah_overlay::veth_peer::delete_veth_peer(
+                                        backend.as_ref(),
+                                        &peering_id,
+                                        &bridge_a,
+                                        &bridge_b,
+                                    )
+                                    .await
+                                    {
+                                        tracing::warn!(
+                                            "peering data plane teardown failed for \
+                                             {from}<->{to}: {e}"
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            "peering data plane torn down: \
+                                             {from}<->{to} ({bridge_a}<->{bridge_b})"
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
                 }
 
                 result

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -110,6 +110,12 @@ pub trait NetworkBackend: Send + Sync {
 
     // ── Query / Discovery ──────────────────────────────────────────────
 
+    /// Check whether a named kernel network interface exists on this node.
+    ///
+    /// Used before creating veth peering pairs to skip hypervisors that have
+    /// no local VMs in either of the peered VPCs (i.e., neither bridge exists).
+    async fn link_exists(&self, name: &str) -> bool;
+
     /// List kernel network interfaces matching a given prefix.
     ///
     /// Used by the reconciliation loop and daemon restart recovery to

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -619,6 +619,10 @@ impl NetworkBackend for LinuxBackend {
         Ok(())
     }
 
+    async fn link_exists(&self, name: &str) -> bool {
+        Self::interface_exists(name).await
+    }
+
     async fn list_interfaces(&self, prefix: &str) -> Result<Vec<String>> {
         let output = Self::run("ip", &["-o", "link", "show"]).await?;
         let mut names = Vec::new();

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -262,6 +262,14 @@ impl NetworkBackend for MockBackend {
         Ok(())
     }
 
+    async fn link_exists(&self, name: &str) -> bool {
+        self.record(format!("link_exists({name})"));
+        self.interfaces
+            .lock()
+            .expect("lock poisoned")
+            .contains(name)
+    }
+
     async fn list_interfaces(&self, prefix: &str) -> Result<Vec<String>> {
         self.record(format!("list_interfaces({prefix})"));
         let interfaces = self.interfaces.lock().expect("lock poisoned");
@@ -355,6 +363,7 @@ mod tests {
         b.remove_nat(&br100, "10.1.1.0/24").await.unwrap();
         b.apply_peering_rules(&br100, &br200).await.unwrap();
         b.remove_peering_rules(&br100, &br200).await.unwrap();
+        b.link_exists(&br100).await;
         b.list_interfaces(crate::naming::BRIDGE_PREFIX)
             .await
             .unwrap();
@@ -362,7 +371,7 @@ mod tests {
         b.list_arp_entries(&vx100).await.unwrap();
 
         let calls = b.calls();
-        assert_eq!(calls.len(), 25, "expected one call per trait method");
+        assert_eq!(calls.len(), 26, "expected one call per trait method");
 
         // Verify each method was recorded
         assert!(calls[0].starts_with("create_vxlan("));
@@ -387,7 +396,8 @@ mod tests {
         assert!(calls[19].starts_with("remove_nat("));
         assert!(calls[20].starts_with("apply_peering_rules("));
         assert!(calls[21].starts_with("remove_peering_rules("));
-        assert!(calls[22].starts_with("list_interfaces("));
+        assert!(calls[22].starts_with("link_exists("));
+        assert!(calls[23].starts_with("list_interfaces("));
 
         // Test reset
         b.reset();


### PR DESCRIPTION
## Problem

When `syfrah vpc peer --from vpc-a --to vpc-b` was run, Raft committed the `VpcPeer` command and the peering record was saved to redb — but the data plane was never wired. Traffic between VMs in peered VPCs failed silently because no veth pair connected the two VPC bridges and no nftables FORWARD rules were added.

Additionally, `vpc unpeer` had no data plane teardown — veth pairs would have been left dangling.

## Changes

### `layers/overlay/src/backend.rs`
Added `link_exists(&self, name: &str) -> bool` to the `NetworkBackend` trait. Used to check whether a VPC bridge exists locally before attempting to wire the peering veth pair.

### `layers/overlay/src/linux.rs`
Implemented `link_exists` for `LinuxBackend` — delegates to the existing `interface_exists` helper (`ip link show <name>`).

### `layers/overlay/src/mock.rs`
Implemented `link_exists` for `MockBackend` — checks the `interfaces` `HashSet`. Updated `trait_method_coverage` test (call count 25 → 26).

### `layers/fabric/src/raft_handler.rs`
Two fixes in the post-Raft side effect block:

1. **VpcPeer**: added bridge existence guard — only create the veth pair + nftables FORWARD rules on hypervisors that have at least one of the two VPC bridges. Hypervisors with no local VMs in either VPC are skipped (nothing to connect).

2. **VpcUnpeer**: added data plane teardown — calls `delete_veth_peer` after Raft commits `UnpeerVpc`, removing the veth pair (kernel auto-removes both ends) and the nftables FORWARD rules.

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test` passes (one pre-existing unrelated failure in `syfrah-compute::binary`)
- [ ] E2E scenario 601 on Hetzner: pre-peering ping fails, post-peering ping works, post-unpeer ping fails

Closes #1133