### PR TITLE
fix(cli): accept --name flag on fabric join

### DIFF
--- a/bin/syfrah/src/main.rs
+++ b/bin/syfrah/src/main.rs
@@ -180,7 +180,8 @@ enum FabricCommand {
     Join {
         /// IP or IP:port of an existing node (default port: 51821)
         target: String,
-        #[arg(long)]
+        /// Node name [default: hostname]
+        #[arg(long, alias = "name")]
         node_name: Option<String>,
         #[arg(long, default_value = "51820")]
         port: u16,


### PR DESCRIPTION
## Summary
- Adds `--name` as a clap alias for the existing `--node-name` flag on `syfrah fabric join`
- `syfrah fabric join 37.27.12.205 --name node-2 --region eu --zone nbg1 --pin ABAK22` now works as expected
- Hostname default behavior is preserved when neither flag is provided

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` passes (1 pre-existing failure in syfrah-compute unrelated to this change)

Closes #1298