### PR TITLE
fix: VPC isolation, ip_forward, and peering veth guards

### DIFF
--- a/layers/compute/src/network_setup.rs
+++ b/layers/compute/src/network_setup.rs
@@ -280,6 +280,14 @@ impl<B: NetworkBackend + ?Sized> NetworkSetup<B> {
             .await
             .map_err(|e| ComputeError::NetworkSetup(format!("bridge creation failed: {e}")))?;
 
+        // Apply per-bridge accept rules (intra-VPC + internet egress) now
+        // that the bridge exists. With policy drop on the forward chain,
+        // traffic would be blocked without these.
+        self.backend
+            .apply_bridge_accept_rules(&bridge_name)
+            .await
+            .map_err(|e| ComputeError::NetworkSetup(format!("bridge accept rules failed: {e}")))?;
+
         self.backend
             .attach_to_bridge(&vxlan_name, &bridge_name)
             .await

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1201,6 +1201,13 @@ pub async fn run_daemon(
                                 .map_err(|e| e.to_string())
                         });
 
+                        // Enable IP forwarding so the kernel routes packets
+                        // between VPC bridges and to the internet. Without
+                        // this, cross-subnet and NAT traffic silently fails.
+                        if let Err(e) = syfrah_overlay::ensure_ip_forwarding() {
+                            warn!("compute: failed to enable ip_forward: {e}");
+                        }
+
                         // Enable bridge netfilter hooks so nftables sees
                         // bridged VM traffic (same-bridge VM-to-VM).  Must
                         // run before any bridge or nftables setup.

--- a/layers/fabric/src/raft_handler.rs
+++ b/layers/fabric/src/raft_handler.rs
@@ -460,13 +460,14 @@ impl LayerHandler for RaftOrgHandler {
                                 let peering_id = format!("{}-{}", va.id.0, vb.id.0);
                                 let backend_guard = self.network_backend.read().await;
                                 if let Some(ref backend) = *backend_guard {
-                                    // Only wire data plane on hypervisors that have at
-                                    // least one of the peered VPC bridges locally. If
-                                    // neither bridge exists, no local VMs are in either
-                                    // VPC and there is nothing to connect.
+                                    // Only wire data plane when BOTH bridges exist
+                                    // locally. If only one exists, the veth would be
+                                    // created but one end cannot attach — resulting in
+                                    // a dangling interface. The reconcile loop will
+                                    // wire the peering once the second bridge appears.
                                     let has_a = backend.link_exists(&bridge_a).await;
                                     let has_b = backend.link_exists(&bridge_b).await;
-                                    if has_a || has_b {
+                                    if has_a && has_b {
                                         if let Err(e) = syfrah_overlay::veth_peer::create_veth_peer(
                                             backend.as_ref(),
                                             &peering_id,
@@ -488,7 +489,8 @@ impl LayerHandler for RaftOrgHandler {
                                     } else {
                                         tracing::debug!(
                                             "skipping peering data plane for {from}<->{to}: \
-                                             no local bridges on this hypervisor"
+                                             need both bridges (has_a={has_a}, has_b={has_b}); \
+                                             reconcile loop will wire when ready"
                                         );
                                     }
                                 }

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -1588,6 +1588,12 @@ async fn create_bridge_handler(
         .as_ref()
         .map(|gt| gt.register(&resource_id));
 
+    // Apply per-bridge accept rules (intra-VPC + internet egress) so
+    // that traffic is not dropped by the forward chain's policy drop.
+    if let Err(e) = backend.apply_bridge_accept_rules(&bridge_name).await {
+        warn!(vpc_id = %req.vpc_id, error = %e, "failed to apply bridge accept rules");
+    }
+
     info!(vpc_id = %req.vpc_id, bridge = %bridge_name, "bridge ensured");
     (
         StatusCode::OK,

--- a/layers/overlay/src/backend.rs
+++ b/layers/overlay/src/backend.rs
@@ -90,6 +90,15 @@ pub trait NetworkBackend: Send + Sync {
     /// physdev dispatch chains. Idempotent — safe to call multiple times.
     async fn apply_sg_base_chain(&self) -> Result<()>;
 
+    /// Apply intra-VPC and internet egress rules for a bridge.
+    ///
+    /// With `policy drop` on the forward chain, these rules explicitly allow:
+    /// 1. Same-bridge traffic (intra-VPC communication)
+    /// 2. Outbound internet egress from the bridge
+    ///
+    /// Must be called when a bridge is created or during reconciliation.
+    async fn apply_bridge_accept_rules(&self, bridge: &str) -> Result<()>;
+
     /// Apply anti-spoofing + default ingress/egress rules for a VM.
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()>;
 

--- a/layers/overlay/src/linux.rs
+++ b/layers/overlay/src/linux.rs
@@ -364,6 +364,13 @@ impl NetworkBackend for LinuxBackend {
         Ok(())
     }
 
+    async fn apply_bridge_accept_rules(&self, bridge: &str) -> Result<()> {
+        let ruleset = crate::nft::generate_bridge_accept_rules(bridge);
+        crate::nft::apply_ruleset(&ruleset)
+            .map_err(|e| OverlayError::CommandFailed(e.to_string()))?;
+        Ok(())
+    }
+
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
         // Ensure table and chain exist (ignore errors if already present)
         Self::run("nft", &["add", "table", "inet", "syfrah"])
@@ -377,7 +384,7 @@ impl NetworkBackend for LinuxBackend {
                 "inet",
                 "syfrah",
                 "forward",
-                "{ type filter hook forward priority 0; policy accept; }",
+                "{ type filter hook forward priority 0; policy drop; }",
             ],
         )
         .await
@@ -567,7 +574,7 @@ impl NetworkBackend for LinuxBackend {
                 "inet",
                 "syfrah",
                 "forward",
-                "{ type filter hook forward priority 0; policy accept; }",
+                "{ type filter hook forward priority 0; policy drop; }",
             ],
         )
         .await

--- a/layers/overlay/src/mock.rs
+++ b/layers/overlay/src/mock.rs
@@ -231,6 +231,11 @@ impl NetworkBackend for MockBackend {
         Ok(())
     }
 
+    async fn apply_bridge_accept_rules(&self, bridge: &str) -> Result<()> {
+        self.record(format!("apply_bridge_accept_rules({bridge})"));
+        Ok(())
+    }
+
     async fn apply_vm_rules(&self, tap: &str, mac: &str, ip: &str) -> Result<()> {
         self.record(format!("apply_vm_rules({tap}, {mac}, {ip})"));
         Ok(())

--- a/layers/overlay/src/nft.rs
+++ b/layers/overlay/src/nft.rs
@@ -37,7 +37,7 @@ pub fn generate_table_setup() -> String {
     writeln!(buf, "add table inet {TABLE_NAME}").unwrap();
     writeln!(
         buf,
-        "add chain inet {TABLE_NAME} {CHAIN_NAME} {{ type filter hook forward priority 0; policy accept; }}"
+        "add chain inet {TABLE_NAME} {CHAIN_NAME} {{ type filter hook forward priority 0; policy drop; }}"
     )
     .unwrap();
     writeln!(
@@ -76,6 +76,19 @@ pub fn generate_infra_protection() -> String {
     writeln!(
         buf,
         "add rule inet {TABLE_NAME} {CHAIN_NAME} tcp dport {PEERING_PORT} drop"
+    )
+    .unwrap();
+
+    // Conntrack: allow established/related return traffic (must come after
+    // infra port blocks so infra ports are always dropped first).
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} ct state established,related accept"
+    )
+    .unwrap();
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} ct state invalid drop"
     )
     .unwrap();
 
@@ -178,6 +191,32 @@ pub fn apply_ruleset(ruleset: &str) -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+// ── VPC bridge base rules ───────────────────────────────────────────
+
+/// Generate nftables rules to allow intra-VPC traffic (same bridge in/out)
+/// and internet egress from a VPC bridge.
+///
+/// With `policy drop` on the forward chain, traffic between bridges is
+/// blocked by default (VPC isolation). These rules explicitly allow:
+/// 1. Same-bridge traffic (intra-VPC communication between subnets)
+/// 2. Outbound internet egress (bridge → non-bridge interface)
+pub fn generate_bridge_accept_rules(bridge: &str) -> String {
+    let mut buf = String::new();
+    // Same bridge: intra-VPC traffic allowed
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} iifname \"{bridge}\" oifname \"{bridge}\" accept"
+    )
+    .unwrap();
+    // Internet egress: bridge → any non-bridge interface
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} iifname \"{bridge}\" oifname != \"syfb-*\" accept"
+    )
+    .unwrap();
+    buf
 }
 
 // ── Subnet isolation ────────────────────────────────────────────────
@@ -353,6 +392,42 @@ mod tests {
         let setup = generate_table_setup();
         assert!(setup.contains("add table inet syfrah"));
         assert!(setup.contains("add chain inet syfrah forward"));
+    }
+
+    #[test]
+    fn forward_chain_policy_drop() {
+        let setup = generate_table_setup();
+        assert!(
+            setup.contains("policy drop"),
+            "forward chain must use policy drop for VPC isolation"
+        );
+    }
+
+    #[test]
+    fn infra_protection_has_conntrack() {
+        let rules = generate_infra_protection();
+        assert!(rules.contains("ct state established,related accept"));
+        assert!(rules.contains("ct state invalid drop"));
+    }
+
+    #[test]
+    fn bridge_accept_rules_intra_vpc() {
+        let br = crate::naming::bridge_name("100");
+        let rules = generate_bridge_accept_rules(&br);
+        assert!(
+            rules.contains(&format!("iifname \"{br}\" oifname \"{br}\" accept")),
+            "same-bridge traffic must be accepted"
+        );
+    }
+
+    #[test]
+    fn bridge_accept_rules_internet_egress() {
+        let br = crate::naming::bridge_name("100");
+        let rules = generate_bridge_accept_rules(&br);
+        assert!(
+            rules.contains(&format!("iifname \"{br}\" oifname != \"syfb-*\" accept")),
+            "bridge to internet must be accepted"
+        );
     }
 
     #[test]

--- a/layers/overlay/src/reconcile.rs
+++ b/layers/overlay/src/reconcile.rs
@@ -180,6 +180,13 @@ pub async fn reconcile_network(
     // 2. Check expected TAPs exist — warn if missing
     check_taps(backend, expected_state, &mut report).await;
 
+    // 3a-pre. Re-enable IP forwarding (sysctl values don't survive reboot)
+    if let Err(e) = crate::sysctl::ensure_ip_forwarding() {
+        report
+            .warnings
+            .push(format!("ip_forward re-enable failed: {e}"));
+    }
+
     // 3a. Re-enable br_netfilter (sysctl values don't survive reboot)
     if let Err(e) = backend.enable_br_netfilter().await {
         report
@@ -273,6 +280,13 @@ async fn check_bridges(
                         .push(format!("failed to re-create bridge {}: {e}", bridge.name));
                 }
             }
+        }
+        // Re-apply per-bridge accept rules (intra-VPC + internet egress).
+        // These nftables rules don't survive reboots.
+        if let Err(e) = backend.apply_bridge_accept_rules(&bridge.name).await {
+            report
+                .warnings
+                .push(format!("bridge {} accept rules failed: {e}", bridge.name));
         }
     }
 }
@@ -557,6 +571,19 @@ async fn reconcile_peerings(
     report: &mut ReconcileReport,
 ) {
     for peering in &state.peerings {
+        // Both bridges must exist before we can wire the veth pair.
+        // If only one exists, skip — the next reconcile tick will retry
+        // once the second bridge appears (after a VM is created in that VPC).
+        let has_a = backend.link_exists(&peering.bridge_a).await;
+        let has_b = backend.link_exists(&peering.bridge_b).await;
+        if !has_a || !has_b {
+            report.warnings.push(format!(
+                "peering {}: skipping — bridges not ready ({}={}, {}={})",
+                peering.peering_id, peering.bridge_a, has_a, peering.bridge_b, has_b,
+            ));
+            continue;
+        }
+
         // Check if the veth peer interface already exists.
         let peer_a = naming::peer_name_a(&peering.peering_id);
         let existing = match backend

--- a/layers/overlay/src/recovery.rs
+++ b/layers/overlay/src/recovery.rs
@@ -151,6 +151,9 @@ pub async fn recover_network(
             warn!(bridge = %bridge, error = %e, "failed to recover bridge");
             continue;
         }
+        if let Err(e) = backend.apply_bridge_accept_rules(&bridge).await {
+            warn!(bridge = %bridge, error = %e, "failed to apply bridge accept rules");
+        }
 
         // Add gateway IPs for subnets in this VPC.
         for subnet in subnets.iter().filter(|s| s.vpc_id == vpc.id) {


### PR DESCRIPTION
## Summary

Fixes three interconnected VPC networking bugs:

- **VPC isolation** (Closes #1149): Change `inet syfrah forward` chain from `policy accept` to `policy drop`. Add conntrack rules and per-bridge accept rules for intra-VPC traffic and internet egress. Cross-VPC traffic is now dropped by default unless explicit peering rules exist.

- **IP forwarding** (Closes #1150): Call `ensure_ip_forwarding()` at daemon startup alongside `br_netfilter`. Also re-enable in the reconcile loop since sysctl values don't survive reboot.

- **Peering veth guard** (Closes #1152): Change `has_a || has_b` to `has_a && has_b` in `raft_handler.rs` VpcPeer side-effect so veth pairs are only wired when both bridges exist. Added same guard to the reconcile peerings loop.

## Changes

- `layers/overlay/src/nft.rs`: Forward chain `policy drop`, conntrack rules in infra protection, new `generate_bridge_accept_rules()` function
- `layers/overlay/src/backend.rs`: New `apply_bridge_accept_rules` trait method
- `layers/overlay/src/linux.rs`: Implement `apply_bridge_accept_rules`, update all chain creation to `policy drop`
- `layers/overlay/src/mock.rs`: Implement mock `apply_bridge_accept_rules`
- `layers/overlay/src/reconcile.rs`: Re-apply bridge accept rules, check both bridges before peering, re-enable ip_forward
- `layers/overlay/src/recovery.rs`: Apply bridge accept rules after bridge recovery
- `layers/compute/src/network_setup.rs`: Apply bridge accept rules after bridge creation
- `layers/forge/src/api.rs`: Apply bridge accept rules in create_bridge_handler
- `layers/fabric/src/daemon.rs`: Enable ip_forward at startup
- `layers/fabric/src/raft_handler.rs`: `has_a && has_b` guard for peering wiring

## Test plan

- [ ] Build passes (`cargo build --workspace`)
- [ ] All tests pass (1 pre-existing unrelated failure in `binary::tests`)
- [ ] Clippy clean
- [ ] Deploy to Hetzner test servers and verify:
  - VMs in same VPC can communicate (same-bridge accept)
  - VMs in different VPCs cannot communicate without peering (policy drop)
  - After `vpc peer`: cross-VPC ping works
  - After `vpc unpeer`: cross-VPC ping fails again
  - Internet egress works from VMs