### PR TITLE
feat(storage): add --zone flag to storage configure CLI

### DIFF
--- a/layers/storage/src/api.rs
+++ b/layers/storage/src/api.rs
@@ -77,9 +77,10 @@ pub enum StorageRequest {
         project: Option<String>,
         force: bool,
     },
-    /// Configure storage backend (S3 + cache settings).
+    /// Configure storage backend (S3 + cache settings) for a specific zone.
     Configure {
-        region: String,
+        zone: String,
+        region: Option<String>,
         s3_endpoint: String,
         s3_bucket: String,
         s3_access_key: String,
@@ -123,7 +124,7 @@ pub enum StorageResponse {
     /// Success with no data.
     Ok,
     /// Storage configuration applied successfully.
-    StorageConfigured { region: String },
+    StorageConfigured { zone: String },
     /// Storage health check results.
     Health(StorageHealthReport),
     /// Storage status results.
@@ -161,6 +162,17 @@ pub struct StorageHealthReport {
     pub cache_memory_limit_bytes: u64,
 }
 
+/// Per-zone storage configuration summary (no credentials).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ZoneConfigSummary {
+    /// Zone identifier (e.g. "fsn1").
+    pub zone: String,
+    /// S3 endpoint URL.
+    pub s3_endpoint: String,
+    /// S3 bucket name.
+    pub s3_bucket: String,
+}
+
 /// Results of a storage status query.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StorageStatusReport {
@@ -168,6 +180,9 @@ pub struct StorageStatusReport {
     pub s3_connected: bool,
     /// S3 endpoint URL (never contains credentials).
     pub s3_endpoint: String,
+    /// Per-zone storage configurations.
+    #[serde(default)]
+    pub zone_configs: Vec<ZoneConfigSummary>,
     /// Per-volume cache utilization (placeholder until ZeroFS metrics in #1187).
     pub volume_cache_stats: Vec<VolumeCacheStat>,
     /// Total dirty bytes across all volumes (placeholder).
@@ -438,6 +453,7 @@ impl StorageLayerHandler {
             }
 
             StorageRequest::Configure {
+                zone,
                 region,
                 s3_endpoint,
                 s3_bucket,
@@ -457,12 +473,19 @@ impl StorageLayerHandler {
                     cache_disk_size_gb: cache_disk_size_gb.unwrap_or(100),
                     cache_memory_size_gb: cache_memory_size_gb.unwrap_or(4),
                 };
+                // Use zone as the Raft config key. Region is optional metadata
+                // stored alongside the zone identifier.
+                let raft_key = if let Some(ref r) = region {
+                    format!("{zone}/{r}")
+                } else {
+                    zone.clone()
+                };
                 let cmd = StateMachineCommand::SetStorageConfig {
-                    region: region.clone(),
+                    region: raft_key,
                     config: Box::new(config),
                 };
                 match self.submit_raft(cmd).await {
-                    Ok(_) => StorageResponse::StorageConfigured { region },
+                    Ok(_) => StorageResponse::StorageConfigured { zone },
                     Err(e) => StorageResponse::Error(e),
                 }
             }
@@ -678,6 +701,8 @@ impl StorageLayerHandler {
             }
 
             StorageRequest::Status => {
+                // Collect per-zone configs from store.
+                let zone_configs = self.list_zone_configs();
                 // Status still uses placeholders for per-volume stats (#1187).
                 StorageResponse::Status(StorageStatusReport {
                     s3_connected: false,
@@ -685,6 +710,7 @@ impl StorageLayerHandler {
                         .get_storage_config()
                         .map(|c| c.s3_endpoint)
                         .unwrap_or_else(|| "(not configured)".into()),
+                    zone_configs,
                     volume_cache_stats: vec![],
                     total_dirty_bytes: 0,
                     s3_put_latency_ms: None,
@@ -806,6 +832,26 @@ impl StorageLayerHandler {
         Err(format!(
             "snapshot '{name}' not found. List available snapshots with: syfrah volume snapshot list"
         ))
+    }
+
+    /// List all per-zone storage configurations from the store.
+    fn list_zone_configs(&self) -> Vec<ZoneConfigSummary> {
+        let store = match self.store.as_ref() {
+            Some(s) => s,
+            None => return vec![],
+        };
+        let configs = match store.list_storage_configs() {
+            Ok(c) => c,
+            Err(_) => return vec![],
+        };
+        configs
+            .into_iter()
+            .map(|(zone_key, cfg)| ZoneConfigSummary {
+                zone: zone_key,
+                s3_endpoint: cfg.s3_endpoint,
+                s3_bucket: cfg.s3_bucket,
+            })
+            .collect()
     }
 
     /// Read StorageConfig from the local store for this node's region.
@@ -984,7 +1030,8 @@ mod tests {
     async fn stub_handler_configure_returns_raft_error() {
         let handler = StorageLayerHandler::new_stub();
         let req = StorageRequest::Configure {
-            region: "par1".into(),
+            zone: "fsn1".into(),
+            region: Some("eu-central".into()),
             s3_endpoint: "https://s3.par.io.cloud.ovh.net".into(),
             s3_bucket: "syfrah-volumes".into(),
             s3_access_key: "key".into(),

--- a/layers/storage/src/binary.rs
+++ b/layers/storage/src/binary.rs
@@ -444,7 +444,7 @@ mod tests {
             Ok(path) => assert!(path.exists(), "returned path should exist"),
             Err(e) => {
                 // Expected in test environments without zerofs or network access.
-                assert!(format!("{e}")!.is_empty(), "error should have a message");
+                assert!(!format!("{e}").is_empty(), "error should have a message");
             }
         }
     }

--- a/layers/storage/src/cli/configure.rs
+++ b/layers/storage/src/cli/configure.rs
@@ -21,7 +21,8 @@ fn control_socket_path() -> PathBuf {
 
 /// Parameters for `syfrah storage configure` (full S3 configuration).
 pub struct ConfigureParams<'a> {
-    pub region: &'a str,
+    pub zone: &'a str,
+    pub region: Option<&'a str>,
     pub s3_endpoint: &'a str,
     pub s3_bucket: &'a str,
     pub s3_access_key: &'a str,
@@ -35,6 +36,7 @@ pub struct ConfigureParams<'a> {
 /// Run the full `syfrah storage configure` flow with all S3 + cache flags.
 pub async fn run_configure(params: &ConfigureParams<'_>) -> anyhow::Result<()> {
     let ConfigureParams {
+        zone,
         region,
         s3_endpoint,
         s3_bucket,
@@ -70,7 +72,8 @@ pub async fn run_configure(params: &ConfigureParams<'_>) -> anyhow::Result<()> {
 
     // --- Send Configure request to daemon ---
     let req = StorageRequest::Configure {
-        region: region.to_string(),
+        zone: zone.to_string(),
+        region: region.map(|s| s.to_string()),
         s3_endpoint: s3_endpoint.to_string(),
         s3_bucket: s3_bucket.to_string(),
         s3_access_key: s3_access_key.to_string(),
@@ -85,8 +88,8 @@ pub async fn run_configure(params: &ConfigureParams<'_>) -> anyhow::Result<()> {
         .map_err(daemon_connect_error)?;
 
     match resp {
-        StorageResponse::StorageConfigured { region } => {
-            println!("Storage configured for region '{region}'.");
+        StorageResponse::StorageConfigured { zone } => {
+            println!("Storage configured for zone '{zone}'.");
             if encryption_passphrase.is_some() {
                 println!("Encryption passphrase saved to {STORAGE_KEY_PATH}.");
             }
@@ -265,7 +268,8 @@ mod tests {
     #[tokio::test]
     async fn run_configure_rejects_nonexistent_cache_disk() {
         let params = ConfigureParams {
-            region: "eu-west",
+            zone: "fsn1",
+            region: Some("eu-central"),
             s3_endpoint: "https://s3.example.com",
             s3_bucket: "bucket",
             s3_access_key: "AKID",
@@ -285,7 +289,8 @@ mod tests {
     #[tokio::test]
     async fn run_configure_rejects_invalid_s3_endpoint() {
         let params = ConfigureParams {
-            region: "eu-west",
+            zone: "fsn1",
+            region: None,
             s3_endpoint: "ftp://bad.example.com",
             s3_bucket: "bucket",
             s3_access_key: "AKID",

--- a/layers/storage/src/cli/health.rs
+++ b/layers/storage/src/cli/health.rs
@@ -133,6 +133,19 @@ fn print_status_report(r: &StorageStatusReport) {
         is_tty,
     );
 
+    // -- Per-zone configs section --
+    if !r.zone_configs.is_empty() {
+        println!();
+        super::fmt::print_heading("Per-Zone Configs", is_tty);
+        for zc in &r.zone_configs {
+            super::fmt::print_kv(
+                &zc.zone,
+                &format!("{} ({})", zc.s3_endpoint, zc.s3_bucket),
+                is_tty,
+            );
+        }
+    }
+
     // -- Cache metrics section --
     if let Some(ref cm) = r.cache_metrics {
         println!();
@@ -344,6 +357,7 @@ mod tests {
         let report = StorageStatusReport {
             s3_connected: true,
             s3_endpoint: "https://s3.example.com".into(),
+            zone_configs: vec![],
             volume_cache_stats: vec![VolumeCacheStat {
                 name: "pgdata".into(),
                 cached_bytes: 1_073_741_824,

--- a/layers/storage/src/cli/mod.rs
+++ b/layers/storage/src/cli/mod.rs
@@ -241,20 +241,23 @@ pub enum StorageCommand {
     /// Show ZeroFS binary version and path
     #[command(after_help = "Examples:\n  syfrah storage version")]
     Version,
-    /// Configure storage backend (S3 endpoint, bucket, cache)
+    /// Configure storage backend (S3 endpoint, bucket, cache) for a specific zone
     #[command(after_help = "Examples:\n  \
-            syfrah storage configure --region eu-west \\\n    \
-              --s3-endpoint https://s3.par.io.cloud.ovh.net \\\n    \
-              --s3-bucket syfrah-storage --s3-access-key AKID --s3-secret-key SECRET \\\n    \
+            syfrah storage configure --zone fsn1 \\\n    \
+              --s3-endpoint https://fsn1.your-objectstorage.com \\\n    \
+              --s3-bucket syfrah-storage-fsn1 --s3-access-key AKID --s3-secret-key SECRET \\\n    \
               --cache-disk-path /dev/nvme1n1 --cache-disk-size 200 --cache-memory-size 8\n  \
-            syfrah storage configure --region eu-west \\\n    \
-              --s3-endpoint https://s3.par.io.cloud.ovh.net \\\n    \
-              --s3-bucket syfrah-storage --s3-access-key AKID --s3-secret-key SECRET \\\n    \
+            syfrah storage configure --zone fsn1 --region eu-central \\\n    \
+              --s3-endpoint https://fsn1.your-objectstorage.com \\\n    \
+              --s3-bucket syfrah-storage-fsn1 --s3-access-key AKID --s3-secret-key SECRET \\\n    \
               --encryption-passphrase-file /path/to/passphrase\n  \
             syfrah storage configure --cache-disk-path /dev/nvme1n1 \\\n    \
               --cache-disk-size 200 --cache-memory-size 8")]
     Configure {
-        /// Target region for this storage configuration
+        /// Target zone for this storage configuration (e.g. fsn1, nbg1, hel1)
+        #[arg(long)]
+        zone: Option<String>,
+        /// Region metadata (optional, for grouping zones)
         #[arg(long)]
         region: Option<String>,
         /// S3-compatible endpoint URL (must start with https:// or http://)
@@ -336,6 +339,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
             Ok(())
         }
         StorageCommand::Configure {
+            zone,
             region,
             s3_endpoint,
             s3_bucket,
@@ -368,7 +372,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
                 || s3_bucket.is_some()
                 || s3_access_key.is_some()
                 || s3_secret_key.is_some()
-                || region.is_some();
+                || zone.is_some();
             let has_cache = cache_disk_path.is_some()
                 || cache_disk_size.is_some()
                 || cache_memory_size.is_some();
@@ -403,7 +407,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
                 anyhow::bail!(
                     "no configuration flags provided.\n\n\
                      Full configuration:\n  \
-                     syfrah storage configure --region <region> \\\n    \
+                     syfrah storage configure --zone <zone> \\\n    \
                        --s3-endpoint <url> --s3-bucket <bucket> \\\n    \
                        --s3-access-key <key> --s3-secret-key <key>\n\n\
                      Cache-only override:\n  \
@@ -412,11 +416,11 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
                 );
             }
 
-            // Full S3 configuration — require all S3 fields
-            let region = region.ok_or_else(|| {
+            // Full S3 configuration — require --zone and all S3 fields
+            let zone = zone.ok_or_else(|| {
                 anyhow::anyhow!(
-                    "--region is required for storage configuration.\n\n\
-                     Usage: syfrah storage configure --region <region> \
+                    "--zone is required for storage configuration.\n\n\
+                     Usage: syfrah storage configure --zone <zone> \
                      --s3-endpoint <url> --s3-bucket <bucket> \
                      --s3-access-key <key> --s3-secret-key <key>"
                 )
@@ -424,7 +428,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
             let endpoint = s3_endpoint.ok_or_else(|| {
                 anyhow::anyhow!(
                     "--s3-endpoint is required for storage configuration.\n\n\
-                     Usage: syfrah storage configure --region {region} \
+                     Usage: syfrah storage configure --zone {zone} \
                      --s3-endpoint <url> --s3-bucket <bucket> \
                      --s3-access-key <key> --s3-secret-key <key>"
                 )
@@ -432,7 +436,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
             let bucket = s3_bucket.ok_or_else(|| {
                 anyhow::anyhow!(
                     "--s3-bucket is required for storage configuration.\n\n\
-                     Usage: syfrah storage configure --region {region} \
+                     Usage: syfrah storage configure --zone {zone} \
                      --s3-endpoint {endpoint} --s3-bucket <bucket> \
                      --s3-access-key <key> --s3-secret-key <key>"
                 )
@@ -440,7 +444,7 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
             let access_key = s3_access_key.ok_or_else(|| {
                 anyhow::anyhow!(
                     "--s3-access-key is required for storage configuration.\n\n\
-                     Usage: syfrah storage configure --region {region} \
+                     Usage: syfrah storage configure --zone {zone} \
                      --s3-endpoint {endpoint} --s3-bucket {bucket} \
                      --s3-access-key <key> --s3-secret-key <key>"
                 )
@@ -448,14 +452,15 @@ pub async fn run_storage(cmd: StorageCommand) -> anyhow::Result<()> {
             let secret_key = s3_secret_key.ok_or_else(|| {
                 anyhow::anyhow!(
                     "--s3-secret-key is required for storage configuration.\n\n\
-                     Usage: syfrah storage configure --region {region} \
+                     Usage: syfrah storage configure --zone {zone} \
                      --s3-endpoint {endpoint} --s3-bucket {bucket} \
                      --s3-access-key {access_key} --s3-secret-key <key>"
                 )
             })?;
 
             configure::run_configure(&configure::ConfigureParams {
-                region: &region,
+                zone: &zone,
+                region: region.as_deref(),
                 s3_endpoint: &endpoint,
                 s3_bucket: &bucket,
                 s3_access_key: &access_key,
@@ -576,8 +581,10 @@ mod tests {
     fn configure_full_parse() {
         let cmd = parse(&[
             "configure",
+            "--zone",
+            "fsn1",
             "--region",
-            "eu-west",
+            "eu-central",
             "--s3-endpoint",
             "https://s3.par.io.cloud.ovh.net",
             "--s3-bucket",
@@ -595,6 +602,7 @@ mod tests {
         ]);
         match cmd {
             StorageCommand::Configure {
+                zone,
                 region,
                 s3_endpoint,
                 s3_bucket,
@@ -606,7 +614,8 @@ mod tests {
                 encryption_passphrase,
                 encryption_passphrase_file,
             } => {
-                assert_eq!(region.as_deref(), Some("eu-west"));
+                assert_eq!(zone.as_deref(), Some("fsn1"));
+                assert_eq!(region.as_deref(), Some("eu-central"));
                 assert_eq!(
                     s3_endpoint.as_deref(),
                     Some("https://s3.par.io.cloud.ovh.net")
@@ -660,8 +669,8 @@ mod tests {
     fn configure_with_encryption_passphrase() {
         let cmd = parse(&[
             "configure",
-            "--region",
-            "eu-west",
+            "--zone",
+            "fsn1",
             "--s3-endpoint",
             "https://s3.example.com",
             "--s3-bucket",
@@ -690,8 +699,8 @@ mod tests {
     fn configure_with_encryption_passphrase_file() {
         let cmd = parse(&[
             "configure",
-            "--region",
-            "eu-west",
+            "--zone",
+            "fsn1",
             "--s3-endpoint",
             "https://s3.example.com",
             "--s3-bucket",
@@ -724,6 +733,7 @@ mod tests {
         let cmd = parse(&["configure"]);
         match cmd {
             StorageCommand::Configure {
+                zone,
                 region,
                 s3_endpoint,
                 s3_bucket,
@@ -735,6 +745,7 @@ mod tests {
                 encryption_passphrase,
                 encryption_passphrase_file,
             } => {
+                assert!(zone.is_none());
                 assert!(region.is_none());
                 assert!(s3_endpoint.is_none());
                 assert!(s3_bucket.is_none());


### PR DESCRIPTION
## Summary
- Adds a required `--zone` flag to `syfrah storage configure` so each zone (e.g. `fsn1`, `nbg1`) gets its own S3 backend config. `--region` is now optional metadata for grouping zones.
- `StorageRequest::Configure` and `StorageResponse::StorageConfigured` updated to use `zone` as the primary key, passed through to the `SetStorageConfig` Raft command.
- `syfrah storage status` now displays per-zone configurations via a new `ZoneConfigSummary` type and `zone_configs` field on `StorageStatusReport`.

## Test plan
- [x] All 62 CLI and API tests pass (`cargo test -p syfrah-storage --lib -- 'cli::' 'api::tests'`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Verify `syfrah storage configure --zone fsn1 --s3-endpoint ... --s3-bucket ...` works end-to-end
- [ ] Verify `syfrah storage status` shows per-zone config entries

Closes #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)