### PR TITLE
Fix Raft subnet_id lookup in raft_compute_handler

### DIFF
--- a/layers/fabric/src/raft_compute_handler.rs
+++ b/layers/fabric/src/raft_compute_handler.rs
@@ -279,7 +279,8 @@ impl RaftComputeHandler {
                                     if let Ok(matches) =
                                         store.find_subnets_by_name(&subnet_info.name)
                                     {
-                                        if let Some((sid, _)) = matches.into_iter().next() {
+                                        if let Some((vpc_name, sub)) = matches.into_iter().next() {
+                                            let sid = format!("{vpc_name}/{}", sub.name);
                                             // Find the NIC that was just created locally.
                                             if let Ok(Some(nic)) = store.find_nic_by_vm(&name) {
                                                 let cmd = StateMachineCommand::CreateNic {
@@ -321,7 +322,7 @@ impl RaftComputeHandler {
                             store
                                 .find_subnets_by_name(&subnet_info.name)
                                 .ok()
-                                .and_then(|matches| matches.into_iter().next().map(|(id, _)| id))
+                                .and_then(|matches| matches.into_iter().next().map(|(vpc_name, sub)| format!("{vpc_name}/{}", sub.name)))
                         } else {
                             None
                         };
@@ -397,7 +398,8 @@ impl RaftComputeHandler {
                                         if let Ok(matches) =
                                             store.find_subnets_by_name(&subnet_info.name)
                                         {
-                                            if let Some((sid, _)) = matches.into_iter().next() {
+                                            if let Some((vpc_name, sub)) = matches.into_iter().next() {
+                                                let sid = format!("{vpc_name}/{}", sub.name);
                                                 let cmd = StateMachineCommand::CreateNic {
                                                     vm_id: name.clone(),
                                                     subnet_id: sid,


### PR DESCRIPTION
## Summary

- Fixes `find_subnets_by_name()` result destructuring in `raft_compute_handler.rs` to construct the proper DB key (`vpc_name/subnet_name`) instead of passing just `vpc_name` as `subnet_id`
- Affects 3 locations: AllocateIp command, and two CreateNic commands
- Without this fix, VM creation fails with `subnet not found: <vpc_name>` when scheduler places VMs on non-leader nodes

## Test plan

- [x] Tested on 2-node Hetzner cluster (fsn1) — VM creation succeeds on both nodes after fix
- [ ] `cargo test` / `cargo clippy` pass
- [ ] CI green

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)