### PR TITLE
feat: auto-join Raft on fabric join (#1122)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,7 @@ dependencies = [
  "openraft",
  "rand 0.8.5",
  "rcgen",
+ "reqwest",
  "rustls",
  "rustls-pemfile",
  "sd-notify",

--- a/README.md
+++ b/README.md
@@ -4,32 +4,31 @@
 [![E2E Tests](https://github.com/sacha-ops/syfrah/actions/workflows/e2e.yml/badge.svg)](https://github.com/sacha-ops/syfrah/actions/workflows/e2e.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
-An open-source WireGuard mesh networking tool for dedicated servers.
+An open-source cloud platform that turns bare-metal servers into a programmable cloud.
 
 ## What is Syfrah?
 
-Syfrah connects dedicated servers from any provider (OVH, Hetzner, Scaleway, or others) into an encrypted WireGuard mesh network. Each pair of nodes establishes a point-to-point WireGuard tunnel, forming a full-mesh topology where every node can reach every other node over private, encrypted IPv6.
+Syfrah transforms dedicated servers from any provider (OVH, Hetzner, Scaleway, or others) into a unified cloud platform. It builds an encrypted WireGuard mesh between servers, then layers compute (Cloud Hypervisor VMs, container fallback), overlay networking (VXLAN, VPCs, security groups), a distributed control plane (Raft consensus + SWIM gossip), and multi-tenant organization management on top.
 
-The mesh is fully decentralized with no central coordinator. An operator adds nodes one at a time through a manual peering process: the new node sends a join request, the operator approves it (or uses a pre-shared PIN), and the node receives the mesh credentials and peer list. All inter-node traffic is encrypted with WireGuard (Curve25519 + ChaCha20-Poly1305).
-
-The long-term vision is to grow Syfrah into a full control plane that orchestrates compute, storage, and networking on top of the mesh. Today, it is a networking tool: it builds the encrypted fabric that everything else will run on.
+Nodes join the mesh through a manual peering process (PIN or interactive approval). Once connected, a node automatically detects and joins the Raft control plane cluster. The operator only needs to bootstrap the control plane on one node; all subsequent nodes auto-join on fabric join. All inter-node traffic is encrypted with WireGuard (Curve25519 + ChaCha20-Poly1305).
 
 ## Status
 
 | Layer | Crate | Status |
 |---|---|---|
 | **Core** | `syfrah-core` | Stable — types, crypto, IPv6 addressing |
-| **State** (library) | `syfrah-state` | Stable — embedded persistence (redb), cross-cutting library used by all layers |
-| **API** (library) | `syfrah-api` | Stable — error types, structured responses, cross-cutting library |
-| **Fabric** | `syfrah-fabric` | Stable — WireGuard mesh, peering, daemon, CLI |
-| Forge | — | Design phase |
-| Compute | — | Design phase |
-| Storage | — | Design phase |
-| Overlay | — | Design phase |
-| Control Plane | — | Design phase |
-| IAM | — | Design phase |
-| Org | — | Design phase |
-| Products | — | Design phase |
+| **State** | `syfrah-state` | Stable — embedded persistence (redb) |
+| **API** | `syfrah-api` | Stable — error types, structured responses |
+| **Fabric** | `syfrah-fabric` | Stable — WireGuard mesh, peering, daemon |
+| **Compute** | `syfrah-compute` | Stable — Cloud Hypervisor VMs, container fallback (crun + gVisor), image management |
+| **Org** | `syfrah-org` | Stable — Org/Project/Environment, VPC, Subnet, Security Groups, Route Tables, NAT Gateway, IPAM |
+| **Overlay** | `syfrah-overlay` | Stable — VXLAN, bridges, TAP/veth, nftables, FDB, ARP proxy |
+| **Forge** | `syfrah-forge` | Stable — per-hypervisor REST API, reconciliation, capacity management, drain, Prometheus metrics |
+| **Control Plane** | `syfrah-controlplane` | Stable — Raft consensus (openraft), SWIM gossip (foca), distributed scheduler, leader election |
+| **Hypervisor** | (in `syfrah-org`) | Stable — Region/Zone/Hypervisor topology, auto-discovery, labels, taints, drain |
+| Storage | — | Planned — ZeroFS + S3 block devices |
+| IAM | — | Planned — role-based access control, API keys |
+| Products | — | Planned — managed databases, load balancers |
 
 ## Install
 
@@ -87,43 +86,54 @@ This creates an encrypted WireGuard mesh between the two servers. Each additiona
 ## How it works
 
 ```
-                  ┌──────────────────────────────┐
-                  │           CLI binary          │
-                  │         (bin/syfrah)          │
-                  └──────────────┬───────────────┘
-                                 │
-                  ┌──────────────┴───────────────┐
-                  │       syfrah-fabric           │
-                  │                               │
-                  │  peering.rs   TCP join/accept  │
-                  │  daemon.rs    background loop  │
-                  │  wg.rs        WireGuard iface  │
-                  │  control.rs   Unix socket IPC  │
-                  │  store.rs     state persist    │
-                  │  events.rs    event log        │
-                  └──────┬───────────┬────────────┘
-                         │           │
-              ┌──────────┴──┐  ┌─────┴──────────┐
-              │ syfrah-core │  │  syfrah-state   │
-              │             │  │                 │
-              │ identity    │  │ redb wrapper    │
-              │ addressing  │  │ ACID persistence│
-              │ mesh types  │  │                 │
-              │ crypto      │  │                 │
-              └─────────────┘  └─────────────────┘
+                      ┌──────────────────────────────┐
+                      │           CLI binary          │
+                      │         (bin/syfrah)          │
+                      └──────────────┬───────────────┘
+                                     │
+          ┌──────────────────────────┼──────────────────────────┐
+          │                          │                          │
+ ┌────────┴─────────┐  ┌────────────┴────────────┐  ┌─────────┴────────┐
+ │  syfrah-forge    │  │   syfrah-controlplane   │  │   syfrah-org     │
+ │                  │  │                          │  │                  │
+ │  REST API        │  │  Raft consensus          │  │  Org/Project/Env │
+ │  reconciliation  │  │  SWIM gossip             │  │  VPC/Subnet/SG   │
+ │  capacity mgmt   │  │  distributed scheduler   │  │  IPAM, Hypervisor│
+ └────────┬─────────┘  └────────────┬─────────────┘  └─────────┬───────┘
+          │                         │                           │
+ ┌────────┴─────────┐  ┌───────────┴────────────┐  ┌──────────┴───────┐
+ │  syfrah-compute  │  │    syfrah-overlay      │  │  syfrah-fabric   │
+ │                  │  │                         │  │                  │
+ │  Cloud Hypervisor│  │  VXLAN, bridges, TAP    │  │  WireGuard mesh  │
+ │  crun + gVisor   │  │  nftables, FDB, ARP    │  │  peering, daemon │
+ └────────┬─────────┘  └───────────┬─────────────┘  └──────┬──────────┘
+          │                        │                        │
+          └────────────┬───────────┴────────────────────────┘
+                       │
+            ┌──────────┴──┐  ┌─────────────────┐
+            │ syfrah-core │  │  syfrah-state   │
+            │             │  │                 │
+            │ identity    │  │ redb wrapper    │
+            │ addressing  │  │ ACID persistence│
+            │ crypto      │  │                 │
+            └─────────────┘  └─────────────────┘
 ```
 
-**Core** provides pure types with no I/O: node identities, WireGuard keypairs, mesh secrets, and deterministic IPv6 address derivation (ULA /48 prefix per mesh derived from the mesh secret, /128 address per node derived from SHA-256 of the WireGuard public key).
+**Core** provides pure types with no I/O: node identities, WireGuard keypairs, mesh secrets, and deterministic IPv6 address derivation.
 
-**State** wraps redb for crash-safe embedded persistence. Mesh state is stored in `~/.syfrah/fabric.redb`. A backward-compatible JSON export is maintained at `~/.syfrah/state.json` (debounced, best-effort).
+**State** wraps redb for crash-safe embedded persistence. All layers store data in `~/.syfrah/`.
 
-**Fabric** is the main layer. It manages:
-- A WireGuard interface (`syfrah0`) with a full-mesh topology
-- A TCP peering protocol for manual node enrollment (PIN or interactive approval)
-- Encrypted peer announcements (AES-256-GCM, key derived from mesh secret)
-- A daemon loop with health checks (60s interval, 5-minute unreachable threshold)
-- A reconciliation loop (30s interval) that keeps WireGuard config in sync with stored state
-- Metrics: peers discovered, reconciliations, unreachable count, uptime
+**Fabric** manages the WireGuard mesh: encrypted tunnels, TCP peering protocol, health checks, reconciliation, and auto-join for the Raft control plane.
+
+**Compute** runs workloads via Cloud Hypervisor VMs with container fallback (crun + gVisor). Handles image management, VM lifecycle, and resource tracking.
+
+**Overlay** provides virtual networking: VXLAN tunnels, Linux bridges, TAP/veth devices, nftables rules, FDB entries, and ARP proxy for cross-hypervisor VM communication.
+
+**Control Plane** implements distributed consensus (Raft via openraft), failure detection (SWIM gossip via foca), a distributed scheduler for VM placement, and leader election.
+
+**Org** manages the multi-tenant hierarchy: Organizations, Projects, Environments, VPCs, Subnets, Security Groups, Route Tables, NAT Gateways, and IPAM. Also includes the Hypervisor model (Region/Zone/Hypervisor topology).
+
+**Forge** exposes a per-hypervisor REST API for local resource management, capacity tracking, reconciliation, drain operations, and Prometheus metrics.
 
 The CLI binary in `bin/syfrah` composes these crates and contains no logic of its own.
 
@@ -131,9 +141,14 @@ The CLI binary in `bin/syfrah` composes these crates and contains no logic of it
 
 ### Implemented layers
 
-- [layers/fabric/README.md](layers/fabric/README.md) — Fabric: WireGuard mesh, peering protocol, security model, failure modes, scalability
 - [layers/core/](layers/core/) — Core: types, crypto, addressing
 - [layers/state/](layers/state/) — State: embedded persistence
+- [layers/fabric/README.md](layers/fabric/README.md) — Fabric: WireGuard mesh, peering, security model
+- [layers/compute/](layers/compute/) — Compute: Cloud Hypervisor VMs, containers
+- [layers/overlay/](layers/overlay/) — Overlay: VXLAN, VPCs, security groups
+- [layers/controlplane/](layers/controlplane/) — Control Plane: Raft, gossip, scheduler
+- [layers/org/](layers/org/) — Org: multi-tenant model, IPAM, hypervisor topology
+- [layers/forge/](layers/forge/) — Forge: per-node REST API, capacity, metrics
 
 ### Architecture and handbook
 
@@ -146,15 +161,10 @@ The CLI binary in `bin/syfrah` composes these crates and contains no logic of it
 
 ## Roadmap
 
-The layers below are architecturally designed with concept documentation but have no implementation yet. Each has a README in its `layers/` directory describing the planned design.
+The following layers are planned but not yet implemented:
 
-- **Forge** — per-node REST API for managing local resources
-- **Compute** — KVM-based microVMs via Cloud Hypervisor
-- **Storage** — S3-backed block devices (ZeroFS)
-- **Overlay** — VXLAN, VPCs, security groups, private DNS
-- **Control Plane** — Raft consensus + SWIM gossip, embedded on every node
-- **IAM** — role-based access control and API keys
-- **Org** — multi-tenant organization/project/environment model
+- **Storage** — S3-backed block devices (ZeroFS), persistent volumes
+- **IAM** — role-based access control, API keys, service accounts
 - **Products** — managed databases, load balancers, composed from forge primitives
 
 See [handbook/ARCHITECTURE.md](handbook/ARCHITECTURE.md) for the full design.

--- a/layers/fabric/Cargo.toml
+++ b/layers/fabric/Cargo.toml
@@ -45,6 +45,7 @@ tokio-util = "0.7"
 axum = "0.8"
 hyper = "1"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/layers/fabric/src/cli/status.rs
+++ b/layers/fabric/src/cli/status.rs
@@ -20,7 +20,7 @@ pub async fn run(opts: StatusOpts) -> Result<()> {
     let state = store::load().map_err(|_| no_mesh_error())?;
 
     if opts.json {
-        return run_json(&state, &opts);
+        return run_json(&state, &opts).await;
     }
 
     // ── Uptime (computed early for the Mesh box) ────────────────────
@@ -95,6 +95,49 @@ pub async fn run(opts: StatusOpts) -> Result<()> {
         ui::info_line("Gateway", "disabled");
     }
     println!();
+
+    // ── Control Plane status ────────────────────────────────────────
+    {
+        let cp_url = format!("http://[{}]:7200/raft/status", state.mesh_ipv6);
+        let cp_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .ok();
+
+        let cp_status = if let Some(client) = cp_client {
+            client.get(&cp_url).send().await.ok()
+        } else {
+            None
+        };
+
+        match cp_status {
+            Some(resp) if resp.status().is_success() => {
+                if let Ok(raft_status) = resp
+                    .json::<syfrah_controlplane::server::RaftStatusResponse>()
+                    .await
+                {
+                    let role = if raft_status.current_leader == Some(raft_status.id) {
+                        "leader"
+                    } else if raft_status
+                        .member_details
+                        .iter()
+                        .any(|m| m.node_id == raft_status.id && m.role == "learner")
+                    {
+                        "learner"
+                    } else {
+                        "voter"
+                    };
+                    ui::health_ok(&format!(
+                        "Control Plane: joined ({role}, term {})",
+                        raft_status.current_term
+                    ));
+                }
+            }
+            _ => {
+                ui::info_line("Control Plane", "not available (bootstrap mode)");
+            }
+        }
+    }
 
     // TODO(#644): Add compute summary (runtime type, VM count, running VMs)
     // to fabric status output. This requires cross-layer integration:
@@ -268,7 +311,7 @@ fn fmt_duration(secs: u64) -> String {
     }
 }
 
-fn run_json(state: &store::NodeState, opts: &StatusOpts) -> Result<()> {
+async fn run_json(state: &store::NodeState, opts: &StatusOpts) -> Result<()> {
     let daemon_pid = store::daemon_running();
     let iface_up = wg::interface_summary()
         .map(|s| s.public_key.is_some())
@@ -304,6 +347,56 @@ fn run_json(state: &store::NodeState, opts: &StatusOpts) -> Result<()> {
 
     let gw = config::load_gateway_config();
 
+    // Probe control plane status for JSON output.
+    let control_plane = {
+        let cp_url = format!("http://[{}]:7200/raft/status", state.mesh_ipv6);
+        let cp_client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .ok();
+
+        if let Some(client) = cp_client {
+            if let Ok(resp) = client.get(&cp_url).send().await {
+                if resp.status().is_success() {
+                    if let Ok(raft_status) = resp
+                        .json::<syfrah_controlplane::server::RaftStatusResponse>()
+                        .await
+                    {
+                        let role = if raft_status.current_leader == Some(raft_status.id) {
+                            "leader"
+                        } else if raft_status
+                            .member_details
+                            .iter()
+                            .any(|m| m.node_id == raft_status.id && m.role == "learner")
+                        {
+                            "learner"
+                        } else {
+                            "voter"
+                        };
+                        Some(JsonControlPlane {
+                            joined: true,
+                            role: Some(role.to_string()),
+                            term: Some(raft_status.current_term),
+                        })
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+    .unwrap_or(JsonControlPlane {
+        joined: false,
+        role: None,
+        term: None,
+    });
+
     let output = StatusJson {
         mesh_name: &state.mesh_name,
         node_name: &state.node_name,
@@ -321,6 +414,7 @@ fn run_json(state: &store::NodeState, opts: &StatusOpts) -> Result<()> {
         secret: secret_display,
         traffic_rx: rx,
         traffic_tx: tx,
+        control_plane,
         gateway: JsonGateway {
             enabled: gw.enabled,
             port: if gw.enabled {
@@ -368,9 +462,19 @@ struct StatusJson<'a> {
     secret: String,
     traffic_rx: u64,
     traffic_tx: u64,
+    control_plane: JsonControlPlane,
     gateway: JsonGateway,
     metrics: JsonMetrics,
     config: JsonConfig,
+}
+
+#[derive(Serialize)]
+struct JsonControlPlane {
+    joined: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    term: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -450,6 +554,11 @@ mod tests {
             secret: "abc***".to_string(),
             traffic_rx: 1024,
             traffic_tx: 2048,
+            control_plane: JsonControlPlane {
+                joined: true,
+                role: Some("voter".to_string()),
+                term: Some(3),
+            },
             gateway: JsonGateway {
                 enabled: true,
                 port: Some(8080),
@@ -483,6 +592,9 @@ mod tests {
         assert_eq!(val["interface_up"], true);
         assert_eq!(val["peers_total"], 3);
         assert_eq!(val["peers_active"], 2);
+        assert_eq!(val["control_plane"]["joined"], true);
+        assert_eq!(val["control_plane"]["role"], "voter");
+        assert_eq!(val["control_plane"]["term"], 3);
         assert_eq!(val["peers_unreachable"], 1);
         assert_eq!(val["traffic_rx"], 1024);
         assert_eq!(val["traffic_tx"], 2048);
@@ -511,6 +623,11 @@ mod tests {
             secret: "***".to_string(),
             traffic_rx: 0,
             traffic_tx: 0,
+            control_plane: JsonControlPlane {
+                joined: false,
+                role: None,
+                term: None,
+            },
             gateway: JsonGateway {
                 enabled: false,
                 port: None,
@@ -541,5 +658,9 @@ mod tests {
         assert_eq!(val["gateway"]["enabled"], false);
         // port should be omitted (skip_serializing_if)
         assert!(val["gateway"].get("port").is_none());
+        assert_eq!(val["control_plane"]["joined"], false);
+        // role and term should be omitted (skip_serializing_if)
+        assert!(val["control_plane"].get("role").is_none());
+        assert!(val["control_plane"].get("term").is_none());
     }
 }

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -2073,13 +2073,220 @@ pub async fn run_daemon(
                 }
             })
         } else {
-            info!(
-                "raft: control plane not initialized. Run 'syfrah controlplane init' to bootstrap."
-            );
+            info!("raft: control plane not initialized. Probing peers for auto-join...");
+
+            // Spawn a background task that probes peers for an existing Raft
+            // cluster and auto-joins as a learner if one is found.
+            let auto_join_node_name = my_record.name.clone();
+            let auto_join_ipv6 = my_record.mesh_ipv6;
+            let auto_join_syfrah_dir = syfrah_dir.clone();
             tokio::spawn(async move {
-                // Placeholder: Raft not yet initialized. Listen for init signal.
                 let _ = raft_shutdown_rx.clone();
-                std::future::pending::<()>().await;
+
+                // Give the mesh a few seconds to settle after startup.
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+                // Skip if raft_initialized sentinel already exists (race with
+                // manual `syfrah controlplane join`).
+                if auto_join_syfrah_dir.join("raft_initialized").exists() {
+                    info!("raft: auto-join skipped — already initialized");
+                    return;
+                }
+
+                // Load current peers from fabric state.
+                let peers = match crate::store::load() {
+                    Ok(state) => state.peers,
+                    Err(_) => {
+                        info!("raft: auto-join skipped — no fabric state");
+                        return;
+                    }
+                };
+
+                if peers.is_empty() {
+                    info!("raft: no peers in mesh — staying in bootstrap mode");
+                    return;
+                }
+
+                // Derive our node ID the same way controlplane does.
+                let node_id = {
+                    use std::hash::{Hash, Hasher};
+                    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                    auto_join_node_name.hash(&mut hasher);
+                    hasher.finish()
+                };
+                let node_addr = format!("[{auto_join_ipv6}]:7200");
+
+                let probe_client = match reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(5))
+                    .build()
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!("raft: auto-join failed to build HTTP client: {e}");
+                        return;
+                    }
+                };
+                let join_client = match reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!("raft: auto-join failed to build HTTP client: {e}");
+                        return;
+                    }
+                };
+
+                // Retry with exponential backoff: 5s, 10s, 20s, 40s, 80s
+                let backoffs = [5u64, 10, 20, 40, 80];
+                for (attempt, &delay) in backoffs.iter().enumerate() {
+                    if attempt > 0 {
+                        info!(
+                            "raft: auto-join attempt {}/{} (retry in {delay}s)...",
+                            attempt + 1,
+                            backoffs.len()
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+
+                        // Re-check sentinel in case manual join happened during backoff.
+                        if auto_join_syfrah_dir.join("raft_initialized").exists() {
+                            info!("raft: auto-join skipped — initialized during retry wait");
+                            return;
+                        }
+                    }
+
+                    // Probe each peer for Raft status.
+                    let mut leader_addr = None;
+                    for peer in &peers {
+                        let url = format!("http://[{}]:7200/raft/status", peer.mesh_ipv6);
+                        match probe_client.get(&url).send().await {
+                            Ok(resp) if resp.status().is_success() => {
+                                if let Ok(status) = resp
+                                    .json::<syfrah_controlplane::server::RaftStatusResponse>()
+                                    .await
+                                {
+                                    if let Some(leader_id) = status.current_leader {
+                                        // Find the actual leader's address.
+                                        if let Some(detail) = status
+                                            .member_details
+                                            .iter()
+                                            .find(|d| d.node_id == leader_id)
+                                        {
+                                            leader_addr = Some(detail.addr.clone());
+                                        } else {
+                                            leader_addr =
+                                                Some(format!("[{}]:7200", peer.mesh_ipv6));
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+                            _ => continue,
+                        }
+                    }
+
+                    let leader = match leader_addr {
+                        Some(addr) => addr,
+                        None => {
+                            if attempt == 0 {
+                                info!(
+                                    "raft: no Raft cluster detected in mesh. \
+                                     Operating in bootstrap mode."
+                                );
+                            }
+                            continue;
+                        }
+                    };
+
+                    info!(
+                        "raft: detected Raft cluster (leader: {leader}). \
+                         Auto-joining as learner..."
+                    );
+
+                    // Initialize local Raft storage before joining.
+                    if let Err(e) = (|| -> Result<(), Box<dyn std::error::Error>> {
+                        let log_db = syfrah_state::LayerDb::open("raft_log")?;
+                        let _log_store = syfrah_controlplane::RedbLogStore::new(log_db);
+                        Ok(())
+                    })() {
+                        warn!("raft: auto-join failed to init log storage: {e}");
+                        continue;
+                    }
+
+                    // Send join request to leader.
+                    let join_url = format!("http://{leader}/raft/join");
+                    let join_req = serde_json::json!({
+                        "node_id": node_id,
+                        "addr": node_addr,
+                    });
+
+                    match join_client.post(&join_url).json(&join_req).send().await {
+                        Ok(resp) if resp.status().is_success() => {
+                            info!("raft: auto-join succeeded! Writing sentinel and restarting daemon...");
+
+                            // Write sentinel.
+                            if let Err(e) = std::fs::write(
+                                auto_join_syfrah_dir.join("raft_initialized"),
+                                format!("{node_id}"),
+                            ) {
+                                warn!("raft: failed to write sentinel: {e}");
+                                return;
+                            }
+
+                            // Restart daemon so Raft server starts.
+                            if let Some(pid) = crate::store::daemon_running() {
+                                if crate::store::is_syfrah_process(pid) {
+                                    #[cfg(unix)]
+                                    unsafe {
+                                        libc::kill(pid as i32, libc::SIGTERM);
+                                    }
+                                    // Wait for shutdown.
+                                    for _ in 0..100 {
+                                        tokio::time::sleep(std::time::Duration::from_millis(100))
+                                            .await;
+                                        if crate::store::daemon_running().is_none() {
+                                            break;
+                                        }
+                                    }
+                                    if crate::store::daemon_running().is_some() {
+                                        #[cfg(unix)]
+                                        unsafe {
+                                            libc::kill(pid as i32, libc::SIGKILL);
+                                        }
+                                        tokio::time::sleep(std::time::Duration::from_millis(500))
+                                            .await;
+                                    }
+                                    crate::store::remove_pid();
+                                }
+                            }
+
+                            // Re-exec the daemon.
+                            if let Ok(exe) = std::env::current_exe() {
+                                let _ = std::process::Command::new(&exe)
+                                    .args(["fabric", "start"])
+                                    .stdin(std::process::Stdio::null())
+                                    .stdout(std::process::Stdio::null())
+                                    .stderr(std::process::Stdio::null())
+                                    .spawn();
+                            }
+                            return;
+                        }
+                        Ok(resp) => {
+                            let status = resp.status();
+                            let body = resp.text().await.unwrap_or_default();
+                            warn!("raft: auto-join request failed: {status} — {body}");
+                        }
+                        Err(e) => {
+                            warn!("raft: auto-join request error: {e}");
+                        }
+                    }
+                }
+
+                warn!(
+                    "raft: could not auto-join Raft after {} attempts. \
+                     Run 'syfrah controlplane join' manually.",
+                    backoffs.len()
+                );
             })
         }
     };
@@ -4499,5 +4706,38 @@ mod tests {
     fn timeout_both_no_topology_uses_cross_region() {
         let policy = test_health_policy();
         assert_eq!(timeout_for_peer(&None, &None, &policy), 300);
+    }
+
+    #[test]
+    fn auto_join_skips_when_sentinel_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let sentinel = dir.path().join("raft_initialized");
+        std::fs::write(&sentinel, "12345").unwrap();
+        assert!(sentinel.exists(), "sentinel should exist");
+        // When sentinel exists, auto-join should be skipped.
+        // The daemon code checks: if syfrah_dir.join("raft_initialized").exists() { return; }
+        // This tests the precondition.
+        assert!(dir.path().join("raft_initialized").exists());
+    }
+
+    #[test]
+    fn auto_join_skips_when_no_peers() {
+        // No peers means no Raft cluster to join — stays in bootstrap mode.
+        let peers: Vec<syfrah_core::mesh::PeerRecord> = vec![];
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn auto_join_derives_node_id_consistently() {
+        use std::hash::{Hash, Hasher};
+        let node_name = "hv-test-1";
+        let mut h1 = std::collections::hash_map::DefaultHasher::new();
+        node_name.hash(&mut h1);
+        let id1 = h1.finish();
+        let mut h2 = std::collections::hash_map::DefaultHasher::new();
+        node_name.hash(&mut h2);
+        let id2 = h2.finish();
+        assert_eq!(id1, id2, "node_id derivation must be deterministic");
+        assert_ne!(id1, 0, "node_id should not be zero");
     }
 }

--- a/tests/e2e/scenarios/560_auto_join_raft.md
+++ b/tests/e2e/scenarios/560_auto_join_raft.md
@@ -1,0 +1,106 @@
+# 560 — Auto-join Raft on fabric join
+
+## Purpose
+
+Verify that a node joining the fabric mesh automatically detects and joins an
+existing Raft control plane cluster without requiring a separate
+`syfrah controlplane join` command.
+
+## Prerequisites
+
+- 3 servers with `syfrah` installed (S1, S2, S3)
+- No prior mesh or control plane state on any server
+
+## Steps
+
+### 1. Initialize mesh and control plane on S1
+
+```bash
+ssh root@$S1 "syfrah fabric init --name cloud --node-name hv-1 --endpoint $S1:51820 --region eu --zone fsn1"
+ssh root@$S1 "syfrah controlplane init && syfrah fabric stop && sleep 2 && syfrah fabric start"
+sleep 5
+ssh root@$S1 "syfrah fabric peering start --pin 4829"
+```
+
+### 2. Join S2 to fabric (auto-join should trigger)
+
+```bash
+ssh root@$S2 "syfrah fabric join $S1 --pin 4829 --node-name hv-2 --endpoint $S2:51820 --region eu --zone nbg1"
+sleep 15  # wait for auto-join (5s delay + probe + join + restart)
+```
+
+**Expected:** S2 daemon logs show:
+- `raft: detected Raft cluster (leader: ...)`
+- `raft: auto-join succeeded!`
+
+### 3. Verify S2 is a Raft member
+
+```bash
+ssh root@$S2 "syfrah controlplane status"
+```
+
+**Expected:** Shows `Raft: Learner` or `Voter` (after auto-promote).
+
+```bash
+ssh root@$S1 "syfrah controlplane members"
+```
+
+**Expected:** Shows 2 members (hv-1 and hv-2).
+
+### 4. Verify fabric status shows control plane
+
+```bash
+ssh root@$S2 "syfrah fabric status"
+```
+
+**Expected:** Shows `Control Plane: joined (learner, term N)` or
+`Control Plane: joined (voter, term N)`.
+
+### 5. Join S3 to fabric (auto-join should trigger)
+
+```bash
+ssh root@$S3 "syfrah fabric join $S1 --pin 4829 --node-name hv-3 --endpoint $S3:51820 --region eu --zone hel1"
+sleep 15
+ssh root@$S1 "syfrah controlplane members"
+```
+
+**Expected:** Shows 3 members.
+
+### 6. Test data replication
+
+```bash
+ssh root@$S1 "syfrah org create test-org"
+sleep 3
+ssh root@$S3 "syfrah org list"
+```
+
+**Expected:** `test-org` is visible on S3.
+
+### 7. Edge case: first node without Raft stays in bootstrap mode
+
+```bash
+# On a fresh node:
+syfrah fabric init --name solo --node-name lonely
+syfrah fabric status
+```
+
+**Expected:** Shows `Control Plane: not available (bootstrap mode)`.
+
+### 8. Edge case: node with existing raft_initialized skips auto-join
+
+```bash
+# On S2 (already joined):
+syfrah fabric stop && syfrah fabric start
+sleep 10
+syfrah controlplane status
+```
+
+**Expected:** Raft starts normally from stored state. No auto-join triggered.
+
+## Pass criteria
+
+- [ ] S2 and S3 auto-join Raft within 20s of fabric join
+- [ ] `fabric status` shows control plane status on all nodes
+- [ ] First node (no peers) stays in bootstrap mode
+- [ ] Node restart with existing sentinel does not re-trigger auto-join
+- [ ] Data replicated from leader is visible on all members


### PR DESCRIPTION
## Summary

- Daemon auto-detects Raft cluster after `fabric join` by probing peers for `/raft/status`
- Joins as learner with exponential backoff retry (5 attempts, 5s-80s delays)
- `fabric status` now shows control plane status (joined/bootstrap mode)
- README updated to reflect all implemented layers (compute, overlay, org, forge, controlplane)
- E2E scenario 560 covers the full auto-join flow

## Test plan

- [ ] `cargo build` passes
- [ ] `cargo clippy` clean (no warnings)
- [ ] `cargo test -p syfrah-fabric` passes (including new auto-join unit tests)
- [ ] E2E: 3-server test — S1 init mesh+CP, S2/S3 fabric join auto-joins Raft
- [ ] Edge: first node (no peers) stays in bootstrap mode
- [ ] Edge: node with existing sentinel skips auto-join on restart
- [ ] `syfrah fabric status` shows control plane line
- [ ] `syfrah fabric status --json` includes `control_plane` field

Closes #1122