### PR TITLE
fix(e2e): add ZEROFS_VERSION to Docker build context

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:latest AS builder
 WORKDIR /app
 RUN rustup target add x86_64-unknown-linux-musl && \
     apt-get update && apt-get install -y musl-tools
-COPY Cargo.toml Cargo.lock CLOUD_HYPERVISOR_VERSION CRUN_VERSION RUNSC_VERSION ./
+COPY Cargo.toml Cargo.lock CLOUD_HYPERVISOR_VERSION CRUN_VERSION RUNSC_VERSION ZEROFS_VERSION ./
 COPY layers layers
 COPY bin bin
 RUN cargo build --release --bin syfrah --target x86_64-unknown-linux-musl


### PR DESCRIPTION
The storage layer's build.rs reads ZEROFS_VERSION at compile time. Without it in the Docker context, cargo build fails inside the E2E container, breaking Build image CI for all PRs.