### PR TITLE
Wire storage reconciler with real Raft state reader

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1458,6 +1458,13 @@ pub async fn run_daemon(
     let forge_gossip_cluster: Arc<tokio::sync::RwLock<Option<syfrah_controlplane::GossipCluster>>> =
         Arc::new(tokio::sync::RwLock::new(None));
 
+    // Late-binding holder for the Raft state machine — the storage reconciler
+    // starts before Raft is initialised, so it reads through this Option.
+    // Once Raft is ready, the SM reference is injected below.
+    let reconciler_sm: Arc<
+        tokio::sync::RwLock<Option<Arc<syfrah_controlplane::RedbStateMachine>>>,
+    > = Arc::new(tokio::sync::RwLock::new(None));
+
     // -- Storage reconciler (background task) ----------------------------------
     //
     // Start the StorageReconciler as a periodic background loop that converges
@@ -1466,6 +1473,7 @@ pub async fn run_daemon(
     let (storage_shutdown_tx, storage_shutdown_rx) = tokio::sync::watch::channel(false);
     {
         let hypervisor_id = my_record.name.clone();
+        let region = my_record.region.as_deref().unwrap_or("default").to_string();
         let encryption_passphrase: String = mesh_secret
             .encryption_key()
             .iter()
@@ -1476,9 +1484,14 @@ pub async fn run_daemon(
             encryption_passphrase,
         );
         let reconciler_shutdown_rx = storage_shutdown_rx.clone();
+        let reconciler_sm_ref = Arc::clone(&reconciler_sm);
         tokio::spawn(async move {
-            let reader: Arc<dyn syfrah_forge::storage_reconciler::VolumeStateReader> =
-                Arc::new(syfrah_forge::storage_reconciler::EmptyStateReader);
+            let reader: Arc<dyn syfrah_forge::storage_reconciler::VolumeStateReader> = Arc::new(
+                syfrah_forge::storage_reconciler::RaftVolumeStateReader::new(
+                    reconciler_sm_ref,
+                    region,
+                ),
+            );
             let mut volume_mgr = syfrah_storage::VolumeMgr::new();
             reconciler
                 .run_loop(reader, &mut volume_mgr, None, reconciler_shutdown_rx)
@@ -1713,7 +1726,7 @@ pub async fn run_daemon(
                 ..Default::default()
             });
 
-            let raft = openraft::Raft::new(node_id, config, network, log_store, sm)
+            let raft = openraft::Raft::new(node_id, config, network, log_store, sm.clone())
                 .await
                 .expect("failed to create Raft node");
 
@@ -1736,6 +1749,19 @@ pub async fn run_daemon(
                     let mut guard = holder.write().await;
                     *guard = Some(client);
                     info!("raft: injected Raft client into Forge API for leader forwarding");
+                });
+            }
+
+            // Inject the Raft state machine into the storage reconciler so it
+            // can read volume desired state from Raft instead of the no-op
+            // EmptyStateReader.
+            {
+                let holder = Arc::clone(&reconciler_sm);
+                let sm_ref = Arc::clone(&sm);
+                tokio::spawn(async move {
+                    let mut guard = holder.write().await;
+                    *guard = Some(sm_ref);
+                    info!("raft: injected state machine into storage reconciler");
                 });
             }
 
@@ -2260,6 +2286,7 @@ pub async fn run_daemon(
             let aj_raft_client_holder = Arc::clone(&raft_client_holder);
             let aj_forge_raft_client = Arc::clone(&forge_raft_client);
             let aj_forge_gossip_cluster = Arc::clone(&forge_gossip_cluster);
+            let aj_reconciler_sm = Arc::clone(&reconciler_sm);
             let aj_raft_org_handler = raft_org_handler.clone();
             let aj_raft_hv_handler_ref = raft_hv_handler_ref.clone();
             let aj_raft_compute_handler_ref = raft_compute_handler_ref.clone();
@@ -2504,7 +2531,11 @@ pub async fn run_daemon(
                             });
 
                                 let raft = match openraft::Raft::new(
-                                    node_id, config, network, log_store, sm,
+                                    node_id,
+                                    config,
+                                    network,
+                                    log_store,
+                                    sm.clone(),
                                 )
                                 .await
                                 {
@@ -2537,6 +2568,17 @@ pub async fn run_daemon(
                                         let mut guard = holder.write().await;
                                         *guard = Some(client);
                                         info!("raft: injected Raft client into Forge API (in-process)");
+                                    });
+                                }
+
+                                // Inject Raft state machine into storage reconciler.
+                                {
+                                    let holder = Arc::clone(&aj_reconciler_sm);
+                                    let sm_ref = Arc::clone(&sm);
+                                    tokio::spawn(async move {
+                                        let mut guard = holder.write().await;
+                                        *guard = Some(sm_ref);
+                                        info!("raft: injected state machine into storage reconciler (in-process)");
                                     });
                                 }
 

--- a/layers/forge/src/storage_reconciler.rs
+++ b/layers/forge/src/storage_reconciler.rs
@@ -823,6 +823,108 @@ impl VolumeStateReader for EmptyStateReader {
 }
 
 // ---------------------------------------------------------------------------
+// RaftVolumeStateReader — reads desired state from the Raft state machine
+// ---------------------------------------------------------------------------
+
+/// A `VolumeStateReader` backed by the Raft state machine's materialized view.
+///
+/// Holds a late-binding reference to the `RedbStateMachine` via
+/// `Arc<tokio::sync::RwLock<Option<Arc<RedbStateMachine>>>>`. Before the Raft
+/// state machine is initialised the Option is `None` and the reader behaves
+/// like `EmptyStateReader` (returns no volumes, no config). Once the control
+/// plane injects the SM reference, the reader returns real data.
+///
+/// The `region` field determines which `StorageConfig` entry to look up.
+pub struct RaftVolumeStateReader {
+    sm: Arc<tokio::sync::RwLock<Option<Arc<syfrah_controlplane::RedbStateMachine>>>>,
+    region: String,
+}
+
+impl RaftVolumeStateReader {
+    /// Create a new reader with a late-binding reference to the state machine.
+    pub fn new(
+        sm: Arc<tokio::sync::RwLock<Option<Arc<syfrah_controlplane::RedbStateMachine>>>>,
+        region: String,
+    ) -> Self {
+        Self { sm, region }
+    }
+}
+
+#[async_trait::async_trait]
+impl VolumeStateReader for RaftVolumeStateReader {
+    async fn desired_volumes(&self, local_hypervisor_id: &str) -> Vec<DesiredVolume> {
+        let guard = self.sm.read().await;
+        let sm = match guard.as_ref() {
+            Some(sm) => sm,
+            None => return Vec::new(),
+        };
+
+        let storage = sm.storage.read().unwrap();
+        storage
+            .volumes
+            .values()
+            .filter(|vol| {
+                vol.state == syfrah_controlplane::VolumeState::Attached
+                    && vol.attached_hypervisor_id.as_deref() == Some(local_hypervisor_id)
+            })
+            .map(|vol| DesiredVolume {
+                id: vol.id.clone(),
+                name: vol.name.clone(),
+                size_gb: vol.size_gb,
+                placement_generation: vol.placement_generation,
+                hypervisor_id: local_hypervisor_id.to_string(),
+                vm_id: vol.attached_vm_id.clone(),
+            })
+            .collect()
+    }
+
+    async fn pending_detaches(&self, local_hypervisor_id: &str) -> Vec<DesiredDetach> {
+        let guard = self.sm.read().await;
+        let sm = match guard.as_ref() {
+            Some(sm) => sm,
+            None => return Vec::new(),
+        };
+
+        let storage = sm.storage.read().unwrap();
+        storage
+            .volumes
+            .values()
+            .filter(|vol| {
+                // Volume is Available (detach requested) but still assigned to
+                // this hypervisor — meaning ZeroFS may still be running locally.
+                vol.state == syfrah_controlplane::VolumeState::Available
+                    && vol.attached_hypervisor_id.as_deref() == Some(local_hypervisor_id)
+            })
+            .map(|vol| DesiredDetach {
+                volume_id: vol.id.clone(),
+                vm_id: vol.attached_vm_id.clone().unwrap_or_default(),
+                // CH device ID follows the naming convention used during attach.
+                ch_device_id: format!("_disk_{}", vol.id),
+                force: false,
+            })
+            .collect()
+    }
+
+    async fn storage_config(&self) -> Option<RegionStorageConfig> {
+        let guard = self.sm.read().await;
+        let sm = guard.as_ref()?;
+
+        let storage = sm.storage.read().unwrap();
+        let cfg = storage.storage_configs.get(&self.region)?;
+
+        Some(RegionStorageConfig {
+            s3_endpoint: cfg.s3_endpoint.clone(),
+            s3_bucket: cfg.s3_bucket.clone(),
+            s3_access_key: cfg.s3_access_key.clone(),
+            s3_secret_key: cfg.s3_secret_key.clone(),
+            cache_disk_path: PathBuf::from(&cfg.cache_disk_path),
+            cache_disk_size_bytes: u64::from(cfg.cache_disk_size_gb) * 1024 * 1024 * 1024,
+            cache_memory_size_bytes: u64::from(cfg.cache_memory_size_gb) * 1024 * 1024 * 1024,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implements `RaftVolumeStateReader` struct that reads volume desired state from the Raft state machine's `StorageState` materialized view
- Uses late-binding `Arc<RwLock<Option<Arc<RedbStateMachine>>>>` pattern (same as Forge Raft client) so the reconciler starts before Raft is initialized and falls back to empty state until the SM is injected
- Wires the SM injection in both the primary Raft init path and the auto-join path in daemon.rs
- Reads `DesiredVolume` (volumes in Attached state assigned to local hypervisor), `DesiredDetach` (Available volumes still assigned locally), and `RegionStorageConfig` from `storage_configs`

## Test plan

- [x] All 37 storage_reconciler tests pass (unchanged — they use MockStateReader)
- [x] Full test suite passes (536/537, 1 pre-existing failure in syfrah-compute unrelated to this change)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)