### PR TITLE
fix: pass target hypervisor to CreateVolume for correct ZeroFS start

### DIFF
--- a/layers/fabric/src/raft_compute_handler.rs
+++ b/layers/fabric/src/raft_compute_handler.rs
@@ -320,6 +320,7 @@ impl RaftComputeHandler {
                                 &name,
                                 root_disk_size_gb,
                                 subnet.as_ref(),
+                                &self.local_node_name,
                             )
                             .await;
                         }
@@ -452,6 +453,7 @@ impl RaftComputeHandler {
                                 &name,
                                 root_disk_size_gb,
                                 subnet.as_ref(),
+                                &decision.hypervisor_id,
                             )
                             .await;
 
@@ -604,6 +606,7 @@ impl RaftComputeHandler {
         vm_name: &str,
         size_gb: u32,
         subnet: Option<&syfrah_compute::types::SubnetInfo>,
+        target_hypervisor: &str,
     ) {
         let root_volume_id = format!("vol-root-{vm_name}");
         let root_volume_name = format!("root-{vm_name}");
@@ -643,7 +646,7 @@ impl RaftComputeHandler {
             project_id,
             env_id,
             volume_type: VolumeType::Root,
-            hypervisor_id: None,
+            hypervisor_id: Some(target_hypervisor.to_string()),
             zone: None, // TODO(#1282): inherit zone from target hypervisor
         };
 


### PR DESCRIPTION
## Summary
- When a VM is created on a non-leader node, `create_root_volume_via_raft()` was passing `hypervisor_id: None` to `CreateVolume`, leaving the root volume without an `attached_hypervisor_id`
- The storage reconciler ignored volumes with no attached hypervisor, so ZeroFS never started on the target node
- Now passes the target hypervisor name: `self.local_node_name` for local placement, `decision.hypervisor_id` for remote placement

## Test plan
- [ ] Create a VM targeting a non-leader node (e.g. HV2/nbg1) and verify the root volume has `attached_hypervisor_id` set
- [ ] Confirm ZeroFS starts on the target hypervisor after volume creation
- [ ] Create a VM on the leader node and verify local placement still works correctly

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)