### PR TITLE
fix: reliable daemon restart + subnet replication retry

### DIFF
--- a/bin/syfrah/src/controlplane/join.rs
+++ b/bin/syfrah/src/controlplane/join.rs
@@ -157,35 +157,65 @@ pub async fn run() -> Result<()> {
         }
     }
 
-    // Re-exec the daemon in the background via the syfrah binary.
+    // Wait for PID file to be fully removed.
+    let pid_path = syfrah_fabric::store::pid_path();
+    for _ in 0..20 {
+        if !pid_path.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    // Wait for control socket to be released.
+    let sock_path = syfrah_fabric::store::control_socket_path();
+    for _ in 0..20 {
+        if !sock_path.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    // Re-exec the daemon in the background via the syfrah binary with retry.
     // This mirrors the double-fork pattern used by `syfrah fabric start`.
     let exe = std::env::current_exe().context("Failed to find syfrah binary")?;
-    let child = std::process::Command::new(&exe)
-        .args(["fabric", "start"])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
+    let mut started = false;
+    for attempt in 0..3u32 {
+        let child = std::process::Command::new(&exe)
+            .args(["fabric", "start"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
 
-    match child {
-        Ok(_) => {
-            // Wait briefly for the daemon to start and write its PID file.
-            for _ in 0..50 {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        match child {
+            Ok(_) => {
+                // Wait briefly for the daemon to start and write its PID file.
+                for _ in 0..50 {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    if syfrah_fabric::store::daemon_running().is_some() {
+                        break;
+                    }
+                }
                 if syfrah_fabric::store::daemon_running().is_some() {
+                    println!("  Daemon restarted with Raft enabled.");
+                    started = true;
                     break;
+                } else {
+                    println!(
+                        "  Daemon spawned but not yet ready (attempt {}/3).",
+                        attempt + 1
+                    );
                 }
             }
-            if syfrah_fabric::store::daemon_running().is_some() {
-                println!("  Daemon restarted with Raft enabled.");
-            } else {
-                println!("  Daemon spawned but not yet ready. Check: syfrah fabric status");
+            Err(e) => {
+                eprintln!("  Warning: restart attempt {}/3 failed: {e}", attempt + 1);
             }
         }
-        Err(e) => {
-            eprintln!("  Warning: failed to restart daemon: {e}");
-            println!("  Restart manually: syfrah fabric stop && syfrah fabric start");
+        if attempt < 2 {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
+    }
+    if !started {
+        eprintln!("  Auto-restart failed after 3 attempts. Run 'syfrah fabric start' manually.");
     }
 
     Ok(())

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -2260,14 +2260,52 @@ pub async fn run_daemon(
                                 }
                             }
 
-                            // Re-exec the daemon.
+                            // Wait for PID file to be fully removed.
+                            let pid_path = crate::store::pid_path();
+                            for _ in 0..20 {
+                                if !pid_path.exists() {
+                                    break;
+                                }
+                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                            }
+                            // Wait for control socket to be released.
+                            let sock_path = crate::store::control_socket_path();
+                            for _ in 0..20 {
+                                if !sock_path.exists() {
+                                    break;
+                                }
+                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                            }
+
+                            // Re-exec the daemon with retry.
+                            let mut started = false;
                             if let Ok(exe) = std::env::current_exe() {
-                                let _ = std::process::Command::new(&exe)
-                                    .args(["fabric", "start"])
-                                    .stdin(std::process::Stdio::null())
-                                    .stdout(std::process::Stdio::null())
-                                    .stderr(std::process::Stdio::null())
-                                    .spawn();
+                                for attempt in 0..3u32 {
+                                    match std::process::Command::new(&exe)
+                                        .args(["fabric", "start"])
+                                        .stdin(std::process::Stdio::null())
+                                        .stdout(std::process::Stdio::null())
+                                        .stderr(std::process::Stdio::null())
+                                        .spawn()
+                                    {
+                                        Ok(_) => {
+                                            started = true;
+                                            break;
+                                        }
+                                        Err(e) => {
+                                            warn!(
+                                                "raft: auto-join restart attempt {}/{} failed: {e}",
+                                                attempt + 1,
+                                                3
+                                            );
+                                            tokio::time::sleep(std::time::Duration::from_secs(2))
+                                                .await;
+                                        }
+                                    }
+                                }
+                            }
+                            if !started {
+                                warn!("raft: auto-restart failed after 3 attempts. Run 'syfrah fabric start' manually.");
                             }
                             return;
                         }

--- a/layers/fabric/src/store.rs
+++ b/layers/fabric/src/store.rs
@@ -696,6 +696,11 @@ fn pid_file() -> PathBuf {
     state_dir().join("daemon.pid")
 }
 
+/// Public accessor for the PID file path.
+pub fn pid_path() -> PathBuf {
+    pid_file()
+}
+
 /// Write the current process PID to the PID file with exclusive flock.
 ///
 /// Uses flock(LOCK_EX | LOCK_NB) to prevent two daemons from running

--- a/layers/forge/src/api.rs
+++ b/layers/forge/src/api.rs
@@ -1135,54 +1135,74 @@ async fn create_instance_handler(
         let _ = task_store.start_task(&task_id);
     }
 
-    // Resolve subnet if specified.
+    // Resolve subnet if specified, with retry for Raft replication lag.
     let subnet_info = if let Some(ref subnet_name) = req.subnet {
         if let Some(ref org_store) = state.org_store {
-            match org_store.find_subnets_by_name(subnet_name) {
-                Ok(matches) if !matches.is_empty() => {
-                    let (_vpc_name, subnet) = &matches[0];
-                    Some(syfrah_compute::types::SubnetInfo {
-                        name: subnet.name.clone(),
-                        cidr: subnet.cidr.clone(),
-                        gateway: subnet.gateway.clone(),
-                        vpc_id: subnet.vpc_id.0.clone(),
-                        env_id: subnet.env_id.0.clone(),
-                    })
-                }
-                Ok(_) => {
-                    // Release capacity reservation on error.
-                    if let Some(ref capacity) = state.capacity {
-                        capacity.release(&req.name, req.vcpus, req.memory_mb as u64);
+            let mut resolved = None;
+            let mut last_err = None;
+            for attempt in 0..5u32 {
+                match org_store.find_subnets_by_name(subnet_name) {
+                    Ok(matches) if !matches.is_empty() => {
+                        let (_vpc_name, subnet) = &matches[0];
+                        resolved = Some(syfrah_compute::types::SubnetInfo {
+                            name: subnet.name.clone(),
+                            cidr: subnet.cidr.clone(),
+                            gateway: subnet.gateway.clone(),
+                            vpc_id: subnet.vpc_id.0.clone(),
+                            env_id: subnet.env_id.0.clone(),
+                        });
+                        break;
                     }
-                    if let Some(ref task_store) = state.task_store {
-                        let _ = task_store.fail_task(&task_id, "subnet not found");
+                    Ok(_) => {
+                        if attempt < 4 {
+                            warn!(
+                                subnet = %subnet_name,
+                                attempt = attempt + 1,
+                                "subnet not found — Raft may not have replicated yet. Retrying..."
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        }
                     }
-                    return (
-                        StatusCode::NOT_FOUND,
-                        Json(serde_json::json!({
-                            "code": "FORGE_SUBNET_NOT_FOUND",
-                            "message": format!("subnet '{}' not found", subnet_name),
-                            "task_id": task_id,
-                        })),
-                    );
-                }
-                Err(e) => {
-                    if let Some(ref capacity) = state.capacity {
-                        capacity.release(&req.name, req.vcpus, req.memory_mb as u64);
+                    Err(e) => {
+                        last_err = Some(e);
+                        break;
                     }
-                    if let Some(ref task_store) = state.task_store {
-                        let _ = task_store.fail_task(&task_id, &e.to_string());
-                    }
-                    return (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Json(serde_json::json!({
-                            "code": "FORGE_SUBNET_RESOLVE_FAILED",
-                            "message": e.to_string(),
-                            "task_id": task_id,
-                        })),
-                    );
                 }
             }
+            if let Some(err) = last_err {
+                if let Some(ref capacity) = state.capacity {
+                    capacity.release(&req.name, req.vcpus, req.memory_mb as u64);
+                }
+                if let Some(ref task_store) = state.task_store {
+                    let _ = task_store.fail_task(&task_id, &err.to_string());
+                }
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "code": "FORGE_SUBNET_RESOLVE_FAILED",
+                        "message": err.to_string(),
+                        "task_id": task_id,
+                    })),
+                );
+            }
+            if resolved.is_none() {
+                // Release capacity reservation on error.
+                if let Some(ref capacity) = state.capacity {
+                    capacity.release(&req.name, req.vcpus, req.memory_mb as u64);
+                }
+                if let Some(ref task_store) = state.task_store {
+                    let _ = task_store.fail_task(&task_id, "subnet not found");
+                }
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({
+                        "code": "FORGE_SUBNET_NOT_FOUND",
+                        "message": format!("subnet '{}' not found after 5 retries", subnet_name),
+                        "task_id": task_id,
+                    })),
+                );
+            }
+            resolved
         } else {
             warn!("forge: subnet requested but org store not available");
             None


### PR DESCRIPTION
## Summary

- **#1163 — Daemon restart race**: After killing the daemon during auto-join or manual `controlplane join`, the restart now waits for the PID file and control socket to be fully removed before spawning the new process. Spawn is retried up to 3 times with 2s backoff.
- **#1164 — Subnet not found on remote node**: When the Forge API receives a create request for a VM on a remote node, subnet lookup now retries up to 5 times with 500ms backoff to allow Raft state to replicate.

## Files changed

- `layers/fabric/src/daemon.rs` — auto-join restart: wait for PID/socket + retry spawn
- `layers/fabric/src/store.rs` — expose `pid_path()` public accessor
- `bin/syfrah/src/controlplane/join.rs` — manual join restart: same wait + retry pattern
- `layers/forge/src/api.rs` — subnet lookup retry with backoff for Raft lag

## Test plan

- [ ] 3-node Hetzner cluster: all nodes auto-join Raft reliably
- [ ] Cross-zone VM create succeeds (exercises subnet replication retry)
- [ ] `cargo build --workspace` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #1163
Closes #1164