### PR TITLE
Wire reconciler to auto-start ZeroFS on volume create

### DIFF
--- a/layers/controlplane/src/commands.rs
+++ b/layers/controlplane/src/commands.rs
@@ -345,6 +345,9 @@ pub enum StateMachineCommand {
     // TODO: Replace String IDs with typed VolumeId/SnapshotId/VmId/HypervisorId
     // from syfrah-core once #1178 lands.
     /// Create a new volume. Raft validates quota and name uniqueness within env.
+    ///
+    /// When `hypervisor_id` is set, the volume is auto-assigned to that node so
+    /// the storage reconciler can start ZeroFS immediately (single-node flow).
     CreateVolume {
         id: String,
         name: String,
@@ -353,6 +356,12 @@ pub enum StateMachineCommand {
         project_id: String,
         env_id: String,
         volume_type: VolumeType,
+        /// Optional hypervisor to auto-assign the volume to on creation.
+        /// When set, `attached_hypervisor_id` and `placement_generation` are
+        /// initialized so the reconciler starts ZeroFS without a separate
+        /// VolumeAttach command.
+        #[serde(default)]
+        hypervisor_id: Option<String>,
     },
     /// Mark a volume for deletion (tombstone). Volume must be Available (not attached).
     /// With `cascade: true`, all snapshots referencing this volume are deleted first.
@@ -822,6 +831,7 @@ mod tests {
                 project_id: "myapp".into(),
                 env_id: "prod".into(),
                 volume_type: VolumeType::Data,
+                hypervisor_id: None,
             },
             StateMachineCommand::DeleteVolume {
                 volume_id: "vol-01".into(),

--- a/layers/controlplane/src/state_machine.rs
+++ b/layers/controlplane/src/state_machine.rs
@@ -1910,6 +1910,7 @@ impl RedbStateMachine {
                 project_id,
                 env_id,
                 volume_type,
+                hypervisor_id,
             } => {
                 // Check quota before creating.
                 if let Err(e) = self.check_volume_quota(org_id, project_id, *size_gb) {
@@ -1933,6 +1934,12 @@ impl RedbStateMachine {
                         "volume with id '{id}' already exists"
                     ));
                 }
+                // When hypervisor_id is provided, auto-assign the volume so the
+                // storage reconciler starts ZeroFS immediately (single-node flow).
+                let (attached_hypervisor_id, placement_generation) = match hypervisor_id {
+                    Some(hv) => (Some(hv.clone()), 1),
+                    None => (None, 0),
+                };
                 let record = VolumeRecord {
                     id: id.clone(),
                     name: name.clone(),
@@ -1943,8 +1950,8 @@ impl RedbStateMachine {
                     volume_type: volume_type.clone(),
                     state: VolumeState::Available,
                     attached_vm_id: None,
-                    attached_hypervisor_id: None,
-                    placement_generation: 0,
+                    attached_hypervisor_id,
+                    placement_generation,
                     deletion_protection: false,
                     deleted_at: None,
                 };
@@ -3001,6 +3008,7 @@ mod tests {
             project_id: project.into(),
             env_id: env.into(),
             volume_type: VolumeType::Data,
+            hypervisor_id: None,
         })
     }
 
@@ -4342,6 +4350,7 @@ mod tests {
             project_id: "myapp".into(),
             env_id: "prod".into(),
             volume_type: VolumeType::Root,
+            hypervisor_id: None,
         });
         assert!(matches!(resp, StateMachineResponse::Created(_)));
 
@@ -4427,6 +4436,7 @@ mod tests {
             project_id: "myapp".into(),
             env_id: "prod".into(),
             volume_type: VolumeType::Root,
+            hypervisor_id: None,
         });
         assert!(matches!(resp, StateMachineResponse::Created(_)));
 

--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -1515,11 +1515,33 @@ pub async fn run_daemon(
     {
         let hypervisor_id = my_record.name.clone();
         let region = my_record.region.as_deref().unwrap_or("default").to_string();
-        let encryption_passphrase: String = mesh_secret
-            .encryption_key()
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect();
+        // Read encryption passphrase from /etc/syfrah/storage-key if it exists,
+        // otherwise derive from the mesh secret (single-node default).
+        let encryption_passphrase: String = match std::fs::read_to_string("/etc/syfrah/storage-key")
+        {
+            Ok(contents) => {
+                let trimmed = contents.trim().to_string();
+                if trimmed.is_empty() {
+                    warn!("/etc/syfrah/storage-key is empty, falling back to mesh secret");
+                    mesh_secret
+                        .encryption_key()
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect()
+                } else {
+                    info!("using encryption passphrase from /etc/syfrah/storage-key");
+                    trimmed
+                }
+            }
+            Err(_) => {
+                debug!("/etc/syfrah/storage-key not found, deriving passphrase from mesh secret");
+                mesh_secret
+                    .encryption_key()
+                    .iter()
+                    .map(|b| format!("{b:02x}"))
+                    .collect()
+            }
+        };
         let reconciler = syfrah_forge::storage_reconciler::StorageReconciler::new(
             hypervisor_id,
             encryption_passphrase,

--- a/layers/fabric/src/raft_compute_handler.rs
+++ b/layers/fabric/src/raft_compute_handler.rs
@@ -643,6 +643,7 @@ impl RaftComputeHandler {
             project_id,
             env_id,
             volume_type: VolumeType::Root,
+            hypervisor_id: None,
         };
 
         match client.write(cmd).await {

--- a/layers/forge/src/storage_reconciler.rs
+++ b/layers/forge/src/storage_reconciler.rs
@@ -867,8 +867,13 @@ impl VolumeStateReader for RaftVolumeStateReader {
             .volumes
             .values()
             .filter(|vol| {
-                vol.state == syfrah_controlplane::VolumeState::Attached
-                    && vol.attached_hypervisor_id.as_deref() == Some(local_hypervisor_id)
+                // Include both Attached volumes (VM-bound) and Available volumes
+                // that have been assigned to this hypervisor (auto-start on create).
+                let assigned_here =
+                    vol.attached_hypervisor_id.as_deref() == Some(local_hypervisor_id);
+                let startable_state = vol.state == syfrah_controlplane::VolumeState::Attached
+                    || vol.state == syfrah_controlplane::VolumeState::Available;
+                assigned_here && startable_state
             })
             .map(|vol| DesiredVolume {
                 id: vol.id.clone(),

--- a/layers/storage/src/api.rs
+++ b/layers/storage/src/api.rs
@@ -288,6 +288,13 @@ impl StorageLayerHandler {
                     None => format!("{org}/{project}/default"),
                 };
                 let volume_id = format!("vol-{}", short_id());
+                // Auto-assign volume to the local hypervisor so the storage
+                // reconciler starts ZeroFS immediately (single-node flow).
+                let hypervisor_id = if self.local_node_name.is_empty() {
+                    None
+                } else {
+                    Some(self.local_node_name.clone())
+                };
                 let cmd = StateMachineCommand::CreateVolume {
                     id: volume_id.clone(),
                     name: name.clone(),
@@ -296,6 +303,7 @@ impl StorageLayerHandler {
                     project_id: project,
                     env_id,
                     volume_type: syfrah_controlplane::commands::VolumeType::Data,
+                    hypervisor_id,
                 };
                 match self.submit_raft(cmd).await {
                     Ok(_) => {


### PR DESCRIPTION
## Summary

- Add optional `hypervisor_id` field to `CreateVolume` Raft command so volumes are auto-assigned to a hypervisor at creation time (single-node flow)
- Update `RaftVolumeStateReader::desired_volumes()` to include `Available` volumes with `attached_hypervisor_id` set, not just `Attached` volumes — this makes the reconciler start ZeroFS immediately when a volume is created
- Storage API (`StorageLayerHandler`) passes `local_node_name` as `hypervisor_id` on volume create
- Daemon reads encryption passphrase from `/etc/syfrah/storage-key` with fallback to mesh-secret-derived key

## Flow after this change
```
syfrah volume create app-data --size 5 --org acme --project web --env prod
  → Raft CreateVolume with hypervisor_id = local node
  → VolumeRecord created: state=Available, attached_hypervisor_id=local, generation=1
  → Reconciler (next tick): sees Available volume assigned here
  → Reads S3Config from RegionStorageConfig in Raft
  → VolumeMgr.start_volume() generates zerofs.toml + spawns ZeroFS
  → ZeroFS connects to S3, starts 9P server
  → mount -t 9p at /var/lib/syfrah/volumes/{vol-id}/
```

## Test plan
- [x] `cargo build` — clean
- [x] `cargo clippy` — clean
- [x] `cargo test` — all passing (1 pre-existing failure in binary permission test when running as root)
- [ ] Manual: `syfrah volume create` on a single-node cluster with S3 configured, verify ZeroFS starts within 5s

Closes #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)