### PR TITLE
fix(overlay): nftables rule ordering — default deny before accept was dead code

### DIFF
--- a/layers/overlay/src/nft.rs
+++ b/layers/overlay/src/nft.rs
@@ -128,11 +128,7 @@ pub fn generate_vm_rules(tap: &str, mac: &str, ip: Ipv4Addr) -> String {
         "add rule inet {TABLE_NAME} {CHAIN_NAME} iif {tap} ip saddr != {ip} drop"
     )
     .unwrap();
-    writeln!(
-        buf,
-        "add rule inet {TABLE_NAME} {CHAIN_NAME} oif {tap} drop"
-    )
-    .unwrap();
+    // Accept rules BEFORE the default deny (order matters in nftables)
     writeln!(
         buf,
         "add rule inet {TABLE_NAME} {CHAIN_NAME} oif {tap} tcp dport 22 accept"
@@ -146,6 +142,12 @@ pub fn generate_vm_rules(tap: &str, mac: &str, ip: Ipv4Addr) -> String {
     writeln!(
         buf,
         "add rule inet {TABLE_NAME} {CHAIN_NAME} oif {tap} ct state established,related accept"
+    )
+    .unwrap();
+    // Default deny ingress — MUST be AFTER accept rules
+    writeln!(
+        buf,
+        "add rule inet {TABLE_NAME} {CHAIN_NAME} oif {tap} drop"
     )
     .unwrap();
     writeln!(
@@ -488,7 +490,11 @@ mod tests {
         let ssh_pos = r.find("tcp dport 22 accept").expect("SSH rule");
         assert!(mac_spoof_pos < ip_spoof_pos);
         assert!(ip_spoof_pos < egress_pos);
-        assert!(deny_pos < ssh_pos);
+        // Accept rules must come BEFORE the default deny drop
+        assert!(
+            ssh_pos < deny_pos,
+            "SSH accept must be before default deny drop"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Root cause
`generate_vm_rules()` placed `oif {tap} drop` (default deny) BEFORE the SSH/ICMP/conntrack accept rules, making them unreachable dead code. All ingress traffic to VMs was dropped.

This is why cross-AZ VXLAN ping failed: packets arrived via VXLAN but were dropped by the catch-all deny before reaching the VM.

## Fix
Moved accept rules (SSH port 22, ICMP echo-request, conntrack established) BEFORE the default deny drop. Standard firewall practice.

## Diagnosis
3-agent parallel investigation confirmed:
- **Soren**: Full packet path trace → identified rule ordering as root cause
- **Kira**: nftables chain analysis → confirmed both inet + bridge tables with policy drop
- **Ren**: FDB propagation audit → confirmed bidirectional via Raft PlacementEvent (not the issue)

Closes #1277