### PR TITLE
fix: prevent daemon exit after in-process Raft init

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -2748,7 +2748,14 @@ pub async fn run_daemon(
                                 "raft: joined and started in-process. No daemon restart needed. \
                                  PID unchanged."
                             );
-                            return;
+
+                            // Do NOT return — the auto-join task is the `raft_task`
+                            // in the main `tokio::select!` loop. If it completes,
+                            // the daemon interprets it as an unexpected exit and
+                            // shuts down. Instead, park this task forever (it will
+                            // be cancelled when the daemon shuts down normally).
+                            std::future::pending::<()>().await;
+                            unreachable!();
                         }
                         Ok(resp) => {
                             let status = resp.status();


### PR DESCRIPTION
## Summary

- Fixes the daemon shutting down immediately after in-process Raft initialization
- The auto-join task is the `raft_task` in the main `tokio::select!` loop — when it returned after starting Raft, the select treated it as an unexpected task exit and shut the daemon down
- Fix: park the task with `std::future::pending()` so it never completes; it gets cancelled naturally during normal daemon shutdown
- Builds on PR #1166 which introduced the in-process Raft init

## Test plan

- [ ] `cargo build && cargo clippy && cargo test` pass
- [ ] 3-node Hetzner test: S2/S3 join, Raft auto-join succeeds, daemon PID stays the same
- [ ] Repeat 3x to verify reliability

Closes #1163