### PR TITLE
feat(storage): implement snapshot creation protocol

### DIFF
--- a/layers/forge/src/storage_reconciler.rs
+++ b/layers/forge/src/storage_reconciler.rs
@@ -37,7 +37,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
 
-use syfrah_storage::volume_mgr::{CacheConfig, S3Config, VolumeMgr, VolumeMgrError};
+use syfrah_storage::volume_mgr::{
+    CacheConfig, S3Config, VolumeManifest, VolumeMgr, VolumeMgrError,
+};
 
 // ---------------------------------------------------------------------------
 // Desired-state types (read from Raft)
@@ -245,6 +247,70 @@ impl ChClientProvider for NoOpChClientProvider {
             "no CH client available for vm={vm_id} device={ch_device_id}"
         ))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot submission trait (Raft command submission)
+// ---------------------------------------------------------------------------
+
+/// Trait for submitting a `CreateSnapshot` command to the Raft state machine.
+///
+/// In production, the implementation serializes a `StateMachineCommand::CreateSnapshot`
+/// and proposes it through the Raft client. In tests, a mock records the call.
+#[async_trait::async_trait]
+pub trait SnapshotSubmitter: Send + Sync {
+    /// Submit a snapshot creation request. Returns the snapshot ID on success.
+    ///
+    /// `snapshot_id` — pre-generated unique ID for the snapshot.
+    /// `source_volume_id` — the volume being snapshotted.
+    /// `manifest` — SST files + WAL position captured from ZeroFS.
+    async fn submit_create_snapshot(
+        &self,
+        snapshot_id: &str,
+        source_volume_id: &str,
+        manifest: &VolumeManifest,
+    ) -> Result<String, String>;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot creation flow (ADR-006 §6)
+// ---------------------------------------------------------------------------
+
+/// Create a snapshot of a running volume.
+///
+/// Orchestrates the full snapshot creation flow:
+/// 1. Capture the current manifest from ZeroFS (SST files + WAL position)
+/// 2. Submit a `CreateSnapshot` Raft command with the manifest data
+/// 3. SST refcount increments happen atomically in the state machine
+///
+/// Returns the snapshot ID on success.
+pub async fn create_snapshot(
+    volume_mgr: &VolumeMgr,
+    submitter: &dyn SnapshotSubmitter,
+    snapshot_id: &str,
+    volume_id: &str,
+) -> Result<String, String> {
+    // Step 1: Capture manifest from ZeroFS.
+    let manifest = volume_mgr
+        .capture_manifest(volume_id)
+        .await
+        .map_err(|e| format!("failed to capture manifest for volume {volume_id}: {e}"))?;
+
+    info!(
+        volume_id,
+        snapshot_id,
+        sst_count = manifest.sst_files.len(),
+        wal_position = manifest.wal_position,
+        "captured volume manifest for snapshot"
+    );
+
+    // Step 2: Submit CreateSnapshot Raft command.
+    let result = submitter
+        .submit_create_snapshot(snapshot_id, volume_id, &manifest)
+        .await?;
+
+    info!(volume_id, snapshot_id, "snapshot created via Raft");
+    Ok(result)
 }
 
 // ---------------------------------------------------------------------------
@@ -1592,5 +1658,130 @@ mod tests {
             StorageReconciler::new("hv-1".into(), "test-pass".into()).with_disk_rate_limit(config);
         assert_eq!(r.disk_rate_limit.bw_size, 100 * 1024 * 1024);
         assert_eq!(r.disk_rate_limit.ops_size, 5_000);
+    }
+
+    // ── Snapshot creation tests (#1200) ────────────────────────────
+
+    /// Mock SnapshotSubmitter that records calls and returns success.
+    struct MockSnapshotSubmitter {
+        calls: Mutex<Vec<(String, String, VolumeManifest)>>,
+        fail_with: Mutex<Option<String>>,
+    }
+
+    impl MockSnapshotSubmitter {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_with: Mutex::new(None),
+            }
+        }
+
+        fn failing(msg: &str) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                fail_with: Mutex::new(Some(msg.to_string())),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+
+        fn last_call(&self) -> Option<(String, String, VolumeManifest)> {
+            self.calls.lock().unwrap().last().cloned()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SnapshotSubmitter for MockSnapshotSubmitter {
+        async fn submit_create_snapshot(
+            &self,
+            snapshot_id: &str,
+            source_volume_id: &str,
+            manifest: &VolumeManifest,
+        ) -> Result<String, String> {
+            if let Some(err) = self.fail_with.lock().unwrap().as_ref() {
+                return Err(err.clone());
+            }
+            self.calls.lock().unwrap().push((
+                snapshot_id.to_string(),
+                source_volume_id.to_string(),
+                manifest.clone(),
+            ));
+            Ok(snapshot_id.to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_succeeds_with_manifest_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut mgr = VolumeMgr::new();
+        mgr = mgr.with_nbd_base(tmp.path().join("nbd"));
+        mgr.inject_fake_process("vol-snap", 1);
+
+        // Pre-write manifest file.
+        let manifest = VolumeManifest {
+            sst_files: vec!["sst-a.sst".into()],
+            wal_position: 42,
+        };
+        let manifest_path = tmp.path().join("vol-snap.manifest.json");
+        tokio::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap())
+            .await
+            .unwrap();
+
+        let submitter = MockSnapshotSubmitter::new();
+        let result = create_snapshot(&mgr, &submitter, "snap-01", "vol-snap").await;
+
+        assert!(result.is_ok(), "create_snapshot failed: {result:?}");
+        assert_eq!(result.unwrap(), "snap-01");
+        assert_eq!(submitter.call_count(), 1);
+
+        let (sid, vid, m) = submitter.last_call().unwrap();
+        assert_eq!(sid, "snap-01");
+        assert_eq!(vid, "vol-snap");
+        assert_eq!(m.sst_files, vec!["sst-a.sst"]);
+        assert_eq!(m.wal_position, 42);
+
+        mgr.stop_volume("vol-snap").await.ok();
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_fails_when_volume_not_running() {
+        let mgr = VolumeMgr::new();
+        let submitter = MockSnapshotSubmitter::new();
+        let result = create_snapshot(&mgr, &submitter, "snap-01", "nonexistent").await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not running"));
+        assert_eq!(submitter.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_propagates_raft_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut mgr = VolumeMgr::new();
+        mgr = mgr.with_nbd_base(tmp.path().join("nbd"));
+        mgr.inject_fake_process("vol-snap", 1);
+
+        // Pre-write manifest file.
+        let manifest_path = tmp.path().join("vol-snap.manifest.json");
+        tokio::fs::write(
+            &manifest_path,
+            serde_json::to_string(&VolumeManifest {
+                sst_files: vec!["sst-x.sst".into()],
+                wal_position: 7,
+            })
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        let submitter = MockSnapshotSubmitter::failing("raft: not leader");
+        let result = create_snapshot(&mgr, &submitter, "snap-01", "vol-snap").await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("raft: not leader"));
+
+        mgr.stop_volume("vol-snap").await.ok();
     }
 }

--- a/layers/storage/src/api.rs
+++ b/layers/storage/src/api.rs
@@ -84,6 +84,20 @@ pub enum StorageRequest {
         cache_disk_size_gb: u32,
         cache_memory_size_gb: u32,
     },
+    /// Create a snapshot of a volume.
+    SnapshotCreate {
+        /// Source volume name (resolved to ID by the handler).
+        volume_name: String,
+        /// Optional project scope for volume lookup.
+        project: Option<String>,
+    },
+    /// List snapshots with optional filters.
+    SnapshotList {
+        volume_name: Option<String>,
+        project: Option<String>,
+    },
+    /// Delete a snapshot.
+    SnapshotDelete { snapshot_id: String },
     /// Run storage health check (S3 probe + cache info).
     Health,
     /// Get storage status (connectivity + cache utilization).
@@ -96,6 +110,10 @@ pub enum StorageResponse {
     Volume(serde_json::Value),
     /// List of volumes.
     VolumeList(Vec<serde_json::Value>),
+    /// Single snapshot info.
+    Snapshot(serde_json::Value),
+    /// List of snapshots.
+    SnapshotList(Vec<serde_json::Value>),
     /// Success with no data.
     Ok,
     /// Storage configuration applied successfully.
@@ -235,6 +253,21 @@ async fn handle_storage_request(req: StorageRequest) -> StorageResponse {
             // TODO: persist cache overrides locally
             StorageResponse::Ok
         }
+        StorageRequest::SnapshotCreate { volume_name, .. } => {
+            // TODO: resolve volume_name → volume_id, call VolumeMgr::capture_manifest,
+            // then submit CreateSnapshot Raft command with the manifest data.
+            // For now, return a placeholder snapshot indicating creation in progress.
+            StorageResponse::Snapshot(serde_json::json!({
+                "volume": volume_name,
+                "state": "creating",
+                "sst_files": [],
+                "wal_position": 0,
+            }))
+        }
+        StorageRequest::SnapshotList { .. } => StorageResponse::SnapshotList(vec![]),
+        StorageRequest::SnapshotDelete { snapshot_id } => {
+            StorageResponse::Error(format!("snapshot '{snapshot_id}' not found"))
+        }
         StorageRequest::Health => {
             // Stub: return a placeholder health report.
             // Real implementation reads StorageConfig from Raft and probes S3.
@@ -373,5 +406,75 @@ mod tests {
         let resp_bytes = handler.handle(payload, None).await;
         let resp: StorageResponse = serde_json::from_slice(&resp_bytes).unwrap();
         assert!(matches!(resp, StorageResponse::VolumeList(v) if v.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn handler_returns_snapshot_on_create() {
+        let handler = StorageLayerHandler;
+        let req = StorageRequest::SnapshotCreate {
+            volume_name: "pgdata".into(),
+            project: Some("backend".into()),
+        };
+        let payload = serde_json::to_vec(&req).unwrap();
+        let resp_bytes = handler.handle(payload, None).await;
+        let resp: StorageResponse = serde_json::from_slice(&resp_bytes).unwrap();
+        match resp {
+            StorageResponse::Snapshot(v) => {
+                assert_eq!(v["volume"], "pgdata");
+                assert_eq!(v["state"], "creating");
+            }
+            other => panic!("expected Snapshot, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn handler_returns_empty_snapshot_list() {
+        let handler = StorageLayerHandler;
+        let req = StorageRequest::SnapshotList {
+            volume_name: None,
+            project: None,
+        };
+        let payload = serde_json::to_vec(&req).unwrap();
+        let resp_bytes = handler.handle(payload, None).await;
+        let resp: StorageResponse = serde_json::from_slice(&resp_bytes).unwrap();
+        assert!(matches!(resp, StorageResponse::SnapshotList(v) if v.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn handler_returns_error_on_snapshot_delete_not_found() {
+        let handler = StorageLayerHandler;
+        let req = StorageRequest::SnapshotDelete {
+            snapshot_id: "snap-nonexistent".into(),
+        };
+        let payload = serde_json::to_vec(&req).unwrap();
+        let resp_bytes = handler.handle(payload, None).await;
+        let resp: StorageResponse = serde_json::from_slice(&resp_bytes).unwrap();
+        match resp {
+            StorageResponse::Error(msg) => {
+                assert!(msg.contains("snap-nonexistent"));
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn snapshot_request_serde_roundtrip() {
+        let req = StorageRequest::SnapshotCreate {
+            volume_name: "pgdata".into(),
+            project: Some("backend".into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let _: StorageRequest = serde_json::from_str(&json).unwrap();
+    }
+
+    #[test]
+    fn snapshot_response_serde_roundtrip() {
+        let resp = StorageResponse::Snapshot(serde_json::json!({
+            "id": "snap-01",
+            "volume": "pgdata",
+            "state": "available",
+        }));
+        let json = serde_json::to_string(&resp).unwrap();
+        let _: StorageResponse = serde_json::from_str(&json).unwrap();
     }
 }

--- a/layers/storage/src/volume_mgr.rs
+++ b/layers/storage/src/volume_mgr.rs
@@ -22,6 +22,22 @@ use tokio::time;
 use crate::binary;
 
 // ---------------------------------------------------------------------------
+// Manifest types (snapshot capture)
+// ---------------------------------------------------------------------------
+
+/// Point-in-time manifest captured from a running ZeroFS process.
+///
+/// Contains the SST files and WAL position needed to record a
+/// crash-consistent snapshot via the Raft `CreateSnapshot` command.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VolumeManifest {
+    /// SST file keys currently referenced by this volume's LSM tree.
+    pub sst_files: Vec<String>,
+    /// WAL byte offset at the time the manifest was captured.
+    pub wal_position: u64,
+}
+
+// ---------------------------------------------------------------------------
 // Configuration types
 // ---------------------------------------------------------------------------
 
@@ -119,6 +135,12 @@ impl VolumeMgr {
     /// Set an explicit zerofs binary path (overrides resolution order).
     pub fn with_binary(mut self, path: PathBuf) -> Self {
         self.binary_override = Some(path);
+        self
+    }
+
+    /// Override the NBD base path (useful for tests).
+    pub fn with_nbd_base(mut self, path: PathBuf) -> Self {
+        self.nbd_base = path;
         self
     }
 
@@ -282,6 +304,65 @@ impl VolumeMgr {
             .iter()
             .map(|(id, proc)| (id.clone(), proc.generation))
             .collect()
+    }
+
+    /// Capture a point-in-time manifest from a running ZeroFS process.
+    ///
+    /// Sends `SIGUSR1` to the ZeroFS process, which triggers it to write
+    /// the current SST file list and WAL position to
+    /// `{cache_dir}/{volume_id}.manifest.json`. The reconciler reads this
+    /// file and submits a `CreateSnapshot` Raft command.
+    ///
+    /// Returns the parsed manifest, or an error if the volume is not
+    /// running or the manifest cannot be captured.
+    pub async fn capture_manifest(
+        &self,
+        volume_id: &str,
+    ) -> Result<VolumeManifest, VolumeMgrError> {
+        let proc = self
+            .processes
+            .get(volume_id)
+            .ok_or_else(|| VolumeMgrError::NotRunning(volume_id.to_string()))?;
+
+        // Send SIGUSR1 to ask ZeroFS to dump its manifest.
+        #[cfg(unix)]
+        {
+            if let Some(pid) = proc.child.id() {
+                unsafe {
+                    libc::kill(pid as i32, libc::SIGUSR1);
+                }
+            } else {
+                return Err(VolumeMgrError::Stop(
+                    "cannot capture manifest: process has no PID".to_string(),
+                ));
+            }
+        }
+
+        // Wait for the manifest file to appear.
+        let manifest_path = self
+            .nbd_base
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("/tmp"))
+            .join(format!("{volume_id}.manifest.json"));
+
+        let deadline = time::Instant::now() + Duration::from_secs(5);
+        while time::Instant::now() < deadline {
+            if manifest_path.exists() {
+                let data = tokio::fs::read_to_string(&manifest_path)
+                    .await
+                    .map_err(|e| VolumeMgrError::Spawn(format!("failed to read manifest: {e}")))?;
+                // Clean up the manifest file after reading.
+                let _ = tokio::fs::remove_file(&manifest_path).await;
+                let manifest: VolumeManifest = serde_json::from_str(&data)
+                    .map_err(|e| VolumeMgrError::Spawn(format!("failed to parse manifest: {e}")))?;
+                return Ok(manifest);
+            }
+            time::sleep(Duration::from_millis(100)).await;
+        }
+
+        Err(VolumeMgrError::Spawn(format!(
+            "manifest file did not appear within 5s for volume {volume_id}"
+        )))
     }
 
     /// Reap any child processes that have exited (crashed or terminated
@@ -666,5 +747,70 @@ mod tests {
     fn nbd_device_path_returns_none_for_unknown_volume() {
         let mgr = VolumeMgr::new();
         assert_eq!(mgr.nbd_device_path("nonexistent"), None);
+    }
+
+    // ── VolumeManifest tests (#1200) ───────────────────────────────
+
+    #[test]
+    fn volume_manifest_serde_roundtrip() {
+        let manifest = VolumeManifest {
+            sst_files: vec!["sst-001.sst".into(), "sst-002.sst".into()],
+            wal_position: 42,
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let deserialized: VolumeManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(manifest, deserialized);
+    }
+
+    #[test]
+    fn volume_manifest_empty_sst_files() {
+        let manifest = VolumeManifest {
+            sst_files: vec![],
+            wal_position: 0,
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let deserialized: VolumeManifest = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.sst_files.is_empty());
+        assert_eq!(deserialized.wal_position, 0);
+    }
+
+    #[tokio::test]
+    async fn capture_manifest_rejects_unknown_volume() {
+        let mgr = VolumeMgr::new();
+        let result = mgr.capture_manifest("nonexistent").await;
+        assert!(matches!(result, Err(VolumeMgrError::NotRunning(_))));
+    }
+
+    #[tokio::test]
+    async fn capture_manifest_reads_file_when_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut mgr = VolumeMgr::new();
+        // Override nbd_base to point inside tmp dir so manifest path resolves there.
+        mgr.nbd_base = tmp.path().join("nbd");
+
+        // Inject a fake process.
+        mgr.inject_fake_process("vol-snap", 1);
+
+        // Pre-write the manifest file that ZeroFS would create on SIGUSR1.
+        let manifest = VolumeManifest {
+            sst_files: vec!["sst-a.sst".into(), "sst-b.sst".into()],
+            wal_position: 100,
+        };
+        let manifest_path = tmp.path().join("vol-snap.manifest.json");
+        tokio::fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap())
+            .await
+            .unwrap();
+
+        let result = mgr.capture_manifest("vol-snap").await;
+        assert!(result.is_ok(), "capture_manifest failed: {result:?}");
+        let captured = result.unwrap();
+        assert_eq!(captured.sst_files, vec!["sst-a.sst", "sst-b.sst"]);
+        assert_eq!(captured.wal_position, 100);
+
+        // Manifest file should be cleaned up.
+        assert!(!manifest_path.exists());
+
+        // Cleanup.
+        mgr.stop_volume("vol-snap").await.ok();
     }
 }


### PR DESCRIPTION
## Summary

- Add `VolumeManifest` type and `VolumeMgr::capture_manifest()` to capture SST files + WAL position from a running ZeroFS process (SIGUSR1 signal triggers manifest dump)
- Add `SnapshotSubmitter` trait and `create_snapshot()` function in forge that orchestrates: manifest capture -> Raft `CreateSnapshot` command submission
- Add `StorageRequest::SnapshotCreate`, `SnapshotList`, `SnapshotDelete` variants to the control socket API with handler stubs
- Unit tests covering manifest serialization, capture success/failure, Raft error propagation, and API handler responses

## Test plan

- [x] `cargo test -p syfrah-storage` -- all 129 tests pass
- [x] `cargo test -p syfrah-forge` -- all storage_reconciler tests pass including 3 new snapshot tests
- [x] `cargo clippy -p syfrah-storage -p syfrah-forge` -- clean
- [x] `cargo fmt --check` -- clean

Closes #1200

🤖 Generated with [Claude Code](https://claude.com/claude-code)