### PR TITLE
fix: subnet create fails to find environments by name

### DIFF
--- a/layers/fabric/src/raft_handler.rs
+++ b/layers/fabric/src/raft_handler.rs
@@ -360,11 +360,22 @@ impl LayerHandler for RaftOrgHandler {
                     Some(v) => v.clone(),
                     None => format!("{org}-{project}-default"),
                 };
-                let env_id = format!("{org}/{project}/{env}");
+                // Resolve environment name to its ID via the name index.
+                // Environments are stored by generated ID (e.g. "env-a1b2c3d4"),
+                // not by composite key ("org/project/env").
+                let resolved_env = match self.org_store.get_env(org, project, env) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        let resp = OrgResponse::Error(format!(
+                            "environment not found: {org}/{project}/{env}: {e}"
+                        ));
+                        return serde_json::to_vec(&resp).unwrap_or_default();
+                    }
+                };
                 let cmd = StateMachineCommand::CreateSubnet {
                     name: name.clone(),
                     vpc: vpc_name,
-                    env_id,
+                    env_id: resolved_env.id.0,
                     cidr: cidr.clone(),
                 };
                 return submit_raft_command(client, &req, cmd, &self.org_store).await;


### PR DESCRIPTION
## HOTFIX — Subnet creation broken in v1.16.4

`syfrah subnet create` fails with **"environment not found: acme/backend/production"** even though the environment exists.

### Root cause

The `CreateSubnet` Raft handler in `raft_handler.rs` constructed the environment ID as a composite key (`format!("{org}/{project}/{env}")` → `"acme/backend/production"`). After the ID migration (#1348), environments are stored by generated IDs (e.g. `env-a1b2c3d4e5f6`) with a separate name index. The composite key no longer matches any entry in the environments table.

### Fix

Resolve the environment name through `OrgStore::get_env()` which uses the `ENV_NAME_IDX` name-to-ID index, then pass the real `EnvironmentId` to the state machine command.

### Tested

- Built and deployed to production server (46.224.166.60)
- Successfully created and deleted a subnet:
  ```
  syfrah subnet create web --env production --project backend --org acme --vpc my-vpc --cidr 10.1.0.0/24
  ```
- Deployed to HYPERVISOR-1 (46.225.152.62)
- `cargo fmt`, `cargo clippy`, `cargo test` all pass (5 pre-existing disk-space failures in syfrah-compute, unrelated)

Closes #1352