### PR TITLE
fix: add VXLAN-to-bridge nftables rules for cross-node traffic

### DIFF
--- a/layers/fabric/src/daemon.rs
+++ b/layers/fabric/src/daemon.rs
@@ -3940,6 +3940,31 @@ pub async fn run_daemon(
                 None => continue,
             };
 
+            // Build expected bridges for VPCs that have VMs on THIS node.
+            // This ensures bridge accept rules (including VXLAN ↔ bridge
+            // forwarding rules) are re-applied on every node, not only the
+            // Raft leader.  Without these rules, cross-node (cross-AZ) VXLAN
+            // traffic is silently dropped by the forward chain's policy drop.
+            let mut expected_bridges: Vec<syfrah_overlay::ExpectedBridge> = Vec::new();
+            if let Some(ref placement_store) = overlay_reconcile_placement_store {
+                match placement_store.list_by_node(&overlay_reconcile_local_node) {
+                    Ok(placements) => {
+                        let mut seen_vpcs = std::collections::HashSet::new();
+                        for p in &placements {
+                            if seen_vpcs.insert(p.vpc_id.clone()) {
+                                expected_bridges.push(syfrah_overlay::ExpectedBridge {
+                                    name: syfrah_overlay::naming::bridge_name(&p.vpc_id),
+                                    vpc_id: p.vpc_id.clone(),
+                                });
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "overlay reconcile: failed to list local placements");
+                    }
+                }
+            }
+
             // Build expected peerings from the org store.
             let peerings = match org_store.list_peerings() {
                 Ok(p) => p,
@@ -3975,6 +4000,7 @@ pub async fn run_daemon(
             }
 
             let state = syfrah_overlay::NetworkState {
+                bridges: expected_bridges,
                 peerings: expected_peerings,
                 ..Default::default()
             };

--- a/layers/overlay/src/nft.rs
+++ b/layers/overlay/src/nft.rs
@@ -195,19 +195,44 @@ pub fn apply_ruleset(ruleset: &str) -> std::io::Result<()> {
 
 // ── VPC bridge base rules ───────────────────────────────────────────
 
-/// Generate nftables rules to allow intra-VPC traffic (same bridge in/out)
-/// and internet egress from a VPC bridge.
+/// Generate nftables rules to allow intra-VPC traffic (same bridge in/out),
+/// cross-node VXLAN overlay traffic, and internet egress from a VPC bridge.
 ///
 /// With `policy drop` on the forward chain, traffic between bridges is
 /// blocked by default (VPC isolation). These rules explicitly allow:
 /// 1. Same-bridge traffic (intra-VPC communication between subnets)
-/// 2. Outbound internet egress (bridge → non-bridge interface)
+/// 2. Bridge-to-VXLAN traffic (local VM → remote VM via VXLAN tunnel)
+/// 3. VXLAN-to-bridge traffic (remote VM → local VM arriving via VXLAN)
+/// 4. Outbound internet egress (bridge → non-bridge interface)
+///
+/// Rules 2 and 3 are essential for cross-AZ / cross-node communication:
+/// VXLAN packets decapsulated on the receiving node arrive on the `syfx-*`
+/// interface and must be forwarded to the local bridge (`syfb-*`). Without
+/// these rules the forward chain's `policy drop` silently discards the
+/// decapsulated traffic.
 pub fn generate_bridge_accept_rules(bridge: &str) -> String {
+    // Derive the matching VXLAN interface name.  Bridge names use the
+    // format `syfb-{hash}` and the corresponding VXLAN interface is
+    // `syfx-{hash}` (same hash suffix).
+    let vxlan = bridge.replacen(crate::naming::BRIDGE_PREFIX, crate::naming::VXLAN_PREFIX, 1);
+
     let mut buf = String::new();
     // Same bridge: intra-VPC traffic allowed
     writeln!(
         buf,
         "add rule inet {TABLE_NAME} {CHAIN_NAME} iifname \"{bridge}\" oifname \"{bridge}\" accept"
+    )
+    .unwrap();
+    // Bridge → VXLAN: local VM sending to remote VM via overlay tunnel
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} iifname \"{bridge}\" oifname \"{vxlan}\" accept"
+    )
+    .unwrap();
+    // VXLAN → Bridge: remote VM traffic arriving via overlay tunnel
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} iifname \"{vxlan}\" oifname \"{bridge}\" accept"
     )
     .unwrap();
     // Internet egress: bridge → any non-bridge interface
@@ -417,6 +442,28 @@ mod tests {
         assert!(
             rules.contains(&format!("iifname \"{br}\" oifname \"{br}\" accept")),
             "same-bridge traffic must be accepted"
+        );
+    }
+
+    #[test]
+    fn bridge_accept_rules_vxlan_to_bridge() {
+        let br = crate::naming::bridge_name("100");
+        let vx = crate::naming::vxlan_name("100");
+        let rules = generate_bridge_accept_rules(&br);
+        assert!(
+            rules.contains(&format!("iifname \"{vx}\" oifname \"{br}\" accept")),
+            "VXLAN-to-bridge traffic must be accepted for cross-node communication"
+        );
+    }
+
+    #[test]
+    fn bridge_accept_rules_bridge_to_vxlan() {
+        let br = crate::naming::bridge_name("100");
+        let vx = crate::naming::vxlan_name("100");
+        let rules = generate_bridge_accept_rules(&br);
+        assert!(
+            rules.contains(&format!("iifname \"{br}\" oifname \"{vx}\" accept")),
+            "bridge-to-VXLAN traffic must be accepted for cross-node communication"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: Cross-AZ ping fails because the `inet syfrah forward` chain (`policy drop`) has no accept rules for traffic between VXLAN interfaces (`syfx-*`) and bridges (`syfb-*`) on non-leader nodes. VXLAN-decapsulated packets arriving from remote hypervisors are silently dropped.
- **Fix 1** (`layers/overlay/src/nft.rs`): `generate_bridge_accept_rules` now emits two additional rules per bridge — `syfb-X` to/from `syfx-X` — so overlay traffic can flow in both directions.
- **Fix 2** (`layers/fabric/src/daemon.rs`): The overlay reconcile loop now populates `NetworkState.bridges` from the local placement store, ensuring bridge accept rules are periodically re-applied on ALL nodes (not just during initial VM creation).

## Evidence

- Same-node ping works (bridge rules exist on the node that created the bridge)
- Cross-node ping fails: `tcpdump` confirms VXLAN packets arrive (`flags [I], vni 100`) but are dropped by the forward chain
- After this fix, the forward chain accepts `syfx-* → syfb-*` and `syfb-* → syfx-*` traffic on every node with active VMs

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -p syfrah-overlay -p syfrah-fabric` — clean
- [x] `cargo test -p syfrah-overlay` — 160 tests pass (including 2 new VXLAN rule tests)
- [ ] Deploy to a 2-node cluster and verify cross-AZ ping works

Closes #0

🤖 Generated with [Claude Code](https://claude.com/claude-code)